### PR TITLE
test(static_centerline_optimizer): add launch test

### DIFF
--- a/autoware_launch/CMakeLists.txt
+++ b/autoware_launch/CMakeLists.txt
@@ -7,6 +7,16 @@ ament_auto_find_build_dependencies()
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  # static centerline optimizer
+  add_launch_test(
+    test/static_centerline_optimizer/test_static_centerline_optimizer.test.py
+    TIMEOUT "30"
+  )
+  install(DIRECTORY
+    test/static_centerline_optimizer/data/
+    DESTINATION share/${PROJECT_NAME}/test/static_centerline_optimizer/data/
+  )
 endif()
 
 ament_auto_package(

--- a/autoware_launch/package.xml
+++ b/autoware_launch/package.xml
@@ -27,6 +27,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+  <test_depend>ros_testing</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/autoware_launch/test/static_centerline_optimizer/data/lanelet2_map.osm
+++ b/autoware_launch/test/static_centerline_optimizer/data/lanelet2_map.osm
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm generator="VMB">
+  <MetaInfo format_version="1" map_version="2"/>
+  <node id="10" lat="35.62554985786315" lon="139.78246505089274">
+    <tag k="mgrs_code" v="54SUE897431"/>
+    <tag k="local_x" v="89747.3792"/>
+    <tag k="local_y" v="43100.1597"/>
+    <tag k="ele" v="12.149"/>
+  </node>
+  <node id="11" lat="35.625753282567665" lon="139.78285100261152">
+    <tag k="mgrs_code" v="54SUE897431"/>
+    <tag k="local_x" v="89782.6096"/>
+    <tag k="local_y" v="43122.2901"/>
+    <tag k="ele" v="5.95"/>
+  </node>
+  <node id="13" lat="35.625587319824625" lon="139.78243545848844">
+    <tag k="mgrs_code" v="54SUE897431"/>
+    <tag k="local_x" v="89744.7508"/>
+    <tag k="local_y" v="43104.348"/>
+    <tag k="ele" v="12.149"/>
+  </node>
+  <node id="14" lat="35.625789398053385" lon="139.78281921887913">
+    <tag k="mgrs_code" v="54SUE897431"/>
+    <tag k="local_x" v="89779.7809"/>
+    <tag k="local_y" v="43126.3315"/>
+    <tag k="ele" v="5.95"/>
+  </node>
+  <node id="17" lat="35.62598180391042" lon="139.78328457291465">
+    <tag k="mgrs_code" v="54SUE898431"/>
+    <tag k="local_x" v="89822.1865"/>
+    <tag k="local_y" v="43147.1509"/>
+    <tag k="ele" v="6.7069"/>
+  </node>
+  <node id="20" lat="35.62633552101926" lon="139.78392036825423">
+    <tag k="mgrs_code" v="54SUE898431"/>
+    <tag k="local_x" v="89880.2479"/>
+    <tag k="local_y" v="43185.6716"/>
+    <tag k="ele" v="12.2602"/>
+  </node>
+  <node id="22" lat="35.62602561192561" lon="139.78326636562227">
+    <tag k="mgrs_code" v="54SUE898431"/>
+    <tag k="local_x" v="89820.5978"/>
+    <tag k="local_y" v="43152.0303"/>
+    <tag k="ele" v="5.9099"/>
+  </node>
+  <node id="23" lat="35.626372598801595" lon="139.78388939065988">
+    <tag k="mgrs_code" v="54SUE898431"/>
+    <tag k="local_x" v="89877.4935"/>
+    <tag k="local_y" v="43189.8188"/>
+    <tag k="ele" v="12.2602"/>
+  </node>
+  <node id="207" lat="35.625526972158134" lon="139.78249307175062">
+    <tag k="mgrs_code" v="54SUE897430"/>
+    <tag k="local_x" v="89749.8853"/>
+    <tag k="local_y" v="43097.5899"/>
+    <tag k="ele" v="5.4342"/>
+  </node>
+  <node id="212" lat="35.6259529904892" lon="139.78331102601197">
+    <tag k="mgrs_code" v="54SUE898431"/>
+    <tag k="local_x" v="89824.5425"/>
+    <tag k="local_y" v="43143.9254"/>
+    <tag k="ele" v="6.0319"/>
+  </node>
+  <node id="213" lat="35.62629786487126" lon="139.7839588039869">
+    <tag k="mgrs_code" v="54SUE898431"/>
+    <tag k="local_x" v="89883.6769"/>
+    <tag k="local_y" v="43181.4519"/>
+    <tag k="ele" v="6.4513"/>
+  </node>
+  <way id="12">
+    <nd ref="10"/>
+    <nd ref="11"/>
+    <nd ref="17"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="dashed"/>
+    <tag k="lane_change" v="yes"/>
+  </way>
+  <way id="15">
+    <nd ref="13"/>
+    <nd ref="14"/>
+    <nd ref="22"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="21">
+    <nd ref="17"/>
+    <nd ref="20"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="dashed"/>
+    <tag k="lane_change" v="yes"/>
+  </way>
+  <way id="24">
+    <nd ref="22"/>
+    <nd ref="23"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="209">
+    <nd ref="207"/>
+    <nd ref="212"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <way id="214">
+    <nd ref="212"/>
+    <nd ref="213"/>
+    <tag k="type" v="line_thin"/>
+    <tag k="subtype" v="solid"/>
+  </way>
+  <relation id="16">
+    <member type="way" role="left" ref="15"/>
+    <member type="way" role="right" ref="12"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="25">
+    <member type="way" role="left" ref="24"/>
+    <member type="way" role="right" ref="21"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="215">
+    <member type="way" role="left" ref="12"/>
+    <member type="way" role="right" ref="209"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+  <relation id="216">
+    <member type="way" role="left" ref="21"/>
+    <member type="way" role="right" ref="214"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+    <tag k="speed_limit" v="10"/>
+    <tag k="location" v="urban"/>
+    <tag k="one_way" v="yes"/>
+  </relation>
+</osm>

--- a/autoware_launch/test/static_centerline_optimizer/test_static_centerline_optimizer.test.py
+++ b/autoware_launch/test/static_centerline_optimizer/test_static_centerline_optimizer.test.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from ament_index_python import get_package_share_directory
+import launch
+from launch import LaunchDescription
+from launch_ros.actions import Node
+import launch_testing
+import pytest
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    lanelet2_map_path = os.path.join(
+        get_package_share_directory("static_centerline_optimizer"), "test/data/lanelet2_map.osm"
+    )
+
+    static_centerline_optimizer_node = Node(
+        package="static_centerline_optimizer",
+        executable="main",
+        output="screen",
+        parameters=[
+            {"lanelet2_map_path": lanelet2_map_path},
+            {"run_background": False},
+            {"rviz": False},
+            {"lanelet2_input_file_path": lanelet2_map_path},
+            {"lanelet2_output_file_path": "/tmp/lanelet2_map.osm"},
+            {"start_lanelet_id": 215},
+            {"end_lanelet_id": 216},
+            os.path.join(
+                get_package_share_directory("autoware_launch"),
+                "config/planning/mission_planning/mission_planner/mission_planner.param.yaml",
+            ),
+            os.path.join(
+                get_package_share_directory("static_centerline_optimizer"),
+                "config/static_centerline_optimizer.param.yaml",
+            ),
+            os.path.join(
+                get_package_share_directory("autoware_launch"),
+                "config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml",
+            ),
+            os.path.join(
+                get_package_share_directory("map_loader"),
+                "config/lanelet2_map_loader.param.yaml",
+            ),
+            os.path.join(
+                get_package_share_directory("autoware_launch"),
+                "config/planning/scenario_planning/common/common.param.yaml",
+            ),
+            os.path.join(
+                get_package_share_directory("autoware_launch"),
+                "config/planning/scenario_planning/common/nearest_search.param.yaml",
+            ),
+            os.path.join(
+                get_package_share_directory("static_centerline_optimizer"),
+                "config/vehicle_info.param.yaml",
+            ),
+        ],
+    )
+
+    context = {}
+
+    return (
+        LaunchDescription(
+            [
+                static_centerline_optimizer_node,
+                # Start test after 1s - gives time for the static_centerline_optimizer to finish initialization
+                launch.actions.TimerAction(
+                    period=1.0, actions=[launch_testing.actions.ReadyToTest()]
+                ),
+            ]
+        ),
+        context,
+    )
+
+
+@launch_testing.post_shutdown_test()
+class TestProcessOutput(unittest.TestCase):
+    def test_exit_code(self, proc_info):
+        # Check that process exits with code 0: no error
+        launch_testing.asserts.assertExitCodes(proc_info)


### PR DESCRIPTION
## Description

We cannot notice the bug when launching [static_centerline_optimizer](https://autowarefoundation.github.io/autoware.universe/main/planning/static_centerline_optimizer/) from autoware_launch.
e.g.) The following bug was put into autoware.universe without anyone knowing it resulting in failure to launch static_centerline_optimizer from autoware_launch.
https://github.com/autowarefoundation/autoware.universe/pull/3360

To keep launching static_centerline_optimizer without failure, I added a test.
<!-- Write a brief description of this PR. -->

## Tests performed

launch test passed.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
