### PR TITLE
fix(autoware_launch): add parameter to launch launch_system_monitor

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -30,6 +30,7 @@
   <arg name="enable_obstacle_collision_checker" default="false" description="use obstacle_collision_checker"/>
   <!-- System -->
   <arg name="system_run_mode" default="online" description="run mode in system"/>
+  <arg name="launch_system_monitor" default="true" description="launch system monitor"/>
   <!-- Tools -->
   <arg name="rviz" default="true" description="launch rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share autoware_launch)/rviz/autoware.rviz" description="rviz config"/>
@@ -67,6 +68,7 @@
   <group if="$(var launch_system)">
     <include file="$(find-pkg-share tier4_system_launch)/launch/system.launch.xml">
       <arg name="run_mode" value="$(var system_run_mode)"/>
+      <arg name="launch_system_monitor" value="$(var launch_system_monitor)"/>
       <arg name="sensor_model" value="$(var sensor_model)"/>
     </include>
   </group>

--- a/autoware_launch/launch/e2e_simulator.launch.xml
+++ b/autoware_launch/launch/e2e_simulator.launch.xml
@@ -22,6 +22,8 @@
   <arg name="enable_obstacle_collision_checker" default="false" description="use obstacle_collision_checker"/>
   <!-- Vehicle -->
   <arg name="launch_vehicle_interface" default="false"/>
+  <!-- System -->
+  <arg name="launch_system_monitor" default="false" description="launch system monitor"/>
   <!-- Tools -->
   <arg name="rviz" default="true" description="launch rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share autoware_launch)/rviz/autoware.rviz" description="rviz config"/>
@@ -49,6 +51,8 @@
       <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>
       <!-- Control -->
       <arg name="enable_obstacle_collision_checker" value="$(var enable_obstacle_collision_checker)"/>
+      <!-- System -->
+      <arg name="launch_system_monitor" value="$(var launch_system_monitor)"/>
       <!-- Sensing -->
       <arg name="launch_sensing_driver" value="false"/>
       <!-- Perception-->

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -26,6 +26,8 @@
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>
   <!-- Control -->
   <arg name="enable_obstacle_collision_checker" default="false" description="use obstacle_collision_checker"/>
+  <!-- System -->
+  <arg name="launch_system_monitor" default="false" description="launch system monitor"/>
   <!-- Tools -->
   <arg name="rviz" default="true" description="launch rviz"/>
   <!-- Scenario simulation -->
@@ -56,6 +58,7 @@
       <!-- System -->
       <arg name="launch_system" value="$(var system)"/>
       <arg name="system_run_mode" value="online"/>
+      <arg name="launch_system_monitor" value="$(var launch_system_monitor)"/>
       <!-- Map -->
       <arg name="lanelet2_map_file" value="$(var lanelet2_map_file)"/>
       <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -11,6 +11,8 @@
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>
   <!-- Control -->
   <arg name="enable_obstacle_collision_checker" default="false" description="use obstacle_collision_checker"/>
+  <!-- System -->
+  <arg name="launch_system_monitor" default="false" description="launch system monitor"/>
   <!-- Tools -->
   <arg name="rviz" default="true" description="launch rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share autoware_launch)/rviz/autoware.rviz" description="rviz config"/>
@@ -46,6 +48,7 @@
       <arg name="launch_vehicle_interface" value="$(var launch_vehicle_interface)"/>
       <!-- System -->
       <arg name="system_run_mode" value="planning_simulation"/>
+      <arg name="launch_system_monitor" value="$(var launch_system_monitor)"/>
       <!-- Map -->
       <arg name="lanelet2_map_file" value="$(var lanelet2_map_file)"/>
       <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>


### PR DESCRIPTION
Signed-off-by: ito-san <fumihito.ito@tier4.jp>

## Description

Add launch parameter to launch system_monitor or not.
The system monitor should be configured according to system configuration but it it difficult to cover all system configurations all over the world, so we made the system_monitor optional.

- The system_monitor launches by default but it does not launch in planning_simulator, logging_simulator, and e2e_simulator.


## Related links

https://github.com/autowarefoundation/autoware.universe/issues/630

## Tests performed

The same tests were done described in https://github.com/autowarefoundation/autoware.universe/pull/2285.
Please see this PR for details.

## Notes for reviewers

Here is related PR that should be merged at the same time.
https://github.com/autowarefoundation/autoware.universe/pull/2285

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
