### PR TITLE
fix(occlusion_spot): occlusion spot parameter disable as default

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
@@ -7,7 +7,7 @@
     launch_blind_spot: true
     launch_detection_area: true
     launch_virtual_traffic_light: true
-    launch_occlusion_spot: true
+    launch_occlusion_spot: false
     launch_no_stopping_area: true
     launch_run_out: false
     launch_speed_bump: false


### PR DESCRIPTION
Signed-off-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>

## Description

This PR aims to disable occlusion spot module by default.

The occlusion spots feature was introduced to decelerate anticipating people jumping out from behind nearby vehicles, but it causes unnecessary slowing down in multi-lane driving. This design issue has yet to be fixed.

Due to the issue, currently, some functional test are facing complication. To reduce this occurrence, occlusion spot is disabled.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
