### PR TITLE
feat: remove web controller

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -140,8 +140,5 @@
   <group>
     <!-- Rviz -->
     <node pkg="rviz2" exec="rviz2" name="rviz2" output="screen" args="-d $(var rviz_config) -s $(find-pkg-share autoware_launch)/rviz/image/autoware.png" if="$(var rviz)"/>
-
-    <!-- Web Controller -->
-    <include file="$(find-pkg-share web_controller)/launch/web_controller.launch.xml" if="$(var launch_web_controller)"/>
   </group>
 </launch>


### PR DESCRIPTION
## Description
Currently, Autoware has a web controller. In the early days, Autoware was controlled via web controller.
https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_launch/launch/autoware.launch.xml#L145

However, Now that the autoware state rviz plugin has been introduced, the need for web controller seems to have disappeared.
https://github.com/orgs/autowarefoundation/discussions/3082

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
