### PR TITLE
fix(behavior_velocity_planner): disable launch_virtual_traffic_light parameter by default

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
@@ -6,7 +6,7 @@
     launch_intersection: true
     launch_blind_spot: true
     launch_detection_area: true
-    launch_virtual_traffic_light: true
+    launch_virtual_traffic_light: false # disabled by default to not confuse newcomers
     launch_occlusion_spot: false
     launch_no_stopping_area: true
     launch_run_out: false


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Closes: https://github.com/autowarefoundation/autoware.universe/issues/2390

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
