### PR TITLE
feat(autoware_launch): add controller mode options to launch file

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -28,6 +28,8 @@
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>
   <!-- Control -->
   <arg name="enable_obstacle_collision_checker" default="false" description="use obstacle_collision_checker"/>
+  <arg name="lateral_controller_mode" default="mpc_follower" description="lateral controller mode: mpc_follower or pure_pursuit"/>
+  <arg name="longitudinal_controller_mode" default="pid" description="longitudinal controller mode: default pid"/>
   <!-- System -->
   <arg name="system_run_mode" default="online" description="run mode in system"/>
   <arg name="launch_system_monitor" default="true" description="launch system monitor"/>
@@ -122,7 +124,8 @@
   <!-- Control -->
   <group if="$(var launch_control)">
     <include file="$(find-pkg-share tier4_control_launch)/launch/control.launch.py">
-      <arg name="lateral_controller_mode" value="mpc_follower"/>
+      <arg name="lateral_controller_mode" value="$(var lateral_controller_mode)"/>
+      <arg name="longitudinal_controller_mode" value="$(var longitudinal_controller_mode)"/>
       <arg name="vehicle_info_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
       <arg name="vehicle_id" value="$(var vehicle_id)"/>
       <arg name="enable_obstacle_collision_checker" value="$(var enable_obstacle_collision_checker)"/>

--- a/autoware_launch/launch/e2e_simulator.launch.xml
+++ b/autoware_launch/launch/e2e_simulator.launch.xml
@@ -20,6 +20,8 @@
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>
   <!-- Control -->
   <arg name="enable_obstacle_collision_checker" default="false" description="use obstacle_collision_checker"/>
+  <arg name="lateral_controller_mode" default="mpc_follower" description="lateral controller mode: mpc_follower or pure_pursuit"/>
+  <arg name="longitudinal_controller_mode" default="pid" description="longitudinal controller mode: default pid"/>
   <!-- Vehicle -->
   <arg name="launch_vehicle_interface" default="false"/>
   <!-- System -->
@@ -51,6 +53,8 @@
       <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>
       <!-- Control -->
       <arg name="enable_obstacle_collision_checker" value="$(var enable_obstacle_collision_checker)"/>
+      <arg name="lateral_controller_mode" value="$(var lateral_controller_mode)"/>
+      <arg name="longitudinal_controller_mode" value="$(var longitudinal_controller_mode)"/>
       <!-- System -->
       <arg name="launch_system_monitor" value="$(var launch_system_monitor)"/>
       <!-- Sensing -->

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -26,6 +26,8 @@
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>
   <!-- Control -->
   <arg name="enable_obstacle_collision_checker" default="false" description="use obstacle_collision_checker"/>
+  <arg name="lateral_controller_mode" default="mpc_follower" description="lateral controller mode: mpc_follower or pure_pursuit"/>
+  <arg name="longitudinal_controller_mode" default="pid" description="longitudinal controller mode: default pid"/>
   <!-- System -->
   <arg name="launch_system_monitor" default="false" description="launch system monitor"/>
   <!-- Tools -->
@@ -64,6 +66,8 @@
       <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>
       <!-- Control -->
       <arg name="enable_obstacle_collision_checker" value="$(var enable_obstacle_collision_checker)"/>
+      <arg name="lateral_controller_mode" value="$(var lateral_controller_mode)"/>
+      <arg name="longitudinal_controller_mode" value="$(var longitudinal_controller_mode)"/>
       <!-- Sensing -->
       <arg name="launch_sensing_driver" value="false"/>
     </include>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -11,6 +11,8 @@
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>
   <!-- Control -->
   <arg name="enable_obstacle_collision_checker" default="false" description="use obstacle_collision_checker"/>
+  <arg name="lateral_controller_mode" default="mpc_follower" description="lateral controller mode: mpc_follower or pure_pursuit"/>
+  <arg name="longitudinal_controller_mode" default="pid" description="longitudinal controller mode: default pid"/>
   <!-- System -->
   <arg name="launch_system_monitor" default="false" description="launch system monitor"/>
   <!-- Tools -->
@@ -51,6 +53,8 @@
       <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>
       <!-- Control -->
       <arg name="enable_obstacle_collision_checker" value="$(var enable_obstacle_collision_checker)"/>
+      <arg name="lateral_controller_mode" value="$(var lateral_controller_mode)"/>
+      <arg name="longitudinal_controller_mode" value="$(var longitudinal_controller_mode)"/>
       <!-- Tools -->
       <arg name="rviz" value="$(var rviz)"/>
       <arg name="rviz_config" value="$(var rviz_config)"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -11,8 +11,6 @@
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>
   <!-- Control -->
   <arg name="enable_obstacle_collision_checker" default="false" description="use obstacle_collision_checker"/>
-  <arg name="lateral_controller_mode" default="mpc_follower" description="lateral controller mode: mpc_follower or pure_pursuit"/>
-  <arg name="longitudinal_controller_mode" default="pid" description="longitudinal controller mode: default pid"/>
   <!-- System -->
   <arg name="launch_system_monitor" default="false" description="launch system monitor"/>
   <!-- Tools -->
@@ -53,8 +51,6 @@
       <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>
       <!-- Control -->
       <arg name="enable_obstacle_collision_checker" value="$(var enable_obstacle_collision_checker)"/>
-      <arg name="lateral_controller_mode" value="$(var lateral_controller_mode)"/>
-      <arg name="longitudinal_controller_mode" value="$(var longitudinal_controller_mode)"/>
       <!-- Tools -->
       <arg name="rviz" value="$(var rviz)"/>
       <arg name="rviz_config" value="$(var rviz_config)"/>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR enables user to specify the lateral and longitudinal controller type. 
It should be merged after [this PR](https://github.com/autowarefoundation/autoware_launch/pull/106) merged!

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
