### PR TITLE
feat(planning_config): update params to enable 60kmph speed

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/common/common.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/common/common.param.yaml
@@ -2,9 +2,9 @@
   ros__parameters:
     # constraints param for normal driving
     normal:
-      min_acc: -0.5         # min deceleration [m/ss]
+      min_acc: -1.0         # min deceleration [m/ss]
       max_acc: 1.0          # max acceleration [m/ss]
-      min_jerk: -0.5        # min jerk [m/sss]
+      min_jerk: -1.0        # min jerk [m/sss]
       max_jerk: 1.0         # max jerk [m/sss]
 
     # constraints to be observed

--- a/autoware_launch/config/planning/scenario_planning/common/motion_velocity_smoother/motion_velocity_smoother.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/common/motion_velocity_smoother/motion_velocity_smoother.param.yaml
@@ -32,7 +32,7 @@
 
     # resampling parameters for optimization
     max_trajectory_length: 200.0        # max trajectory length for resampling [m]
-    min_trajectory_length: 150.0        # min trajectory length for resampling [m]
+    min_trajectory_length: 180.0        # min trajectory length for resampling [m]
     resample_time: 2.0                  # resample total time for dense sampling [s]
     dense_resample_dt: 0.2              # resample time interval for dense sampling [s]
     dense_min_interval_distance: 0.1    # minimum points-interval length for dense sampling [m]


### PR DESCRIPTION

## Description

The maximum speed with the current planning parameter is about 40km/h. This limit mainly comes from

- Maximum acceleration limit,
- Maximum jerk limit, and
- Trajectory length in motion_velocity_smoother`.

This PR changes the acceleration and jerk limit, which was very small, and slightly makes the trajectory longer internally used in `motion_velocity_smoother` to achieve 60km/h speed.

This change slightly increases the CPU cost (40% -> 45% of one core in the attached movie).

https://user-images.githubusercontent.com/21360593/216321628-d264c3fd-ed89-4707-8239-55f831edbf41.mp4



## Related links




[TIERIV INTERNAL LINK](https://tier4.atlassian.net/browse/T4PB-20279)

## Tests performed

Psim & real vehicle 

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
