### PR TITLE
feat(behavior_path_planner): param to skip some linestring types when expanding the drivable area

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/drivable_area_expansion.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/drivable_area_expansion.param.yaml
@@ -3,18 +3,24 @@
     avoidance:
       drivable_area_right_bound_offset: 0.0
       drivable_area_left_bound_offset: 0.0
+      drivable_area_types_to_skip: [road_border]
     lane_change:
       drivable_area_right_bound_offset: 0.0
       drivable_area_left_bound_offset: 0.0
+      drivable_area_types_to_skip: [road_border]
     lane_following:
       drivable_area_right_bound_offset: 0.0
       drivable_area_left_bound_offset: 0.0
+      drivable_area_types_to_skip: [road_border]
     pull_out:
       drivable_area_right_bound_offset: 0.0
       drivable_area_left_bound_offset: 0.0
+      drivable_area_types_to_skip: [road_border]
     pull_over:
       drivable_area_right_bound_offset: 0.0
       drivable_area_left_bound_offset: 0.0
+      drivable_area_types_to_skip: [road_border]
     side_shift:
       drivable_area_right_bound_offset: 0.0
       drivable_area_left_bound_offset: 0.0
+      drivable_area_types_to_skip: [road_border]


### PR DESCRIPTION
Signed-off-by: Maxime CLEMENT <maxime.clement@tier4.jp>

## Description

<!-- Write a brief description of this PR. -->
Add parameters for the feature newly added to universe (https://github.com/autowarefoundation/autoware.universe/pull/2288#).

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
