### PR TITLE
refactor(avoidance): remove redundant parameter

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
@@ -99,7 +99,6 @@
         lateral:
           lateral_collision_margin: 1.0                 # [m]
           lateral_execution_threshold: 0.499            # [m]
-          lateral_passable_safety_buffer: 1.0           # [m]
           road_shoulder_safety_margin: 0.3              # [m]
           max_right_shift_length: 5.0
           max_left_shift_length: 5.0

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
@@ -98,9 +98,9 @@
         # avoidance lateral parameters
         lateral:
           lateral_collision_margin: 1.0                 # [m]
+          lateral_execution_threshold: 0.499            # [m]
           lateral_passable_safety_buffer: 1.0           # [m]
           road_shoulder_safety_margin: 0.3              # [m]
-          avoidance_execution_lateral_threshold: 0.499
           max_right_shift_length: 5.0
           max_left_shift_length: 5.0
         # avoidance distance parameters


### PR DESCRIPTION
## Description

- rename `avoidance_execution_lateral_threshold` -> `lateral_execution_threshold`.
- remove `lateral_passable_safety_buffer` and use each objects' `safety_buffer_lateral` instead.
- https://github.com/autowarefoundation/autoware.universe/pull/3623

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Evaluator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
