### PR TITLE
fix(behavior_path_planner): add side_shift module in rtc_auto_mode_manager

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/rtc_auto_mode_manager/rtc_auto_mode_manager.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/rtc_auto_mode_manager/rtc_auto_mode_manager.param.yaml
@@ -16,6 +16,7 @@
       - "goal_planner"
       - "pull_out"
       - "intersection_occlusion"
+      - "side_shift"
 
     default_enable_list:
       - "blind_spot"
@@ -31,3 +32,4 @@
       - "goal_planner"
       - "pull_out"
       - "intersection_occlusion"
+      - "side_shift"


### PR DESCRIPTION
## Description
add side_shift module in rtc_auto_mode_manager param
Should be merged with https://github.com/autowarefoundation/autoware.universe/pull/3646 and https://github.com/tier4/tier4_autoware_msgs/pull/86
<!-- Write a brief description of this PR. -->

## Tests performed
run psim

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
