### PR TITLE
feat(behavior_velocity_planner::intersection): add intersection occlusion gridmap marker

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -1677,6 +1677,32 @@ Visualization Manager:
                             Reliability Policy: Reliable
                             Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/intersection
                           Value: false
+                        - Alpha: 0.5
+                          Autocompute Intensity Bounds: true
+                          Class: grid_map_rviz_plugin/GridMap
+                          Color: 200; 200; 200
+                          Color Layer: color
+                          Color Transformer: IntensityLayer
+                          Enabled: false
+                          Height Layer: elevation
+                          Height Transformer: Layer
+                          History Length: 1
+                          Invert Rainbow: false
+                          Max Color: 255; 255; 255
+                          Max Intensity: 10
+                          Min Color: 0; 0; 0
+                          Min Intensity: 0
+                          Name: IntersectionOcclusion
+                          Show Grid Lines: false
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            Filter size: 10
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/debug/intersection/occlusion_grid
+                          Use Rainbow: true
+                          Value: false
                         - Class: rviz_default_plugins/MarkerArray
                           Enabled: false
                           Name: Blind Spot


### PR DESCRIPTION
## Description

Add debug marker box for intersection occlusion grid.

## Related links

`grid_map_rviz_plugin` should be installed manually or by `rosdep install`.

https://github.com/autowarefoundation/autoware.universe/pull/3509

## Tests performed

![image](https://user-images.githubusercontent.com/28677420/234784216-ce5f58b4-af3b-4c75-8539-89211685d991.png)

To view this check the "IntersectionOcclusion" box.

![image](https://user-images.githubusercontent.com/28677420/234784338-c9fc5cf5-f687-42d1-aa20-3a82e501b2ab.png)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

Not applicable

## Effects on system behavior

Not applicable

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
