### PR TITLE
feat(autoware_launch): make drivable area expansion parameters common

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/drivable_area_expansion.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/drivable_area_expansion.param.yaml
@@ -1,26 +1,9 @@
 /**:
   ros__parameters:
     # Static expansion
-    avoidance:
-      drivable_area_right_bound_offset: 0.0
-      drivable_area_left_bound_offset: 0.0
-      drivable_area_types_to_skip: [road_border]
-    lane_change:
-      drivable_area_right_bound_offset: 0.0
-      drivable_area_left_bound_offset: 0.0
-      drivable_area_types_to_skip: [road_border]
-    pull_out:
-      drivable_area_right_bound_offset: 0.0
-      drivable_area_left_bound_offset: 0.0
-      drivable_area_types_to_skip: [road_border]
-    pull_over:
-      drivable_area_right_bound_offset: 0.0
-      drivable_area_left_bound_offset: 0.0
-      drivable_area_types_to_skip: [road_border]
-    side_shift:
-      drivable_area_right_bound_offset: 0.0
-      drivable_area_left_bound_offset: 0.0
-      drivable_area_types_to_skip: [road_border]
+    drivable_area_right_bound_offset: 0.0
+    drivable_area_left_bound_offset: 0.0
+    drivable_area_types_to_skip: [road_border]
 
     # Dynamic expansion by projecting the ego footprint along the path
     dynamic_expansion:


### PR DESCRIPTION
## Description
launcher PR for https://github.com/autowarefoundation/autoware.universe/pull/3499
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
planning simulator worked well.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
