### PR TITLE
fix(obstacle_stop_planner): add lacking param

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/adaptive_cruise_control.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner/adaptive_cruise_control.param.yaml
@@ -10,6 +10,7 @@
       obstacle_velocity_thresh_to_start_acc: 1.5 # start adaptive cruise control when the velocity of the forward obstacle exceeds this value [m/s]
       obstacle_velocity_thresh_to_stop_acc: 1.0 # stop adaptive cruise control when the velocity of the forward obstacle falls below this value [m/s]
       emergency_stop_acceleration: -5.0 # supposed minimum acceleration (deceleration) in emergency stop [m/ss]
+      obstacle_emergency_stop_acceleration: -5.0
       emergency_stop_idling_time: 0.5 # supposed idling time to start emergency stop [s]
       min_dist_stop: 4.0 # minimum distance of emergency stop [m]
       max_standard_acceleration: 0.5 # supposed maximum acceleration in active cruise control [m/ss]
@@ -18,6 +19,7 @@
       min_dist_standard: 4.0 # minimum distance in active cruise control [m]
       obstacle_min_standard_acceleration: -1.5 # supposed minimum acceleration of forward obstacle [m/ss]
       margin_rate_to_change_vel: 0.3 # margin to insert upper velocity [-]
+      use_time_compensation_to_calc_distance: true
 
       # pid parameter for ACC
       p_coefficient_positive: 0.1 # coefficient P in PID control (used when target dist -current_dist >=0) [-]


### PR DESCRIPTION
## Description

Add erased deform values as parameters.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
