### PR TITLE
fix(planning_launch): disable external lc module in new framework

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -41,14 +41,14 @@
     # https://github.com/autowarefoundation/autoware.universe/blob/main/planning/behavior_path_planner/CMakeLists.txt
     # NOTE: The smaller the priority number is, the higher the module priority is.
     ext_request_lane_change_left:
-      enable_module: true
-      enable_simultaneous_execution: true
+      enable_module: false
+      enable_simultaneous_execution: false
       priority: 6
       max_module_size: 1
 
     ext_request_lane_change_right:
-      enable_module: true
-      enable_simultaneous_execution: true
+      enable_module: false
+      enable_simultaneous_execution: false
       priority: 6
       max_module_size: 1
 


### PR DESCRIPTION
## Description

Disable external lane change module by default in the new behavior path planner architecture.

https://github.com/autowarefoundation/autoware.universe/pull/3068#issuecomment-1475117823

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
