### PR TITLE
fix(autoware_launch): add missing param of vehicle_cmd_gate in yaml

### DIFF
--- a/autoware_launch/config/control/vehicle_cmd_gate/vehicle_cmd_gate.param.yaml
+++ b/autoware_launch/config/control/vehicle_cmd_gate/vehicle_cmd_gate.param.yaml
@@ -15,9 +15,11 @@
       lon_jerk_lim: 5.0
       lat_acc_lim: 5.0
       lat_jerk_lim: 5.0
+      actual_steer_diff_lim: 1.0
     on_transition:
       vel_lim: 50.0
       lon_acc_lim: 1.0
       lon_jerk_lim: 0.5
       lat_acc_lim: 1.2
       lat_jerk_lim: 0.75
+      actual_steer_diff_lim: 0.05


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

Parameter in vehicle_cmd gate is missing due to https://github.com/autowarefoundation/autoware.universe/pull/2585
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
