### PR TITLE
feat(autoware_launch): add enable_boost_check param

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
@@ -19,6 +19,8 @@
       skip_optimization: false # skip MPT and EB
       reset_prev_optimization: false
 
+      enable_boost_check: false # use boost implementation for polygon intersection check
+
     common:
       # sampling
       num_sampling_points: 100 # number of optimizing points

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
@@ -6,7 +6,6 @@
       is_publishing_clearance_map: false # publish clearance map as nav_msgs::OccupancyGrid
       is_publishing_object_clearance_map: false # publish clearance map as nav_msgs::OccupancyGrid
       is_publishing_area_with_objects: false # publish occupancy map as nav_msgs::OccupancyGrid
-
       is_stopping_if_outside_drivable_area: true # stop if the ego's footprint will be outside the drivable area
 
       # show
@@ -18,7 +17,6 @@
       enable_pre_smoothing: true # enable EB
       skip_optimization: false # skip MPT and EB
       reset_prev_optimization: false
-
       enable_boost_check: false # use boost implementation for polygon intersection check
 
     common:


### PR DESCRIPTION
Signed-off-by: beyza <bnk@leodrive.ai>

## Description

This PR adds boost check config file path description to tier4_planning_component launch file.

## Related Link

https://github.com/autowarefoundation/autoware.universe/pull/1999

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
