### PR TITLE
chore(error_monitor): exclude ndt monitoring

### DIFF
--- a/autoware_launch/config/system/system_error_monitor/system_error_monitor.param.yaml
+++ b/autoware_launch/config/system/system_error_monitor/system_error_monitor.param.yaml
@@ -22,7 +22,7 @@
         /autoware/control/control_command_gate/node_alive_monitoring: default
 
         /autoware/localization/node_alive_monitoring: default
-        /autoware/localization/performance_monitoring/matching_score: { sf_at: "warn", lf_at: "none", spf_at: "none" }
+        # /autoware/localization/performance_monitoring/matching_score: { sf_at: "warn", lf_at: "none", spf_at: "none" }
         /autoware/localization/performance_monitoring/localization_accuracy: default
 
         /autoware/map/node_alive_monitoring: default


### PR DESCRIPTION
## Description

Changed the configuration file so that system error monitor does not monitor the diagnostics of ndt_scan_matcher.

This change is because `ndt_scan_matcher` will no longer be a node that is always launched. 
(cf. https://github.com/autowarefoundation/autoware.universe/pull/3063)

Must be merged with

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
