### PR TITLE
feat(avoidance): add config for new framework

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -37,6 +37,7 @@
 
     # USE ONLY WHEN THE OPTION COMPILE_WITH_OLD_ARCHITECTURE IS SET TO FALSE.
     # https://github.com/autowarefoundation/autoware.universe/blob/main/planning/behavior_path_planner/CMakeLists.txt
+    # NOTE: The smaller the priority number is, the higher the module priority is.
     lane_change:
       enable_module: true
       enable_simultaneous_execution: false

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -60,3 +60,9 @@
       enable_simultaneous_execution: false
       priority: 2
       max_module_size: 1
+
+    avoidance:
+      enable_module: true
+      enable_simultaneous_execution: false
+      priority: 2
+      max_module_size: 1

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -40,13 +40,13 @@
     lane_change:
       enable_module: true
       enable_simultaneous_execution: false
-      priority: 0
+      priority: 4
       max_module_size: 1
 
     pull_out:
       enable_module: true
       enable_simultaneous_execution: false
-      priority: 1
+      priority: 0
       max_module_size: 1
 
     side_shift:
@@ -58,11 +58,11 @@
     pull_over:
       enable_module: true
       enable_simultaneous_execution: false
-      priority: 2
+      priority: 1
       max_module_size: 1
 
     avoidance:
       enable_module: true
       enable_simultaneous_execution: false
-      priority: 2
+      priority: 3
       max_module_size: 1


### PR DESCRIPTION
## Description

:arrow_down: PR for autoware.universe
https://github.com/autowarefoundation/autoware.universe/pull/2987

add config for avoidance on new framework

```yaml
...
    # USE ONLY WHEN THE OPTION COMPILE_WITH_OLD_ARCHITECTURE IS SET TO FALSE.
    # https://github.com/autowarefoundation/autoware.universe/blob/main/planning/behavior_path_planner/CMakeLists.txt
    avoidance:
      enable_module: true
      enable_simultaneous_execution: false
      priority: 0
      max_module_size: 1
```

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
