### PR TITLE
chore(autoware_launch): visualize thin predicted trajectory on rviz

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -1993,6 +1993,7 @@ Visualization Manager:
             Color: 255; 255; 255
             Constant Color: true
             Value: true
+            Constant Width: true
             Width: 0.05000000074505806
           View Velocity:
             Alpha: 1


### PR DESCRIPTION
## Description
With the following PR, the path width is calculated automatically from the global parameters' vehicle width.
https://github.com/autowarefoundation/autoware.universe/pull/3504

However, the predicted trajectory from the lateral controller is supposed to be thin as follows.
The white trajectory is the predicted trajectory.
**with this PR**
![image](https://user-images.githubusercontent.com/20228327/233837346-76a7cb6e-f3d3-4158-ab33-6760496221ab.png)
**without this PR**
![image](https://user-images.githubusercontent.com/20228327/233837435-462e9755-8a62-439b-92a8-f512757d2a38.png)


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator works well

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
