### PR TITLE
fix(autoware_launch): add missing system file

### DIFF
--- a/autoware_launch/config/system/system_error_monitor/diagnostic_aggregator/system.param.yaml
+++ b/autoware_launch/config/system/system_error_monitor/diagnostic_aggregator/system.param.yaml
@@ -1,0 +1,15 @@
+/**:
+  ros__parameters:
+    system:
+      type: diagnostic_aggregator/AnalyzerGroup
+      path: system
+      analyzers:
+        debug_data_logger:
+          type: diagnostic_aggregator/AnalyzerGroup
+          path: debug_data_logger
+          analyzers:
+            storage_error:
+              type: diagnostic_aggregator/GenericAnalyzer
+              path: storage_error
+              contains: ["bagpacker"]
+              timeout: 3.0

--- a/autoware_launch/launch/components/tier4_system_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_system_component.launch.xml
@@ -13,6 +13,7 @@
     <arg name="system_error_monitor_param_path" value="$(find-pkg-share autoware_launch)/config/system/system_error_monitor/system_error_monitor.param.yaml"/>
     <arg name="system_error_monitor_planning_simulator_param_path" value="$(find-pkg-share autoware_launch)/config/system/system_error_monitor/system_error_monitor.planning_simulation.param.yaml"/>
     <arg name="diagnostic_aggregator_vehicle_param_path" value="$(find-pkg-share autoware_launch)/config/system/system_error_monitor/diagnostic_aggregator/vehicle.param.yaml"/>
+    <arg name="diagnostic_aggregator_system_param_path" value="$(find-pkg-share autoware_launch)/config/system/system_error_monitor/diagnostic_aggregator/system.param.yaml"/>
     <arg name="dummy_diag_publisher_param_path" value="$(find-pkg-share autoware_launch)/config/system/dummy_diag_publisher/dummy_diag_publisher.param.yaml"/>
     <arg name="system_monitor_cpu_monitor_param_path" value="$(find-pkg-share autoware_launch)/config/system/system_monitor/cpu_monitor.param.yaml"/>
     <arg name="system_monitor_gpu_monitor_param_path" value="$(find-pkg-share autoware_launch)/config/system/system_monitor/gpu_monitor.param.yaml"/>


### PR DESCRIPTION
## Description

Currently, autoware_launch cannot be launched due to the following error. :bow: 

I removed the necessary file and setting by mistake in this PR.
I reverted the change.

I confirmed planning simulator worked well.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
