### PR TITLE
feat(lane_change): support param for new framework (include external lc)

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -40,15 +40,15 @@
     # USE ONLY WHEN THE OPTION COMPILE_WITH_OLD_ARCHITECTURE IS SET TO FALSE.
     # https://github.com/autowarefoundation/autoware.universe/blob/main/planning/behavior_path_planner/CMakeLists.txt
     # NOTE: The smaller the priority number is, the higher the module priority is.
-    external_lane_change_left:
+    ext_request_lane_change_left:
       enable_module: true
-      enable_simultaneous_execution: false
-      priority: 7
+      enable_simultaneous_execution: true
+      priority: 6
       max_module_size: 1
 
-    external_lane_change_right:
+    ext_request_lane_change_right:
       enable_module: true
-      enable_simultaneous_execution: false
+      enable_simultaneous_execution: true
       priority: 6
       max_module_size: 1
 

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -40,7 +40,25 @@
     # USE ONLY WHEN THE OPTION COMPILE_WITH_OLD_ARCHITECTURE IS SET TO FALSE.
     # https://github.com/autowarefoundation/autoware.universe/blob/main/planning/behavior_path_planner/CMakeLists.txt
     # NOTE: The smaller the priority number is, the higher the module priority is.
-    lane_change:
+    external_lane_change_left:
+      enable_module: true
+      enable_simultaneous_execution: false
+      priority: 7
+      max_module_size: 1
+
+    external_lane_change_right:
+      enable_module: true
+      enable_simultaneous_execution: false
+      priority: 6
+      max_module_size: 1
+
+    lane_change_left:
+      enable_module: true
+      enable_simultaneous_execution: false
+      priority: 5
+      max_module_size: 1
+
+    lane_change_right:
       enable_module: true
       enable_simultaneous_execution: false
       priority: 4


### PR DESCRIPTION
## Description
This PR is related to new framework in behavior path planner.

The objective of this PR is as follow
1. supporting `external_lane_change` module in the new framework.
2. separating `lane_change` module to `lane_change_left` and `lane_change_right`

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
