### PR TITLE
fix: rename use_external_emergency_stop to check_external_emergency_heartbeat

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -38,7 +38,7 @@
   <!-- Perception -->
   <arg name="traffic_light_recognition/enable_fine_detection" default="true" description="enable traffic light fine detection"/>
   <!-- Control -->
-  <arg name="use_external_emergency_stop" default="true" description="use external emergency stop"/>
+  <arg name="check_external_emergency_heartbeat" default="true" description="use external emergency stop"/>
 
   <!-- Global parameters -->
   <group scoped="false">
@@ -127,7 +127,7 @@
       <arg name="vehicle_info_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
       <arg name="vehicle_id" value="$(var vehicle_id)"/>
       <arg name="enable_obstacle_collision_checker" value="$(var enable_obstacle_collision_checker)"/>
-      <arg name="use_external_emergency_stop" value="$(var use_external_emergency_stop)"/>
+      <arg name="check_external_emergency_heartbeat" value="$(var check_external_emergency_heartbeat)"/>
     </include>
   </group>
 

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -59,7 +59,7 @@
       <arg name="rviz_config" value="$(var rviz_config)"/>
       <arg name="launch_web_controller" value="$(var launch_web_controller)"/>
       <!-- Control -->
-      <arg name="use_external_emergency_stop" value="false"/>
+      <arg name="check_external_emergency_heartbeat" value="false"/>
     </include>
   </group>
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
See https://github.com/autowarefoundation/autoware.universe/pull/2455
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
