### PR TITLE
fix(behavior_velocity_planner): fix detection area being ignored when the ego vehicle stops over the stop line

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/detection_area.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/detection_area.param.yaml
@@ -7,3 +7,4 @@
       use_pass_judge_line: false
       state_clear_time: 2.0
       hold_stop_margin_distance: 0.0
+      distance_to_judge_over_stop_line: 0.5

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/detection_area.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/detection_area.param.yaml
@@ -6,3 +6,4 @@
       dead_line_margin: 5.0
       use_pass_judge_line: false
       state_clear_time: 2.0
+      hold_stop_margin_distance: 0.0


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Related PR: https://github.com/autowarefoundation/autoware.universe/pull/3114

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
