### PR TITLE
refactor(behavior_velocity_planner): removed external input from behavior_velocity

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/crosswalk.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/crosswalk.param.yaml
@@ -29,7 +29,6 @@
       ego_yield_query_stop_duration: 0.1 # [s] the amount of time which ego should be stopping to query whether it yields or not
 
       # param for input data
-      external_input_timeout: 1.0
       tl_state_timeout: 3.0 # [s] timeout threshold for traffic light signal
 
       # param for target area & object
@@ -43,4 +42,3 @@
     walkway:
       stop_duration_sec: 1.0 # [s] stop time at stop position
       stop_line_distance: 3.5 # [m] make stop line away from crosswalk when no explicit stop line exists
-      external_input_timeout: 1.0

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
@@ -22,10 +22,6 @@
       assumed_front_car_decel: 1.0 # [m/ss] the expected deceleration of front car when front car as well as ego are turning
       enable_front_car_decel_prediction: false # By default this feature is disabled
       stop_overshoot_margin: 0.5 # [m] overshoot margin for stuck, collision detection
-      external_input_timeout: 1.0
 
-    merge_from_private_road:
-      stop_duration_sec: 1.0
     merge_from_private:
-      merge_from_private_area:
-        stop_duration_sec: 1.0
+      stop_duration_sec: 1.0

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/traffic_light.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/traffic_light.param.yaml
@@ -3,6 +3,5 @@
     traffic_light:
       stop_margin: 0.0
       tl_state_timeout: 1.0
-      external_tl_state_timeout: 1.0
       yellow_lamp_period: 2.75
       enable_pass_judge: true


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

## Related links

feature PR: https://github.com/autowarefoundation/autoware.universe/pull/3407

## Tests performed

In Psim

## Interface changes

Removed deprecated topic `~/input/external_{intersection, crosswalk, traffic_light}_status`.

## Effects on system behavior

No influence on current system configuration

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
