### PR TITLE
feat(autoware_launch): add option to use akima spline at first

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -19,7 +19,9 @@
     turn_signal_shift_length_threshold: 0.3
     turn_signal_on_swerving: true
 
-    path_interval: 2.0
+    enable_akima_spline_first: true
+    input_path_interval: 2.0
+    output_path_interval: 2.0
 
     visualize_maximum_drivable_area: true
 

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -19,7 +19,7 @@
     turn_signal_shift_length_threshold: 0.3
     turn_signal_on_swerving: true
 
-    enable_akima_spline_first: true
+    enable_akima_spline_first: false
     input_path_interval: 2.0
     output_path_interval: 2.0
 


### PR DESCRIPTION
## Description

launcher PR for https://github.com/autowarefoundation/autoware.universe/pull/2800
NOTE: Akima spline is disabled by default.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
