### PR TITLE
feat(autoware_launch): enable use_individual_control_param

### DIFF
--- a/autoware_launch/config/control/vehicle_cmd_gate/vehicle_cmd_gate.param.yaml
+++ b/autoware_launch/config/control/vehicle_cmd_gate/vehicle_cmd_gate.param.yaml
@@ -15,9 +15,11 @@
       lon_jerk_lim: 5.0
       lat_acc_lim: 5.0
       lat_jerk_lim: 5.0
+      actual_steer_diff_lim: 1.0
     on_transition:
       vel_lim: 50.0
       lon_acc_lim: 1.0
       lon_jerk_lim: 0.5
       lat_acc_lim: 1.2
       lat_jerk_lim: 0.75
+      actual_steer_diff_lim: 0.05

--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -125,6 +125,7 @@
       <arg name="enable_obstacle_collision_checker" value="$(var enable_obstacle_collision_checker)"/>
       <arg name="lateral_controller_mode" value="mpc"/>
       <arg name="longitudinal_controller_mode" value="pid"/>
+      <arg name="use_individual_control_param" value="false"/>
     </include>
   </group>
 

--- a/autoware_launch/launch/components/tier4_control_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_control_component.launch.xml
@@ -5,6 +5,10 @@
   <arg name="enable_obstacle_collision_checker"/>
   <arg name="lateral_controller_mode"/>
   <arg name="longitudinal_controller_mode"/>
+  <arg name="use_individual_control_param"/>
+
+  <let name="latlon_controller_param_path_dir" value="$(var vehicle_id)" if="$(var use_individual_control_param)"/>
+  <let name="latlon_controller_param_path_dir" value="" unless="$(var use_individual_control_param)"/>
 
   <include file="$(find-pkg-share tier4_control_launch)/launch/control.launch.py">
     <arg name="vehicle_param_file" value="$(var vehicle_param_file)"/>
@@ -14,8 +18,14 @@
     <arg name="vehicle_id" value="$(var vehicle_id)"/>
     <arg name="enable_obstacle_collision_checker" value="$(var enable_obstacle_collision_checker)"/>
     <arg name="trajectory_follower_node_param_path" value="$(find-pkg-share autoware_launch)/config/control/trajectory_follower/trajectory_follower_node.param.yaml"/>
-    <arg name="lat_controller_param_path" value="$(find-pkg-share autoware_launch)/config/control/trajectory_follower/lateral/$(var lateral_controller_mode).param.yaml"/>
-    <arg name="lon_controller_param_path" value="$(find-pkg-share autoware_launch)/config/control/trajectory_follower/longitudinal/$(var longitudinal_controller_mode).param.yaml"/>
+    <arg
+      name="lat_controller_param_path"
+      value="$(find-pkg-share autoware_launch)/config/control/trajectory_follower/$(var latlon_controller_param_path_dir)/lateral/$(var lateral_controller_mode).param.yaml"
+    />
+    <arg
+      name="lon_controller_param_path"
+      value="$(find-pkg-share autoware_launch)/config/control/trajectory_follower/$(var latlon_controller_param_path_dir)/longitudinal/$(var longitudinal_controller_mode).param.yaml"
+    />
     <arg name="lateral_controller_mode" value="$(var lateral_controller_mode)"/>
     <arg name="longitudinal_controller_mode" value="$(var longitudinal_controller_mode)"/>
 


### PR DESCRIPTION
## Description

Depending on the physical vehicles' characteristics or how much the vehicle was tuned, the lateral/longitudinal controller sometimes has to be tuned for individual vehicles.
To enable this individual tuning for the controller, I added a flag `use_individual_control_param` set to false by default.

- When `use_individual_control_param` is true
    - lateral/longitudinal controller param path is `autoware_launch/config/control/trajectory_follower/$(var vehicle_id)`
- When `use_individual_control_param` is false
    - lateral/longitudinal controller param path is `autoware_launch/config/control/trajectory_follower/`

**TODO**
- [x] rebase this PR after https://github.com/autowarefoundation/autoware_launch/pull/147 is merged.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
