### PR TITLE
fix: use sim time option

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -38,9 +38,10 @@
   <!-- Global parameters -->
   <group scoped="false">
     <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
-    <arg name="use_sim_time" value="$(var use_sim_time)"/>
-    <arg name="vehicle_model" value="$(var vehicle_model)"/>
-  </include>
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
+      <arg name="vehicle_model" value="$(var vehicle_model)"/>
+    </include>
+  </group>
 
   <!-- Pointcloud container -->
   <group if="$(var use_pointcloud_container)">

--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -36,8 +36,8 @@
   <arg name="launch_web_controller" default="true" description="launch web controller"/>
 
   <!-- Global parameters -->
-  <!--  <group scoped="false"> -->
-  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
+  <group scoped="false">
+    <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
     <arg name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="vehicle_model" value="$(var vehicle_model)"/>
   </include>

--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -8,7 +8,6 @@
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
 
   <!-- Optional parameters -->
-  <arg name="is_simulation" default="false" description="if this is simulation or not"/>
   <!-- Modules to be launched -->
   <arg name="launch_vehicle" default="true" description="launch vehicle"/>
   <arg name="launch_system" default="true" description="launch system"/>
@@ -38,8 +37,7 @@
 
   <!-- Global parameters -->
   <!-- Do not add "group" in order to propagate global parameters -->
-  <!-- this is already launched by simulator -->
-  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py" unless="$(var is_simulation)">
+  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
     <arg name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="vehicle_model" value="$(var vehicle_model)"/>
   </include>

--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -8,6 +8,7 @@
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
 
   <!-- Optional parameters -->
+  <arg name="is_simulation" default="false" description="if this is simulation or not"/>
   <!-- Modules to be launched -->
   <arg name="launch_vehicle" default="true" description="launch vehicle"/>
   <arg name="launch_system" default="true" description="launch system"/>
@@ -37,7 +38,8 @@
 
   <!-- Global parameters -->
   <!-- Do not add "group" in order to propagate global parameters -->
-  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
+  <!-- this is already launched by simulator -->
+  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py" unless="$(var is_simulation)">
     <arg name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="vehicle_model" value="$(var vehicle_model)"/>
   </include>

--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -36,7 +36,7 @@
   <arg name="launch_web_controller" default="true" description="launch web controller"/>
 
   <!-- Global parameters -->
-  <!-- Do not add "group" in order to propagate global parameters -->
+  <!--  <group scoped="false"> -->
   <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
     <arg name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="vehicle_model" value="$(var vehicle_model)"/>

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -30,6 +30,12 @@
   <!-- Scenario simulation -->
   <arg name="scenario_simulation" default="false" description="use scenario simulation"/>
 
+  <!-- Add this to enable use_sim_time option -->
+  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
+    <arg name="vehicle_model" value="$(var vehicle_model)"/>
+  </include>
+
   <group>
     <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
       <!-- Common -->

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -8,7 +8,7 @@
 
   <!-- Optional parameters -->
   <arg name="use_sim_time" default="false" description="use_sim_time"/>
-  <arg name="is_simulation" default="true" description="if this is simulation or not" />
+  <arg name="is_simulation" default="true" description="if this is simulation or not"/>
   <!-- Modules to be launched -->
   <arg name="vehicle" default="true" description="launch vehicle"/>
   <arg name="system" default="true" description="launch system"/>

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -30,36 +30,44 @@
   <!-- Scenario simulation -->
   <arg name="scenario_simulation" default="false" description="use scenario simulation"/>
 
-  <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
-    <!-- Common -->
-    <arg name="map_path" value="$(var map_path)"/>
+  <!-- Add this to enable use_sim_time option -->
+  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
     <arg name="vehicle_model" value="$(var vehicle_model)"/>
-    <arg name="sensor_model" value="$(var sensor_model)"/>
-    <!-- Modules to be launched -->
-    <arg name="launch_vehicle" value="$(var vehicle)"/>
-    <arg name="launch_map" value="$(var map)"/>
-    <arg name="launch_sensing" value="$(var sensing)"/>
-    <arg name="launch_localization" value="$(var localization)"/>
-    <arg name="launch_perception" value="$(var perception)"/>
-    <arg name="launch_planning" value="$(var planning)"/>
-    <arg name="launch_control" value="$(var control)"/>
-    <!-- Global parameters -->
-    <arg name="use_sim_time" value="true"/>
-    <!-- Pointcloud container -->
-    <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
-    <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
-    <!-- Vehicle -->
-    <arg name="vehicle_id" value="$(var vehicle_id)"/>
-    <arg name="launch_vehicle_interface" value="$(var launch_vehicle_interface)"/>
-    <!-- System -->
-    <arg name="launch_system" value="$(var system)"/>
-    <arg name="system_run_mode" value="online"/>
-    <!-- Map -->
-    <arg name="lanelet2_map_file" value="$(var lanelet2_map_file)"/>
-    <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>
-    <!-- Sensing -->
-    <arg name="launch_sensing_driver" value="false"/>
-    <!-- API -->
-    <arg name="init_simulator_pose" value="false"/>
   </include>
+
+  <group>
+    <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
+      <!-- Common -->
+      <arg name="map_path" value="$(var map_path)"/>
+      <arg name="vehicle_model" value="$(var vehicle_model)"/>
+      <arg name="sensor_model" value="$(var sensor_model)"/>
+      <!-- Modules to be launched -->
+      <arg name="launch_vehicle" value="$(var vehicle)"/>
+      <arg name="launch_map" value="$(var map)"/>
+      <arg name="launch_sensing" value="$(var sensing)"/>
+      <arg name="launch_localization" value="$(var localization)"/>
+      <arg name="launch_perception" value="$(var perception)"/>
+      <arg name="launch_planning" value="$(var planning)"/>
+      <arg name="launch_control" value="$(var control)"/>
+      <!-- Global parameters -->
+      <arg name="use_sim_time" value="true"/>
+      <!-- Pointcloud container -->
+      <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+      <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
+      <!-- Vehicle -->
+      <arg name="vehicle_id" value="$(var vehicle_id)"/>
+      <arg name="launch_vehicle_interface" value="$(var launch_vehicle_interface)"/>
+      <!-- System -->
+      <arg name="launch_system" value="$(var system)"/>
+      <arg name="system_run_mode" value="online"/>
+      <!-- Map -->
+      <arg name="lanelet2_map_file" value="$(var lanelet2_map_file)"/>
+      <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>
+      <!-- Sensing -->
+      <arg name="launch_sensing_driver" value="false"/>
+      <!-- API -->
+      <arg name="init_simulator_pose" value="false"/>
+    </include>
+  </group>
 </launch>

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -8,7 +8,6 @@
 
   <!-- Optional parameters -->
   <arg name="use_sim_time" default="false" description="use_sim_time"/>
-  <arg name="is_simulation" default="true" description="if this is simulation or not" />
   <!-- Modules to be launched -->
   <arg name="vehicle" default="true" description="launch vehicle"/>
   <arg name="system" default="true" description="launch system"/>
@@ -30,11 +29,6 @@
   <arg name="rviz" default="true" description="launch rviz"/>
   <!-- Scenario simulation -->
   <arg name="scenario_simulation" default="false" description="use scenario simulation"/>
-
-  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
-    <arg name="use_sim_time" value="$(var use_sim_time)"/>
-    <arg name="vehicle_model" value="$(var vehicle_model)"/>
-  </include>
 
   <group>
     <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -8,7 +8,7 @@
 
   <!-- Optional parameters -->
   <arg name="use_sim_time" default="false" description="use_sim_time"/>
-  <arg name="is_simulation" default="true" description="if this is simulation or not"/>
+  <arg name="is_simulation" default="true" description="if this is simulation or not" />
   <!-- Modules to be launched -->
   <arg name="vehicle" default="true" description="launch vehicle"/>
   <arg name="system" default="true" description="launch system"/>

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -8,6 +8,7 @@
 
   <!-- Optional parameters -->
   <arg name="use_sim_time" default="false" description="use_sim_time"/>
+  <arg name="is_simulation" default="true" description="if this is simulation or not" />
   <!-- Modules to be launched -->
   <arg name="vehicle" default="true" description="launch vehicle"/>
   <arg name="system" default="true" description="launch system"/>
@@ -29,6 +30,11 @@
   <arg name="rviz" default="true" description="launch rviz"/>
   <!-- Scenario simulation -->
   <arg name="scenario_simulation" default="false" description="use scenario simulation"/>
+
+  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
+    <arg name="vehicle_model" value="$(var vehicle_model)"/>
+  </include>
 
   <group>
     <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -32,7 +32,6 @@
 
   <group>
     <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
-     <arg name="use_sim_time" value="$(var use_sim_time)"/>
       <!-- Common -->
       <arg name="map_path" value="$(var map_path)"/>
       <arg name="vehicle_model" value="$(var vehicle_model)"/>

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -7,7 +7,6 @@
   <arg name="vehicle_id" default="$(env VEHICLE_ID default)" description="vehicle specific ID"/>
 
   <!-- Optional parameters -->
-  <arg name="use_sim_time" default="false" description="use_sim_time"/>
   <!-- Modules to be launched -->
   <arg name="vehicle" default="true" description="launch vehicle"/>
   <arg name="system" default="true" description="launch system"/>
@@ -30,13 +29,7 @@
   <!-- Scenario simulation -->
   <arg name="scenario_simulation" default="false" description="use scenario simulation"/>
 
-  <!-- Add this to enable use_sim_time option -->
-  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
-    <arg name="use_sim_time" value="$(var use_sim_time)"/>
-    <arg name="vehicle_model" value="$(var vehicle_model)"/>
-  </include>
-
-  <group>
+  <group scoped="false">
     <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
       <!-- Common -->
       <arg name="map_path" value="$(var map_path)"/>

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -7,6 +7,7 @@
   <arg name="vehicle_id" default="$(env VEHICLE_ID default)" description="vehicle specific ID"/>
 
   <!-- Optional parameters -->
+  <arg name="use_sim_time" default="false" description="use_sim_time"/>
   <!-- Modules to be launched -->
   <arg name="vehicle" default="true" description="launch vehicle"/>
   <arg name="system" default="true" description="launch system"/>
@@ -29,14 +30,9 @@
   <!-- Scenario simulation -->
   <arg name="scenario_simulation" default="false" description="use scenario simulation"/>
 
-  <!-- Add this to enable use_sim_time option -->
-  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
-    <arg name="use_sim_time" value="$(var use_sim_time)"/>
-    <arg name="vehicle_model" value="$(var vehicle_model)"/>
-  </include>
-
   <group>
     <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
+     <arg name="use_sim_time" value="$(var use_sim_time)"/>
       <!-- Common -->
       <arg name="map_path" value="$(var map_path)"/>
       <arg name="vehicle_model" value="$(var vehicle_model)"/>

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -38,7 +38,7 @@
 
   <group>
     <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
-      <arg name="use_sim_time" value="$(var use_sim_time)"/>
+     <arg name="use_sim_time" value="$(var use_sim_time)"/>
       <!-- Common -->
       <arg name="map_path" value="$(var map_path)"/>
       <arg name="vehicle_model" value="$(var vehicle_model)"/>

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -29,6 +29,12 @@
   <!-- Scenario simulation -->
   <arg name="scenario_simulation" default="false" description="use scenario simulation"/>
 
+  <!-- Add this to enable use_sim_time option -->
+  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
+    <arg name="vehicle_model" value="$(var vehicle_model)"/>
+  </include>
+
   <group>
     <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
       <!-- Common -->

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -30,44 +30,36 @@
   <!-- Scenario simulation -->
   <arg name="scenario_simulation" default="false" description="use scenario simulation"/>
 
-  <!-- Add this to enable use_sim_time option -->
-  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
-    <arg name="use_sim_time" value="$(var use_sim_time)"/>
+  <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
+    <!-- Common -->
+    <arg name="map_path" value="$(var map_path)"/>
     <arg name="vehicle_model" value="$(var vehicle_model)"/>
+    <arg name="sensor_model" value="$(var sensor_model)"/>
+    <!-- Modules to be launched -->
+    <arg name="launch_vehicle" value="$(var vehicle)"/>
+    <arg name="launch_map" value="$(var map)"/>
+    <arg name="launch_sensing" value="$(var sensing)"/>
+    <arg name="launch_localization" value="$(var localization)"/>
+    <arg name="launch_perception" value="$(var perception)"/>
+    <arg name="launch_planning" value="$(var planning)"/>
+    <arg name="launch_control" value="$(var control)"/>
+    <!-- Global parameters -->
+    <arg name="use_sim_time" value="true"/>
+    <!-- Pointcloud container -->
+    <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+    <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
+    <!-- Vehicle -->
+    <arg name="vehicle_id" value="$(var vehicle_id)"/>
+    <arg name="launch_vehicle_interface" value="$(var launch_vehicle_interface)"/>
+    <!-- System -->
+    <arg name="launch_system" value="$(var system)"/>
+    <arg name="system_run_mode" value="online"/>
+    <!-- Map -->
+    <arg name="lanelet2_map_file" value="$(var lanelet2_map_file)"/>
+    <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>
+    <!-- Sensing -->
+    <arg name="launch_sensing_driver" value="false"/>
+    <!-- API -->
+    <arg name="init_simulator_pose" value="false"/>
   </include>
-
-  <group>
-    <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
-      <!-- Common -->
-      <arg name="map_path" value="$(var map_path)"/>
-      <arg name="vehicle_model" value="$(var vehicle_model)"/>
-      <arg name="sensor_model" value="$(var sensor_model)"/>
-      <!-- Modules to be launched -->
-      <arg name="launch_vehicle" value="$(var vehicle)"/>
-      <arg name="launch_map" value="$(var map)"/>
-      <arg name="launch_sensing" value="$(var sensing)"/>
-      <arg name="launch_localization" value="$(var localization)"/>
-      <arg name="launch_perception" value="$(var perception)"/>
-      <arg name="launch_planning" value="$(var planning)"/>
-      <arg name="launch_control" value="$(var control)"/>
-      <!-- Global parameters -->
-      <arg name="use_sim_time" value="true"/>
-      <!-- Pointcloud container -->
-      <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
-      <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
-      <!-- Vehicle -->
-      <arg name="vehicle_id" value="$(var vehicle_id)"/>
-      <arg name="launch_vehicle_interface" value="$(var launch_vehicle_interface)"/>
-      <!-- System -->
-      <arg name="launch_system" value="$(var system)"/>
-      <arg name="system_run_mode" value="online"/>
-      <!-- Map -->
-      <arg name="lanelet2_map_file" value="$(var lanelet2_map_file)"/>
-      <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>
-      <!-- Sensing -->
-      <arg name="launch_sensing_driver" value="false"/>
-      <!-- API -->
-      <arg name="init_simulator_pose" value="false"/>
-    </include>
-  </group>
 </launch>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -6,7 +6,6 @@
   <arg name="sensor_model" description="sensor model name"/>
 
   <!-- Optional parameters -->
-  <arg name="use_sim_time" default="false" description="use_sim_time"/>
   <!-- Map -->
   <arg name="lanelet2_map_file" default="lanelet2_map.osm" description="lanelet2 map file name"/>
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>
@@ -22,13 +21,7 @@
   <!-- Vcu emulation -->
   <arg name="vehicle_simulation" default="true" description="use vehicle simulation"/>
 
-  <!-- Add this to enable use_sim_time option -->
-  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
-    <arg name="use_sim_time" value="$(var use_sim_time)"/>
-    <arg name="vehicle_model" value="$(var vehicle_model)"/>
-  </include>
-
-  <group>
+  <group scoped="false">
     <!-- Vehicle -->
     <let name="launch_vehicle_interface" value="false" if="$(var vehicle_simulation)"/>
     <let name="launch_vehicle_interface" value="true" unless="$(var vehicle_simulation)"/>
@@ -37,7 +30,6 @@
     <let name="launch_web_controller" value="true" unless="$(var scenario_simulation)"/>
 
     <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
-      <arg name="use_sim_time" value="$(var use_sim_time)"/>
       <!-- Common -->
       <arg name="map_path" value="$(var map_path)"/>
       <arg name="vehicle_model" value="$(var vehicle_model)"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -6,6 +6,7 @@
   <arg name="sensor_model" description="sensor model name"/>
 
   <!-- Optional parameters -->
+  <arg name="use_sim_time" default="false" description="use_sim_time"/>
   <!-- Map -->
   <arg name="lanelet2_map_file" default="lanelet2_map.osm" description="lanelet2 map file name"/>
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>
@@ -21,13 +22,6 @@
   <!-- Vcu emulation -->
   <arg name="vehicle_simulation" default="true" description="use vehicle simulation"/>
 
-
-  <!-- Add this to enable use_sim_time option -->
-  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
-    <arg name="use_sim_time" value="$(var use_sim_time)"/>
-    <arg name="vehicle_model" value="$(var vehicle_model)"/>
-  </include>
-
   <group>
     <!-- Vehicle -->
     <let name="launch_vehicle_interface" value="false" if="$(var vehicle_simulation)"/>
@@ -37,6 +31,7 @@
     <let name="launch_web_controller" value="true" unless="$(var scenario_simulation)"/>
 
     <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
       <!-- Common -->
       <arg name="map_path" value="$(var map_path)"/>
       <arg name="vehicle_model" value="$(var vehicle_model)"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -7,7 +7,7 @@
 
   <!-- Optional parameters -->
   <arg name="use_sim_time" default="false" description="use_sim_time"/>
-  <arg name="is_simulation" default="true" description="if this is simulation or not" />
+  <arg name="is_simulation" default="true" description="if this is simulation or not"/>
   <!-- Map -->
   <arg name="lanelet2_map_file" default="lanelet2_map.osm" description="lanelet2 map file name"/>
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -22,7 +22,6 @@
   <!-- Vcu emulation -->
   <arg name="vehicle_simulation" default="true" description="use vehicle simulation"/>
 
-
   <!-- Add this to enable use_sim_time option -->
   <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
     <arg name="use_sim_time" value="$(var use_sim_time)"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -21,6 +21,13 @@
   <!-- Vcu emulation -->
   <arg name="vehicle_simulation" default="true" description="use vehicle simulation"/>
 
+
+  <!-- Add this to enable use_sim_time option -->
+  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
+    <arg name="vehicle_model" value="$(var vehicle_model)"/>
+  </include>
+
   <group>
     <!-- Vehicle -->
     <let name="launch_vehicle_interface" value="false" if="$(var vehicle_simulation)"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -7,7 +7,7 @@
 
   <!-- Optional parameters -->
   <arg name="use_sim_time" default="false" description="use_sim_time"/>
-  <arg name="is_simulation" default="true" description="if this is simulation or not"/>
+  <arg name="is_simulation" default="true" description="if this is simulation or not" />
   <!-- Map -->
   <arg name="lanelet2_map_file" default="lanelet2_map.osm" description="lanelet2 map file name"/>
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -7,7 +7,6 @@
 
   <!-- Optional parameters -->
   <arg name="use_sim_time" default="false" description="use_sim_time"/>
-  <arg name="is_simulation" default="true" description="if this is simulation or not" />
   <!-- Map -->
   <arg name="lanelet2_map_file" default="lanelet2_map.osm" description="lanelet2 map file name"/>
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>
@@ -23,11 +22,6 @@
   <!-- Vcu emulation -->
   <arg name="vehicle_simulation" default="true" description="use vehicle simulation"/>
 
-  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
-    <arg name="use_sim_time" value="$(var use_sim_time)"/>
-    <arg name="vehicle_model" value="$(var vehicle_model)"/>
-  </include>
-
   <group>
     <!-- Vehicle -->
     <let name="launch_vehicle_interface" value="false" if="$(var vehicle_simulation)"/>
@@ -38,7 +32,6 @@
 
     <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
       <arg name="use_sim_time" value="$(var use_sim_time)"/>
-      <arg name="is_simulation" value="$(var is_simulation)"/>
       <!-- Common -->
       <arg name="map_path" value="$(var map_path)"/>
       <arg name="vehicle_model" value="$(var vehicle_model)"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -22,47 +22,39 @@
   <!-- Vcu emulation -->
   <arg name="vehicle_simulation" default="true" description="use vehicle simulation"/>
 
-  <!-- Add this to enable use_sim_time option -->
-  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
+  <!-- Vehicle -->
+  <let name="launch_vehicle_interface" value="false" if="$(var vehicle_simulation)"/>
+  <let name="launch_vehicle_interface" value="true" unless="$(var vehicle_simulation)"/>
+  <!-- Tools -->
+  <let name="launch_web_controller" value="false" if="$(var scenario_simulation)"/>
+  <let name="launch_web_controller" value="true" unless="$(var scenario_simulation)"/>
+
+  <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
     <arg name="use_sim_time" value="$(var use_sim_time)"/>
+    <!-- Common -->
+    <arg name="map_path" value="$(var map_path)"/>
     <arg name="vehicle_model" value="$(var vehicle_model)"/>
-  </include>
-
-  <group>
+    <arg name="sensor_model" value="$(var sensor_model)"/>
+    <!-- Modules to be launched -->
+    <arg name="launch_sensing" value="false"/>
+    <arg name="launch_localization" value="false"/>
+    <arg name="launch_perception" value="false"/>
+    <!-- Pointcloud container -->
+    <arg name="use_pointcloud_container" value="false"/>
     <!-- Vehicle -->
-    <let name="launch_vehicle_interface" value="false" if="$(var vehicle_simulation)"/>
-    <let name="launch_vehicle_interface" value="true" unless="$(var vehicle_simulation)"/>
+    <arg name="launch_vehicle_interface" value="$(var launch_vehicle_interface)"/>
+    <!-- System -->
+    <arg name="system_run_mode" value="planning_simulation"/>
+    <!-- Map -->
+    <arg name="lanelet2_map_file" value="$(var lanelet2_map_file)"/>
+    <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>
+    <!-- API -->
+    <arg name="init_simulator_pose" value="true"/>
     <!-- Tools -->
-    <let name="launch_web_controller" value="false" if="$(var scenario_simulation)"/>
-    <let name="launch_web_controller" value="true" unless="$(var scenario_simulation)"/>
-
-    <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
-      <arg name="use_sim_time" value="$(var use_sim_time)"/>
-      <!-- Common -->
-      <arg name="map_path" value="$(var map_path)"/>
-      <arg name="vehicle_model" value="$(var vehicle_model)"/>
-      <arg name="sensor_model" value="$(var sensor_model)"/>
-      <!-- Modules to be launched -->
-      <arg name="launch_sensing" value="false"/>
-      <arg name="launch_localization" value="false"/>
-      <arg name="launch_perception" value="false"/>
-      <!-- Pointcloud container -->
-      <arg name="use_pointcloud_container" value="false"/>
-      <!-- Vehicle -->
-      <arg name="launch_vehicle_interface" value="$(var launch_vehicle_interface)"/>
-      <!-- System -->
-      <arg name="system_run_mode" value="planning_simulation"/>
-      <!-- Map -->
-      <arg name="lanelet2_map_file" value="$(var lanelet2_map_file)"/>
-      <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>
-      <!-- API -->
-      <arg name="init_simulator_pose" value="true"/>
-      <!-- Tools -->
-      <arg name="rviz" value="$(var rviz)"/>
-      <arg name="rviz_config" value="$(var rviz_config)"/>
-      <arg name="launch_web_controller" value="$(var launch_web_controller)"/>
-    </include>
-  </group>
+    <arg name="rviz" value="$(var rviz)"/>
+    <arg name="rviz_config" value="$(var rviz_config)"/>
+    <arg name="launch_web_controller" value="$(var launch_web_controller)"/>
+  </include>
 
   <!-- Initial Pose Relay -->
   <group>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -22,39 +22,47 @@
   <!-- Vcu emulation -->
   <arg name="vehicle_simulation" default="true" description="use vehicle simulation"/>
 
-  <!-- Vehicle -->
-  <let name="launch_vehicle_interface" value="false" if="$(var vehicle_simulation)"/>
-  <let name="launch_vehicle_interface" value="true" unless="$(var vehicle_simulation)"/>
-  <!-- Tools -->
-  <let name="launch_web_controller" value="false" if="$(var scenario_simulation)"/>
-  <let name="launch_web_controller" value="true" unless="$(var scenario_simulation)"/>
-
-  <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
+  <!-- Add this to enable use_sim_time option -->
+  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
     <arg name="use_sim_time" value="$(var use_sim_time)"/>
-    <!-- Common -->
-    <arg name="map_path" value="$(var map_path)"/>
     <arg name="vehicle_model" value="$(var vehicle_model)"/>
-    <arg name="sensor_model" value="$(var sensor_model)"/>
-    <!-- Modules to be launched -->
-    <arg name="launch_sensing" value="false"/>
-    <arg name="launch_localization" value="false"/>
-    <arg name="launch_perception" value="false"/>
-    <!-- Pointcloud container -->
-    <arg name="use_pointcloud_container" value="false"/>
-    <!-- Vehicle -->
-    <arg name="launch_vehicle_interface" value="$(var launch_vehicle_interface)"/>
-    <!-- System -->
-    <arg name="system_run_mode" value="planning_simulation"/>
-    <!-- Map -->
-    <arg name="lanelet2_map_file" value="$(var lanelet2_map_file)"/>
-    <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>
-    <!-- API -->
-    <arg name="init_simulator_pose" value="true"/>
-    <!-- Tools -->
-    <arg name="rviz" value="$(var rviz)"/>
-    <arg name="rviz_config" value="$(var rviz_config)"/>
-    <arg name="launch_web_controller" value="$(var launch_web_controller)"/>
   </include>
+
+  <group>
+    <!-- Vehicle -->
+    <let name="launch_vehicle_interface" value="false" if="$(var vehicle_simulation)"/>
+    <let name="launch_vehicle_interface" value="true" unless="$(var vehicle_simulation)"/>
+    <!-- Tools -->
+    <let name="launch_web_controller" value="false" if="$(var scenario_simulation)"/>
+    <let name="launch_web_controller" value="true" unless="$(var scenario_simulation)"/>
+
+    <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
+      <!-- Common -->
+      <arg name="map_path" value="$(var map_path)"/>
+      <arg name="vehicle_model" value="$(var vehicle_model)"/>
+      <arg name="sensor_model" value="$(var sensor_model)"/>
+      <!-- Modules to be launched -->
+      <arg name="launch_sensing" value="false"/>
+      <arg name="launch_localization" value="false"/>
+      <arg name="launch_perception" value="false"/>
+      <!-- Pointcloud container -->
+      <arg name="use_pointcloud_container" value="false"/>
+      <!-- Vehicle -->
+      <arg name="launch_vehicle_interface" value="$(var launch_vehicle_interface)"/>
+      <!-- System -->
+      <arg name="system_run_mode" value="planning_simulation"/>
+      <!-- Map -->
+      <arg name="lanelet2_map_file" value="$(var lanelet2_map_file)"/>
+      <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>
+      <!-- API -->
+      <arg name="init_simulator_pose" value="true"/>
+      <!-- Tools -->
+      <arg name="rviz" value="$(var rviz)"/>
+      <arg name="rviz_config" value="$(var rviz_config)"/>
+      <arg name="launch_web_controller" value="$(var launch_web_controller)"/>
+    </include>
+  </group>
 
   <!-- Initial Pose Relay -->
   <group>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -22,6 +22,13 @@
   <!-- Vcu emulation -->
   <arg name="vehicle_simulation" default="true" description="use vehicle simulation"/>
 
+
+  <!-- Add this to enable use_sim_time option -->
+  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
+    <arg name="vehicle_model" value="$(var vehicle_model)"/>
+  </include>
+
   <group>
     <!-- Vehicle -->
     <let name="launch_vehicle_interface" value="false" if="$(var vehicle_simulation)"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -7,6 +7,7 @@
 
   <!-- Optional parameters -->
   <arg name="use_sim_time" default="false" description="use_sim_time"/>
+  <arg name="is_simulation" default="true" description="if this is simulation or not" />
   <!-- Map -->
   <arg name="lanelet2_map_file" default="lanelet2_map.osm" description="lanelet2 map file name"/>
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>
@@ -22,6 +23,11 @@
   <!-- Vcu emulation -->
   <arg name="vehicle_simulation" default="true" description="use vehicle simulation"/>
 
+  <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
+    <arg name="use_sim_time" value="$(var use_sim_time)"/>
+    <arg name="vehicle_model" value="$(var vehicle_model)"/>
+  </include>
+
   <group>
     <!-- Vehicle -->
     <let name="launch_vehicle_interface" value="false" if="$(var vehicle_simulation)"/>
@@ -32,6 +38,7 @@
 
     <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
       <arg name="use_sim_time" value="$(var use_sim_time)"/>
+      <arg name="is_simulation" value="$(var is_simulation)"/>
       <!-- Common -->
       <arg name="map_path" value="$(var map_path)"/>
       <arg name="vehicle_model" value="$(var vehicle_model)"/>


### PR DESCRIPTION
Signed-off-by: tanaka3 <ttatcoder@outlook.jp>

## Description

Without this PR, we cannot designate use_sim_time by ros2 launch
With this PR fix use sim time option for planning simulator and logging simulator

I confirm use sim time is correctly set with simulation clock rviz plugin
https://user-images.githubusercontent.com/65527974/181677348-ada9f356-d719-4f0f-b884-0012e23a630b.mp4



## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
