### PR TITLE
feat(autoware_launch): add param for configurable lateral_distance

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/obstacle_stop_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/obstacle_stop_planner.param.yaml
@@ -7,6 +7,8 @@
     voxel_grid_x: 0.05                       # voxel grid x parameter for filtering pointcloud [m]
     voxel_grid_y: 0.05                       # voxel grid y parameter for filtering pointcloud [m]
     voxel_grid_z: 100000.0                   # voxel grid z parameter for filtering pointcloud [m]
+    use_predicted_objects: False            # whether to use predicted objects [-]
+    publish_obstacle_polygon: False          # whether to publish obstacle polygon [-]
 
     stop_planner:
       # params for stop position
@@ -17,7 +19,10 @@
 
       # params for detection area
       detection_area:
-        lateral_margin: 0.0                  # margin of vehicle footprint [m]
+        lateral_margin: 0.0                  # margin [m]
+        vehicle_lateral_margin: 0.0          # margin of vehicle footprint [m]
+        pedestrian_lateral_margin: 0.0       # margin of pedestrian footprint [m]
+        unknown_lateral_margin: 0.0          # margin of unknown footprint [m]
         step_length: 1.0                     # step length for pointcloud search range [m]
         extend_distance: 0.0                 # extend trajectory to consider after goal obstacle in the extend_distance [m]
 
@@ -33,6 +38,9 @@
       # params for detection area
       detection_area:
         lateral_margin: 1.0                  # offset from vehicle side edge for expanding the search area of the surrounding point cloud [m]
+        vehicle_lateral_margin: 1.0          # offset from vehicle side edge for expanding the search area of the surrounding point cloud [m]
+        pedestrian_lateral_margin: 1.0       # offset from pedestrian side edge for expanding the search area of the surrounding point cloud [m]
+        unknown_lateral_margin: 1.0          # offset from unknown side edge for expanding the search area of the surrounding point cloud [m]
 
       # params for velocity
       target_velocity:


### PR DESCRIPTION
Signed-off-by: beyza <bnk@leodrive.ai>

## Description

This PR adds parameters for using predicted objects to autoware_launch/config

## Related Link

https://github.com/autowarefoundation/autoware.universe/pull/2290

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
