### PR TITLE
feat: lengthen safety_check_backward_distance in avoidance module

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
@@ -55,11 +55,11 @@
 
       # For safety check
       safety_check:
-        safety_check_backward_distance: 50.0            # [m]
-        safety_check_time_horizon: 10.0                 # [s]
-        safety_check_idling_time: 1.5                   # [s]
-        safety_check_accel_for_rss: 2.5                 # [m/ss]
-        safety_check_hysteresis_factor: 2.0             # [-]
+        safety_check_backward_distance: 100.0            # [m]
+        safety_check_time_horizon: 10.0                  # [s]
+        safety_check_idling_time: 1.5                    # [s]
+        safety_check_accel_for_rss: 2.5                  # [m/ss]
+        safety_check_hysteresis_factor: 2.0              # [-]
 
       # For avoidance maneuver
       avoidance:


### PR DESCRIPTION
## Description
Change safety_check_backward_distance value from 50m to 100m according to the perception module.
 ( The value of ```min_x```, distance of backward point cloud used by perception module, was changed from 50m to 100m [here](https://github.com/autowarefoundation/autoware_launch/pull/141) )

<!-- Write a brief description of this PR. -->

## Related links
https://github.com/autowarefoundation/autoware_launch/pull/141
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
