### PR TITLE
feat: disable some namespace for lanelet2

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -359,7 +359,9 @@ Visualization Manager:
           Name: Lanelet2VectorMap
           Namespaces:
             center_lane_line: false
+            center_line_arrows: false
             crosswalk_lanelets: true
+            lane_start_bound: false
             lanelet direction: true
             lanelet_id: false
             left_lane_bound: true


### PR DESCRIPTION
## Description

disable namespace
- center_line_arrows, https://github.com/autowarefoundation/autoware.universe/pull/931
- lane_start_bound, https://github.com/autowarefoundation/autoware.universe/pull/923

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
