### PR TITLE
perf(mpc_lateral_controller): mpc works more stably

### DIFF
--- a/autoware_launch/config/control/trajectory_follower/lateral/mpc.param.yaml
+++ b/autoware_launch/config/control/trajectory_follower/lateral/mpc.param.yaml
@@ -19,12 +19,12 @@
     qp_solver_type: "osqp"                       # optimization solver option (unconstraint_fast or osqp)
     mpc_prediction_horizon: 50                   # prediction horizon step
     mpc_prediction_dt: 0.1                       # prediction horizon period [s]
-    mpc_weight_lat_error: 0.1                    # lateral error weight in matrix Q
+    mpc_weight_lat_error: 1.0                    # lateral error weight in matrix Q
     mpc_weight_heading_error: 0.0                # heading error weight in matrix Q
     mpc_weight_heading_error_squared_vel: 0.3    # heading error * velocity weight in matrix Q
     mpc_weight_steering_input: 1.0               # steering error weight in matrix R
     mpc_weight_steering_input_squared_vel: 0.25  # steering error * velocity weight in matrix R
-    mpc_weight_lat_jerk: 0.0                     # lateral jerk weight in matrix R
+    mpc_weight_lat_jerk: 0.1                     # lateral jerk weight in matrix R
     mpc_weight_steer_rate: 0.0                   # steering rate weight in matrix R
     mpc_weight_steer_acc: 0.000001               # steering angular acceleration weight in matrix R
     mpc_low_curvature_weight_lat_error: 0.1                    # lateral error weight in matrix Q in low curvature point


### PR DESCRIPTION
## Description

Current MPC's parameters seem to stick to decrease a lateral error too much lacking steering angle stability.
Since the path changes dynamically in complicated environments and the path may have a bit high curvature, MPC's stability against a more unstable path is important as follows.
https://www.youtube.com/watch?v=opqtckENIs8&amp;ab_channel=ApolloAuto&ab_channel=ApolloAuto

With this PR, MPC
- can still make a small tracking error
- is not so sensitive to a more unstable path (the dynamic path change and a bit high curvature)


(Hard to see the difference from the video though)
The following is a case of avoidance by obstacle_avoidance_planner which has a bit high curvature.
The critical difference is when returning to the reference path after avoidance. Without this PR, the steering wheel changed from right to left suddenly.
**Without this PR**
[Screencast from 2023年04月29日 01時58分15秒.webm](https://user-images.githubusercontent.com/20228327/235208601-8708afb5-a46f-43d1-81a4-900b5aad847e.webm)
**With this PR**
[Screencast from 2023年04月29日 01時53分21秒.webm](https://user-images.githubusercontent.com/20228327/235207828-00a8ba36-15c8-4e8a-804b-6b1737ac027a.webm)

The code I changed is
- autoware.universe
```bash
$ git diff
diff --git a/planning/behavior_path_planner/CMakeLists.txt b/planning/behavior_path_planner/CMakeLists.txt
index 78383f6146..710f287175 100644
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -7,7 +7,7 @@ autoware_package()
 find_package(OpenCV REQUIRED)
 find_package(magic_enum CONFIG REQUIRED)
 
-set(COMPILE_WITH_OLD_ARCHITECTURE TRUE)
+set(COMPILE_WITH_OLD_ARCHITECTURE FALSE)
 
 set(common_src
   src/steering_factor_interface.cpp
```
- autoware_launch

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

The behavior of MPC's tracking characteristics may change a bit.
These parameters have to be tuned for each specific vehicle.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
