### PR TITLE
refactor(autoware_launch): change pure_pursuit debug marker topic name

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -1679,7 +1679,7 @@ Visualization Manager:
             Durability Policy: Volatile
             History Policy: Keep Last
             Reliability Policy: Reliable
-            Value: /control/trajectory_follower/pure_pursuit/debug/markers
+            Value: /control/trajectory_follower/controller_node_exe/debug/markers
           Value: false
       Enabled: true
       Name: Control


### PR DESCRIPTION
Signed-off-by: Berkay Karaman <berkay@leodrive.ai>

## Description

<!-- Write a brief description of this PR. -->
In current rviz file, `pure_pursuit` debug topic name is wrong. I want to change it.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
