### PR TITLE
feat(autoware_launch): update autoware.rviz not to visualize obstacle_avoidance_planner markers

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -1257,35 +1257,14 @@ Visualization Manager:
                       Enabled: true
                       Name: ObstacleAvoidance
                       Namespaces:
-                        avoiding_objects: false
-                        base_bounds_line: false
-                        bounds_candidate_base_text: false
-                        bounds_candidate_for_base: false
-                        bounds_candidate_for_top: false
-                        bounds_candidate_top_text: false
-                        constrain_rect: false
-                        constrain_rect_text: false
-                        constrain_rect_location: false
-                        current_vehicle_footprint: false
-                        extending_constrain_rect: false
-                        extending_constrain_rect_text: false
-                        extending_constrain_rect_location: false
-                        fixed_mpt_points: false
-                        fixed_points_for_extending: false
-                        fixed_points_marker: false
-                        interpolated_points_for_extending: false
-                        interpolated_points_marker: false
-                        interpolated_points_text_marker: false
-                        non_fixed_points_for_extending: false
-                        non_fixed_points_marker: false
-                        num_vehicle_footprint: false
-                        optimized_points_marker: false
-                        optimized_points_text_marker: false
-                        smoothed_points_text: false
-                        straight_points_marker: false
-                        top_bounds_line: false
-                        mid_bounds_line: false
-                        vehicle_footprint: false
+                        base_bounds_0: false
+                        base_bounds_1: false
+                        base_bounds_2: false
+                        current_vehicle_circles: false
+                        lateral_errors: false
+                        mpt_footprints: false
+                        vehicle_circle_lines: false
+                        vehicle_circles: false
                         virtual_wall: true
                         virtual_wall_text: true
                       Topic:


### PR DESCRIPTION

Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

**Note**: Confirm the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/) before submitting a pull request.

Click the `Preview` tab and select a PR template:

- [Standard change](?expand=1&template=standard-change.md)
- [Small change](?expand=1&template=small-change.md)

**Do NOT send a PR with this description.**
