### PR TITLE
fix(autoware_launch): minor change with tier4_planning_component

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -113,19 +113,7 @@
 
   <!-- Planning -->
   <group if="$(var launch_planning)">
-    <include file="$(find-pkg-share autoware_launch)/launch/components/tier4_planning_component.launch.xml">
-      <arg name="vehicle_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
-      <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
-      <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
-      <arg
-        name="behavior_path_planner_tree_param_path"
-        value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner_tree.xml"
-      />
-      <arg name="cruise_planner_type" value="obstacle_stop_planner"/>
-      <arg name="use_experimental_lane_change_function" value="false"/>
-      <arg name="use_surround_obstacle_check" value="true"/>
-      <arg name="smoother_type" value="JerkFiltered"/>
-    </include>
+    <include file="$(find-pkg-share autoware_launch)/launch/components/tier4_planning_component.launch.xml"/>
   </group>
 
   <!-- Control -->

--- a/autoware_launch/launch/components/tier4_planning_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_planning_component.launch.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="vehicle_param_file"/>
-  <arg name="use_pointcloud_container"/>
-  <arg name="pointcloud_container_name"/>
+  <arg name="vehicle_param_file" default="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
   <!-- behavior -->
-  <arg name="behavior_path_planner_tree_param_path"/>
+  <arg name="use_experimental_lane_change_function" default="false"/>
   <!-- motion -->
-  <arg name="cruise_planner_type" description="options: obstacle_stop_planner, obstacle_cruise_planner, none"/>
-  <arg name="use_surround_obstacle_check"/>
-  <arg name="smoother_type" description="options: JerkFiltered, L2, Analytical, Linf(Unstable)"/>
-  <arg name="use_experimental_lane_change_function"/>
+  <arg name="cruise_planner_type" default="obstacle_stop_planner" description="options: obstacle_stop_planner, obstacle_cruise_planner, none"/>
+  <arg name="use_surround_obstacle_check" default="true"/>
+  <arg name="smoother_type" default="JerkFiltered" description="options: JerkFiltered, L2, Analytical, Linf(Unstable)"/>
 
   <include file="$(find-pkg-share tier4_planning_launch)/launch/planning.launch.xml">
     <arg name="vehicle_param_file" value="$(var vehicle_param_file)"/>
@@ -47,7 +44,10 @@
       name="drivable_area_expansion_param_path"
       value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/drivable_area_expansion.param.yaml"
     />
-    <arg name="behavior_path_planner_tree_param_path" value="$(var behavior_path_planner_tree_param_path)"/>
+    <arg
+      name="behavior_path_planner_tree_param_path"
+      value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner_tree.xml"
+    />
     <arg
       name="behavior_path_planner_param_path"
       value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml"

--- a/autoware_launch/launch/components/tier4_planning_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_planning_component.launch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="vehicle_param_file" default="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
+  <!-- NOTE: optional parameters are written here -->
   <!-- behavior -->
   <arg name="use_experimental_lane_change_function" default="false"/>
   <!-- motion -->
@@ -9,7 +9,7 @@
   <arg name="smoother_type" default="JerkFiltered" description="options: JerkFiltered, L2, Analytical, Linf(Unstable)"/>
 
   <include file="$(find-pkg-share tier4_planning_launch)/launch/planning.launch.xml">
-    <arg name="vehicle_param_file" value="$(var vehicle_param_file)"/>
+    <arg name="vehicle_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
     <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
     <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
     <arg name="smoother_type" value="$(var smoother_type)"/>


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

clean up autoware.launch.xml regarding tier4_planning_component
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
