### PR TITLE
fix(behavior_path_planner): change pull over maximum_deceleration

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/pull_over/pull_over.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/pull_over/pull_over.param.yaml
@@ -9,7 +9,7 @@
       pull_over_minimum_velocity: 1.38
       margin_from_boundary: 0.5
       decide_path_distance: 10.0
-      maximum_deceleration: 1.0
+      maximum_deceleration: 0.5
       # goal research
       enable_goal_research: true
       search_priority: "efficient_path" # "efficient_path" or "close_goal"


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

`maximum_deceleration: 1.0` of pull_over sometimes causes a sudden stop in the latter module.

https://user-images.githubusercontent.com/39142679/221588989-a2e13c5e-7164-4bed-a005-8f44ceb548ca.mp4




## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

scenario test
[TIER IV internal scenario test](https://evaluation.tier4.jp/evaluation/reports/3af5348f-d4dc-59ce-8f96-9ba25452f99d?project_id=prd_jt) 
875/877 -> 876/877


https://user-images.githubusercontent.com/39142679/221589034-5754c204-0882-4a32-b6d8-c52564b22940.mp4



## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
