### PR TITLE
feat(behavior_velocity_planner::intersection): add occlusion detection feature

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
@@ -28,13 +28,13 @@
         collision_end_margin_time: 6.0 # [s] this + state_transit_margin_time should be higher to account for collision with slow/decelerating object
         keep_detection_vel_thr: 0.833 # == 3.0km/h. keep detection if ego is ego.vel < keep_detection_vel_thr
       occlusion_detection_area_length: 70.0 # [m]
-      occlusion_creep_velocity: 0.555 # the creep velocity to occlusion limit stop line
+      occlusion_creep_velocity: 0.8333 # the creep velocity to occlusion limit stop line
       extra_occlusion_margin: 0.0
       occlusion:
         free_space_max: 43
         occupied_min: 58
         do_dp: true
-      before_creep_stop_time: 1.5 # [s]
+      before_creep_stop_time: 1.0 # [s]
       min_vehicle_brake_for_rss: -2.5 # [m/s^2]
       max_vehicle_velocity_for_rss: 16.66 # [m/s] == 60kmph
       max_entry_for_occlusion_clerance: 0.1 # [m] maximum entry into the frist detection area lanelet

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
@@ -29,7 +29,6 @@
         keep_detection_vel_thr: 0.833 # == 3.0km/h. keep detection if ego is ego.vel < keep_detection_vel_thr
       occlusion_detection_area_length: 70.0 # [m]
       occlusion_creep_velocity: 0.8333 # the creep velocity to occlusion limit stop line
-      extra_occlusion_margin: 0.0
       occlusion:
         free_space_max: 43
         occupied_min: 58
@@ -37,7 +36,6 @@
       before_creep_stop_time: 1.0 # [s]
       min_vehicle_brake_for_rss: -2.5 # [m/s^2]
       max_vehicle_velocity_for_rss: 16.66 # [m/s] == 60kmph
-      max_entry_for_occlusion_clerance: 0.1 # [m] maximum entry into the frist detection area lanelet
 
     merge_from_private:
       stop_duration_sec: 1.0

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
@@ -27,15 +27,16 @@
         collision_start_margin_time: 4.0 # [s] this + state_transit_margin_time should be higher to account for collision with fast/accelerating object
         collision_end_margin_time: 6.0 # [s] this + state_transit_margin_time should be higher to account for collision with slow/decelerating object
         keep_detection_vel_thr: 0.833 # == 3.0km/h. keep detection if ego is ego.vel < keep_detection_vel_thr
-      occlusion_detection_area_length: 70.0 # [m]
-      occlusion_creep_velocity: 0.8333 # the creep velocity to occlusion limit stop line
+
       occlusion:
+        occlusion_detection_area_length: 70.0 # [m]
+        occlusion_creep_velocity: 0.8333 # the creep velocity to occlusion limit stop line
         free_space_max: 43
         occupied_min: 58
         do_dp: true
-      before_creep_stop_time: 1.0 # [s]
-      min_vehicle_brake_for_rss: -2.5 # [m/s^2]
-      max_vehicle_velocity_for_rss: 16.66 # [m/s] == 60kmph
+        before_creep_stop_time: 1.0 # [s]
+        min_vehicle_brake_for_rss: -2.5 # [m/s^2]
+        max_vehicle_velocity_for_rss: 16.66 # [m/s] == 60kmph
 
     merge_from_private:
       stop_duration_sec: 1.0

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
@@ -27,6 +27,17 @@
         collision_start_margin_time: 4.0 # [s] this + state_transit_margin_time should be higher to account for collision with fast/accelerating object
         collision_end_margin_time: 6.0 # [s] this + state_transit_margin_time should be higher to account for collision with slow/decelerating object
         keep_detection_vel_thr: 0.833 # == 3.0km/h. keep detection if ego is ego.vel < keep_detection_vel_thr
+      occlusion_detection_area_length: 70.0 # [m]
+      occlusion_creep_velocity: 0.555 # the creep velocity to occlusion limit stop line
+      extra_occlusion_margin: 0.0
+      occlusion:
+        free_space_max: 43
+        occupied_min: 58
+        do_dp: true
+      before_creep_stop_time: 1.5 # [s]
+      min_vehicle_brake_for_rss: -2.5 # [m/s^2]
+      max_vehicle_velocity_for_rss: 16.66 # [m/s] == 60kmph
+      max_entry_for_occlusion_clerance: 0.1 # [m] maximum entry into the frist detection area lanelet
 
     merge_from_private:
       stop_duration_sec: 1.0

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
@@ -29,6 +29,7 @@
         keep_detection_vel_thr: 0.833 # == 3.0km/h. keep detection if ego is ego.vel < keep_detection_vel_thr
 
       occlusion:
+        enable: false
         occlusion_detection_area_length: 70.0 # [m]
         occlusion_creep_velocity: 0.8333 # the creep velocity to occlusion limit stop line
         free_space_max: 43

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/rtc_auto_mode_manager/rtc_auto_mode_manager.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/rtc_auto_mode_manager/rtc_auto_mode_manager.param.yaml
@@ -15,6 +15,7 @@
       - "avoidance_right"
       - "pull_over"
       - "pull_out"
+      - "intersection_occlusion"
 
     default_enable_list:
       - "blind_spot"
@@ -29,3 +30,4 @@
       - "avoidance_right"
       - "pull_over"
       - "pull_out"
+      - "intersection_occlusion"


### PR DESCRIPTION
## Description

add intersection occlusion param

## Related links

feature PR: https://github.com/autowarefoundation/autoware.universe/pull/3458

## Tests performed

see the feature PR

## Notes for reviewers

None

## Interface changes

A topic /planning/cooperate_status/intersection_occlusion is newly added

## Effects on system behavior

If enabled, the vehicle will stop in the intersection if occlusion is detected.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
