### PR TITLE
fix(autoware_launch): fix wrong parameter name

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -122,7 +122,7 @@
         value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner_tree.xml"
       />
       <arg name="cruise_planner_type" value="obstacle_stop_planner"/>
-      <arg name="enable_fully_automated_lane_change" value="false"/>
+      <arg name="use_experimental_lane_change_function" value="false"/>
       <arg name="use_surround_obstacle_check" value="true"/>
       <arg name="smoother_type" value="JerkFiltered"/>
     </include>

--- a/autoware_launch/launch/components/tier4_planning_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_planning_component.launch.xml
@@ -9,7 +9,7 @@
   <arg name="cruise_planner_type" description="options: obstacle_stop_planner, obstacle_cruise_planner, none"/>
   <arg name="use_surround_obstacle_check"/>
   <arg name="smoother_type" description="options: JerkFiltered, L2, Analytical, Linf(Unstable)"/>
-  <arg name="enable_fully_automated_lane_change" default="false"/>
+  <arg name="use_experimental_lane_change_function" default="false"/>
 
   <include file="$(find-pkg-share tier4_planning_launch)/launch/planning.launch.xml">
     <arg name="vehicle_param_file" value="$(var vehicle_param_file)"/>
@@ -113,7 +113,7 @@
     />
     <arg name="cruise_planner_type" value="$(var cruise_planner_type)"/>
     <arg name="use_surround_obstacle_check" value="$(var use_surround_obstacle_check)"/>
-    <arg name="enable_fully_automated_lane_change" value="$(var enable_fully_automated_lane_change)"/>
+    <arg name="use_experimental_lane_change_function" value="$(var use_experimental_lane_change_function)"/>
     <arg name="smoother_type" value="$(var smoother_type)"/>
 
     <!-- motion velocity smoother -->

--- a/autoware_launch/launch/components/tier4_planning_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_planning_component.launch.xml
@@ -9,7 +9,7 @@
   <arg name="cruise_planner_type" description="options: obstacle_stop_planner, obstacle_cruise_planner, none"/>
   <arg name="use_surround_obstacle_check"/>
   <arg name="smoother_type" description="options: JerkFiltered, L2, Analytical, Linf(Unstable)"/>
-  <arg name="use_experimental_lane_change_function" default="false"/>
+  <arg name="use_experimental_lane_change_function"/>
 
   <include file="$(find-pkg-share tier4_planning_launch)/launch/planning.launch.xml">
     <arg name="vehicle_param_file" value="$(var vehicle_param_file)"/>


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

The wrong parameter name was merged with the following PR.
https://github.com/autowarefoundation/autoware_launch/pull/165

Renamed to use_experimental_lane_change_function, which is correct.

Relates to https://github.com/autowarefoundation/autoware.universe/pull/2676
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
