### PR TITLE
chore(autoware_launch): tune intersection parameters

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
@@ -33,11 +33,11 @@
         occlusion_detection_area_length: 70.0 # [m]
         enable_creeping: false # flag to use the creep velocity when reaching occlusion limit stop line
         occlusion_creep_velocity: 0.8333 # the creep velocity to occlusion limit stop line
-        peeking_offset: -0.1 # [m] offset for peeking into detection area
+        peeking_offset: -0.5 # [m] offset for peeking into detection area
         free_space_max: 43
         occupied_min: 58
         do_dp: true
-        before_creep_stop_time: 1.0 # [s]
+        before_creep_stop_time: 0.1 # [s]
         min_vehicle_brake_for_rss: -2.5 # [m/s^2]
         max_vehicle_velocity_for_rss: 16.66 # [m/s] == 60kmph
 


### PR DESCRIPTION
## Description

Tuned intersection parameters

## Tests performed

In the following video the ray-trace origin of occupancy grid map is `velodyne_top` and ego is able to autonomously handle the static occlusion.

https://user-images.githubusercontent.com/28677420/234277148-b45a0110-5a9b-425c-8001-51024961eeae.mp4

## Effects on system behavior

Only when the occlusion feature for the intersection module works, a behavior changes a bit.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
