### PR TITLE
feat(autoware_launch): add fitting_uniform_circle parameter for mpt

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
@@ -148,6 +148,9 @@
               num: 3
               radius_ratio: 0.8
 
+            fitting_uniform_circle:
+                num: 3  # must be greater than 1
+
             rear_drive:
               num_for_calculation: 3
               front_radius_ratio: 1.0

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
@@ -149,7 +149,7 @@
               radius_ratio: 0.8
 
             fitting_uniform_circle:
-                num: 3  # must be greater than 1
+              num: 3  # must be greater than 1
 
             rear_drive:
               num_for_calculation: 3


### PR DESCRIPTION
## Description

This PR adds a new parameter for fitting_uniform_circle configuration for mpt optimizer.

**Related links:**

- https://github.com/autowarefoundation/autoware.universe/pull/2646
- https://github.com/orgs/autowarefoundation/discussions/3189

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
