### PR TITLE
feat(autoware_launch): add speed bump parameters

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
@@ -10,6 +10,7 @@
     launch_occlusion_spot: true
     launch_no_stopping_area: true
     launch_run_out: false
+    launch_speed_bump: true
     forward_path_length: 1000.0
     backward_path_length: 5.0
     max_accel: -2.8

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
@@ -10,7 +10,7 @@
     launch_occlusion_spot: true
     launch_no_stopping_area: true
     launch_run_out: false
-    launch_speed_bump: true
+    launch_speed_bump: false
     forward_path_length: 1000.0
     backward_path_length: 5.0
     max_accel: -2.8

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/speed_bump.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/speed_bump.param.yaml
@@ -1,0 +1,13 @@
+/**:
+  ros__parameters:
+    speed_bump:
+      slow_start_margin: 1.0
+      slow_end_margin: 1.0
+      print_debug_info: false
+
+      # limits for speed bump height and slow down speed to create a linear equation
+      speed_calculation:
+        min_height: 0.05 # [m]
+        max_height: 0.30 # [m]
+        min_speed: 1.39  # [m/s] = [5 kph]
+        max_speed: 2.78  # [m/s] = [10 kph]

--- a/autoware_launch/launch/components/tier4_planning_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_planning_component.launch.xml
@@ -70,6 +70,7 @@
       value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/no_stopping_area.param.yaml"
     />
     <arg name="run_out_param_path" value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/run_out.param.yaml"/>
+    <arg name="speed_bump_param_path" value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/speed_bump.param.yaml"/>
     <arg
       name="behavior_velocity_planner_param_path"
       value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml"


### PR DESCRIPTION
## Description

This PR adds speed bump config file path description to `tier4_planning_component` launch file.

## Related links

https://github.com/autowarefoundation/autoware.universe/pull/647

## Tests performed

Config file is read as it is intended. Changes some parameters in config file to make sure that everything works as expected. 

## Notes for reviewers

**This PR needs to be merged before** [speed bump PR](https://github.com/autowarefoundation/autoware.universe/pull/647)

To test this PR:

Follow the[ test steps in speed bump PR](https://github.com/autowarefoundation/autoware.universe/pull/647#:~:text=Notes%20for%20reviewers-,Test%20Method,-If%20autowarefoundation/autoware_common)
Change some parameters in config file and observe the expected changes (using debud markers in rviz)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
