### PR TITLE
fix: incorrect arguments and including launch

### DIFF
--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -18,7 +18,6 @@
   <arg name="rviz" default="true" description="launch rviz"/>
   <arg name="lanelet2_map_file" default="lanelet2_map.osm" description="lanelet2 map file name"/>
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>
-  <arg name="vehicle_simulation" default="false" description="use vehicle simulation"/>
   <arg name="use_pointcloud_container" default="true" description="launch pointcloud container"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
   <!-- Optional parameters for scenario simulation -->
@@ -41,14 +40,11 @@
 
   <!-- Vehicle -->
   <group>
-    <let name="launch_vehicle_interface" value="false" if="$(var vehicle_simulation)"/>
-    <let name="launch_vehicle_interface" value="true" unless="$(var vehicle_simulation)"/>
-
     <include file="$(find-pkg-share tier4_vehicle_launch)/launch/vehicle.launch.xml" if="$(var vehicle)">
       <arg name="vehicle_model" value="$(var vehicle_model)"/>
       <arg name="sensor_model" value="$(var sensor_model)"/>
       <arg name="vehicle_id" value="$(var vehicle_id)"/>
-      <arg name="launch_vehicle_interface" value="$(var launch_vehicle_interface)"/>
+      <arg name="launch_vehicle_interface" value="false"/>
     </include>
   </group>
 
@@ -124,18 +120,5 @@
 
     <!-- Web Controller -->
     <include file="$(find-pkg-share web_controller)/launch/web_controller.launch.xml"/>
-  </group>
-
-  <!-- Simulator -->
-  <group>
-    <let name="launch_dummy_perception" value="false"/>
-    <let name="launch_dummy_vehicle" value="false"/>
-
-    <include file="$(find-pkg-share tier4_simulator_launch)/launch/simulator.launch.xml">
-      <arg name="launch_dummy_perception" value="$(var launch_dummy_perception)"/>
-      <arg name="launch_dummy_vehicle" value="$(var launch_dummy_vehicle)"/>
-      <arg name="vehicle_model" value="$(var vehicle_model)"/>
-      <arg name="vehicle_info_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
-    </include>
   </group>
 </launch>

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -20,6 +20,7 @@
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>
   <arg name="use_pointcloud_container" default="true" description="launch pointcloud container"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
+  <arg name="launch_vehicle_interface" value="false"/>
   <!-- Optional parameters for scenario simulation -->
   <arg name="scenario_simulation" default="false" description="use scenario simulation"/>
 
@@ -44,7 +45,7 @@
       <arg name="vehicle_model" value="$(var vehicle_model)"/>
       <arg name="sensor_model" value="$(var sensor_model)"/>
       <arg name="vehicle_id" value="$(var vehicle_id)"/>
-      <arg name="launch_vehicle_interface" value="false"/>
+      <arg name="launch_vehicle_interface" value="$(var launch_vehicle_interface)"/>
     </include>
   </group>
 

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -20,7 +20,7 @@
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>
   <arg name="use_pointcloud_container" default="true" description="launch pointcloud container"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
-  <arg name="launch_vehicle_interface" value="false"/>
+  <arg name="launch_vehicle_interface" default="false"/>
   <!-- Optional parameters for scenario simulation -->
   <arg name="scenario_simulation" default="false" description="use scenario simulation"/>
 


### PR DESCRIPTION
Signed-off-by: Yukihiro Saito <yukky.saito@gmail.com>

## Description
Fixed incorrect arguments and including launch.
The logging simulator does not launch the vehicle interface since the vehicle interface often requires the connection of a real machine.

~In other words, the logging simulator is out of the scope of the vehicle interface test.
If you want to test it, you can do so by setting this to true, but the default is false. This will be considered depending on future requests.~
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
