### PR TITLE
feat(autoware_launch): update autoware.rviz not to visualize occlusion spot markers

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -1132,8 +1132,11 @@ Visualization Manager:
                         collision: false
                         info_obstacle: false
                         obstacle: false
-                        sidewalk: false
+                        detection_area: false
+                        close_partition: false
                         slow factor_text: true
+                        path_raw: false
+                        path_interp: false
                       Topic:
                         Depth: 5
                         Durability Policy: Volatile


### PR DESCRIPTION
Signed-off-by: taikitanaka3 <taiki.tanaka@tier4.jp>

**Note**: Confirm the [contribution guidelines](https://autowarefoundation.github.io/autoware-documentation/main/contributing/) before submitting a pull request.

Click the `Preview` tab and select a PR template:

- [Standard change](?expand=1&template=standard-change.md)
- [Small change](?expand=1&template=small-change.md)

**Do NOT send a PR with this description.**
