### PR TITLE
feat(tier4_simulator_launch): add use_baselink_z option for dummy_perception_publisher

### DIFF
--- a/autoware_launch/launch/components/tier4_simulator_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_simulator_component.launch.xml
@@ -6,6 +6,7 @@
   <arg name="launch_diagnostic_converter"/>
   <arg name="perception/enable_detection_failure"/>
   <arg name="perception/enable_object_recognition"/>
+  <arg name="perception/use_base_link_z"/>
   <arg name="sensing/visible_range"/>
   <arg name="vehicle_model"/>
   <arg name="initial_engage_state"/>
@@ -18,6 +19,7 @@
     <arg name="launch_diagnostic_converter" value="$(var launch_diagnostic_converter)"/>
     <arg name="perception/enable_detection_failure" value="$(var perception/enable_detection_failure)"/>
     <arg name="perception/enable_object_recognition" value="$(var perception/enable_object_recognition)"/>
+    <arg name="perception/use_base_link_z" value="$(var perception/use_base_link_z)"/>
     <arg name="sensing/visible_range" value="$(var sensing/visible_range)"/>
     <arg name="vehicle_model" value="$(var vehicle_model)"/>
     <arg name="initial_engage_state" value="$(var initial_engage_state)"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -19,6 +19,7 @@
   <arg name="initial_engage_state" default="true" description="/vehicle/engage state after starting Autoware"/>
   <arg name="perception/enable_detection_failure" default="true" description="enable to simulate detection failure when using dummy perception"/>
   <arg name="perception/enable_object_recognition" default="true" description="enable object recognition when using dummy perception"/>
+  <arg name="perception/use_base_link_z" default="true" description="dummy perception uses base_link z axis coordinate if it is true"/>
   <arg name="sensing/visible_range" default="300.0" description="visible range when using dummy perception"/>
   <arg name="scenario_simulation" default="false" description="use scenario simulation"/>
   <!-- Vcu emulation -->
@@ -71,6 +72,7 @@
       <arg name="launch_diagnostic_converter" value="$(var launch_diagnostic_converter)"/>
       <arg name="perception/enable_detection_failure" value="$(var perception/enable_detection_failure)"/>
       <arg name="perception/enable_object_recognition" value="$(var perception/enable_object_recognition)"/>
+      <arg name="perception/use_base_link_z" value="$(var perception/use_base_link_z)"/>
       <arg name="sensing/visible_range" value="$(var sensing/visible_range)"/>
       <arg name="vehicle_model" value="$(var vehicle_model)"/>
       <arg name="initial_engage_state" value="$(var initial_engage_state)"/>


### PR DESCRIPTION


## Description

<!-- Write a brief description of this PR. -->
PR universe: https://github.com/autowarefoundation/autoware.universe/pull/3457
In current implementation of autoware, dummy_perception_publisher always uses the baselink z position while publishing dummy object. Object's Z position can not be arranged from rviz plugin. I added a parameter to make it configurable. Default value of the parameter is true.
## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
