### PR TITLE
fix(autoware_launch): change planning parameters

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/common/motion_velocity_smoother/motion_velocity_smoother.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/common/motion_velocity_smoother/motion_velocity_smoother.param.yaml
@@ -9,7 +9,7 @@
 
     # curve parameters
     max_lateral_accel: 1.0             # max lateral acceleration limit [m/ss]
-    min_curve_velocity: 0.5            # min velocity at lateral acceleration limit and steering angle rate limit [m/s]
+    min_curve_velocity: 2.74            # min velocity at lateral acceleration limit and steering angle rate limit [m/s]
     decel_distance_before_curve: 3.5   # slow speed distance before a curve for lateral acceleration limit
     decel_distance_after_curve: 2.0    # slow speed distance after a curve for lateral acceleration limit
     min_decel_for_lateral_acc_lim_filter: -2.5  # deceleration limit applied in the lateral acceleration filter to avoid sudden braking [m/ss]

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/pull_out/pull_out.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/pull_out/pull_out.param.yaml
@@ -5,12 +5,11 @@
       th_stopped_velocity: 0.01
       th_stopped_time: 1.0
       collision_check_margin: 1.0
-      pull_out_finish_judge_buffer: 1.0
+      collision_check_distance_from_end: 1.0
       # shift pull out
       enable_shift_pull_out: true
       shift_pull_out_velocity: 2.0
       pull_out_sampling_num: 4
-      before_pull_out_straight_distance: 0.0
       minimum_shift_pull_out_distance: 20.0
       maximum_lateral_jerk: 2.0
       minimum_lateral_jerk: 0.5
@@ -26,7 +25,7 @@
       # search start pose backward
       enable_back: true
       search_priority: "efficient_path"  # "efficient_path" or "short_back_distance"
-      max_back_distance: 15.0
+      max_back_distance: 30.0
       backward_search_resolution: 2.0
       backward_path_update_duration: 3.0
       ignore_distance_from_lane_end: 15.0

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/pull_over/pull_over.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/pull_over/pull_over.param.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
     pull_over:
-      request_length: 200.0
+      request_length: 100.0
       th_arrived_distance: 1.0
       th_stopped_velocity: 0.01
       th_stopped_time: 2.0  # It must be greater than the state_machine's.
@@ -17,6 +17,8 @@
       backward_goal_search_length: 20.0
       goal_search_interval: 2.0
       longitudinal_margin: 3.0
+      max_lateral_offset: 0.5
+      lateral_offset_interval: 0.25
       ignore_distance_from_lane_start: 15.0
       # occupancy grid map
       use_occupancy_grid: true
@@ -33,8 +35,7 @@
       maximum_lateral_jerk: 2.0
       minimum_lateral_jerk: 0.5
       deceleration_interval: 15.0
-      after_pull_over_straight_distance: 5.0
-      before_pull_over_straight_distance: 5.0
+      after_pull_over_straight_distance: 1.0
       # parallel parking path
       enable_arc_forward_parking: true
       enable_arc_backward_parking: true


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

change default parameters:
- min_curve_velocity: since the current value is too slow for the passenger vehicle (bus/taxi, etc), it is increased to 10km/h. 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
