### PR TITLE
feat(lane_departure_checker): add optional neighbor lanelets parameters

### DIFF
--- a/autoware_launch/config/control/lane_departure_checker/lane_departure_checker.param.yaml
+++ b/autoware_launch/config/control/lane_departure_checker/lane_departure_checker.param.yaml
@@ -3,6 +3,10 @@
     # Node
     update_rate: 10.0
     visualize_lanelet: false
+    include_right_lanes: false
+    include_left_lanes: false
+    include_opposite_lanes: false
+    include_conflicting_lanes: false
 
     # Core
     footprint_margin_scale: 1.0


### PR DESCRIPTION
## Description
With this [PR](https://github.com/autowarefoundation/autoware.universe/pull/2709) we added some options about which lanes should be included to drivable area borders.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
