### PR TITLE
feat(autoware_launch): add controller_mode params as global variable

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -28,6 +28,8 @@
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>
   <!-- Control -->
   <arg name="enable_obstacle_collision_checker" default="false" description="use obstacle_collision_checker"/>
+  <arg name="lateral_controller_mode" default="mpc" description="pure_pursuit or mpc"/>
+  <arg name="longitudinal_controller_mode" default="pid" description="only pid controller is available"/>
   <!-- System -->
   <arg name="system_run_mode" default="online" description="run mode in system"/>
   <arg name="launch_system_monitor" default="true" description="launch system monitor"/>
@@ -123,8 +125,8 @@
       <arg name="vehicle_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
       <arg name="vehicle_id" value="$(var vehicle_id)"/>
       <arg name="enable_obstacle_collision_checker" value="$(var enable_obstacle_collision_checker)"/>
-      <arg name="lateral_controller_mode" value="mpc"/>
-      <arg name="longitudinal_controller_mode" value="pid"/>
+      <arg name="lateral_controller_mode" value="$(var lateral_controller_mode)"/>
+      <arg name="longitudinal_controller_mode" value="$(var longitudinal_controller_mode)"/>
       <arg name="use_individual_control_param" value="false"/>
     </include>
   </group>


### PR DESCRIPTION
Signed-off-by: Berkay Karaman <brkay54@gmail.com>

## Description

<!-- Write a brief description of this PR. -->

Because controller_mode parameters were not declared as global parameters in `autoware.launch.xml`, we can not change them in command line. I made these params globally in launch file. 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
