### PR TITLE
feat(perception): change detection region

### DIFF
--- a/autoware_launch/config/perception/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml
+++ b/autoware_launch/config/perception/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml
@@ -7,11 +7,11 @@
 
     common_crop_box_filter:
       parameters:
-        min_x: -50.0
-        max_x: 100.0
-        min_y: -50.0
-        max_y: 50.0
-        max_z: 2.5  # recommended 2.5 for non elevation_grid_mode
+        min_x: -100.0
+        max_x: 150.0
+        min_y: -70.0
+        max_y: 70.0
+        max_z: 2.5
         min_z: -2.5 # recommended 0.0 for non elevation_grid_mode
         negative: False
 


### PR DESCRIPTION
Signed-off-by: badai-nguyen <dai.nguyen@tier4.jp>

## Description

This PR to extend the detection region of ground segmentation. As the result, it also extend the region of perception module. The computational cost has been discussed at this [PR](https://github.com/autowarefoundation/autoware.universe/pull/2521#issue-1502492084)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
