### PR TITLE
feat(rviz): add path reference marker

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -1013,6 +1013,98 @@ Visualization Manager:
                         Value: true
                     - Class: rviz_plugins/Path
                       Color Border Vel Max: 3
+                      Enabled: false
+                      Name: PathReference_Avoidnace
+                      Topic:
+                        Depth: 5
+                        Durability Policy: Volatile
+                        History Policy: Keep Last
+                        Reliability Policy: Reliable
+                        Value: /planning/path_reference/avoidance
+                      Value: true
+                      View Path:
+                        Alpha: 0.3
+                        Color: 210; 110; 210
+                        Constant Color: true
+                        Value: true
+                        Width: 2
+                      View Velocity:
+                        Alpha: 0.30000001192092896
+                        Color: 0; 0; 0
+                        Constant Color: false
+                        Scale: 0.30000001192092896
+                        Value: false
+                    - Class: rviz_plugins/Path
+                      Color Border Vel Max: 3
+                      Enabled: false
+                      Name: PathReference_LaneChange
+                      Topic:
+                        Depth: 5
+                        Durability Policy: Volatile
+                        History Policy: Keep Last
+                        Reliability Policy: Reliable
+                        Value: /planning/path_reference/lane_change
+                      Value: true
+                      View Path:
+                        Alpha: 0.3
+                        Color: 210; 110; 210
+                        Constant Color: true
+                        Value: true
+                        Width: 2
+                      View Velocity:
+                        Alpha: 0.30000001192092896
+                        Color: 0; 0; 0
+                        Constant Color: false
+                        Scale: 0.30000001192092896
+                        Value: false
+                    - Class: rviz_plugins/Path
+                      Color Border Vel Max: 3
+                      Enabled: false
+                      Name: PathReference_PullOver
+                      Topic:
+                        Depth: 5
+                        Durability Policy: Volatile
+                        History Policy: Keep Last
+                        Reliability Policy: Reliable
+                        Value: /planning/path_reference/pull_over
+                      Value: true
+                      View Path:
+                        Alpha: 0.3
+                        Color: 210; 110; 210
+                        Constant Color: true
+                        Value: true
+                        Width: 2
+                      View Velocity:
+                        Alpha: 0.30000001192092896
+                        Color: 0; 0; 0
+                        Constant Color: false
+                        Scale: 0.30000001192092896
+                        Value: false
+                    - Class: rviz_plugins/Path
+                      Color Border Vel Max: 3
+                      Enabled: false
+                      Name: PathReference_PullOut
+                      Topic:
+                        Depth: 5
+                        Durability Policy: Volatile
+                        History Policy: Keep Last
+                        Reliability Policy: Reliable
+                        Value: /planning/path_reference/pull_out
+                      Value: true
+                      View Path:
+                        Alpha: 0.3
+                        Color: 210; 110; 210
+                        Constant Color: true
+                        Value: true
+                        Width: 2
+                      View Velocity:
+                        Alpha: 0.30000001192092896
+                        Color: 0; 0; 0
+                        Constant Color: false
+                        Scale: 0.30000001192092896
+                        Value: false
+                    - Class: rviz_plugins/Path
+                      Color Border Vel Max: 3
                       Enabled: true
                       Name: PathChangeCandidate_LaneChange
                       Topic:

--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -1047,7 +1047,7 @@ Visualization Manager:
                       Value: true
                       View Path:
                         Alpha: 0.3
-                        Color: 210; 110; 210
+                        Color: 210; 210; 110
                         Constant Color: true
                         Value: true
                         Width: 2
@@ -1070,7 +1070,7 @@ Visualization Manager:
                       Value: true
                       View Path:
                         Alpha: 0.3
-                        Color: 210; 110; 210
+                        Color: 110; 110; 210
                         Constant Color: true
                         Value: true
                         Width: 2
@@ -1093,7 +1093,7 @@ Visualization Manager:
                       Value: true
                       View Path:
                         Alpha: 0.3
-                        Color: 210; 110; 210
+                        Color: 210; 110; 110
                         Constant Color: true
                         Value: true
                         Width: 2

--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -1014,7 +1014,7 @@ Visualization Manager:
                     - Class: rviz_plugins/Path
                       Color Border Vel Max: 3
                       Enabled: false
-                      Name: PathReference_Avoidnace
+                      Name: PathReference_Avoidance
                       Topic:
                         Depth: 5
                         Durability Policy: Volatile


### PR DESCRIPTION
## Description

- add path marker config for path reference of behavior path planner.
- the marker is hided as default.

---

- **translucent purple**: reference path
- **translucent green**: behavior output path

![rviz_screenshot_2023_03_10-14_12_24](https://user-images.githubusercontent.com/44889564/224229328-fe8830d0-e958-471f-8dac-281f47b1c8aa.png)

![rviz_screenshot_2023_03_10-14_12_03](https://user-images.githubusercontent.com/44889564/224229323-2efd3204-e6b2-4f00-8876-2e6bea5079f9.png)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
