### PR TITLE
refactor(behavior_path_planner): rename lane chagne parameters

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -17,8 +17,8 @@
       lane_change_sampling_num: 3
 
       # collision check
-      enable_collision_check_at_prepare_phase: false
-      prepare_phase_ignore_target_speed_thresh: 0.1 # [m/s]
+      enable_prepare_segment_collision_check: false
+      prepare_segment_ignore_object_velocity_thresh: 0.1 # [m/s]
       use_predicted_path_outside_lanelet: false
       use_all_predicted_path: false
 


### PR DESCRIPTION
## Description
Rename some lane change parameters. Use `velocity` rather than `speed` and `segment` rather than `phase`.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
