### PR TITLE
fix(tier4_perception_component_launch): add sync_param_path

### DIFF
--- a/autoware_launch/config/perception/object_recognition/detection/roi_sync.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/roi_sync.param.yaml
@@ -1,0 +1,5 @@
+/**:
+  ros__parameters:
+    input_offset_ms: [61.67, 111.67, 45.0, 28.33, 78.33, 95.0]
+    timeout_ms: 70.0
+    match_threshold_ms: 50.0

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -21,10 +21,7 @@
       name="object_recognition_detection_pointcloud_map_filter_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/pointcloud_map_filter.param.yaml"
     />
-    <arg
-      name="object_recognition_detection_fusion_sync_param_path"
-      value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/roi_sync.param.yaml"
-    />
+    <arg name="object_recognition_detection_fusion_sync_param_path" value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/roi_sync.param.yaml"/>
     <arg
       name="object_recognition_tracking_multi_object_tracker_data_association_matrix_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/tracking/multi_object_tracker/data_association_matrix.param.yaml"

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -22,6 +22,10 @@
       value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/pointcloud_map_filter.param.yaml"
     />
     <arg
+      name="object_recognition_detection_fusion_sync_param_path"
+      value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/roi_sync.param.yaml"
+    />
+    <arg
       name="object_recognition_tracking_multi_object_tracker_data_association_matrix_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/tracking/multi_object_tracker/data_association_matrix.param.yaml"
     />


### PR DESCRIPTION
## Description

This PR add a copy of [roi_sync.param.yaml](https://github.com/autowarefoundation/autoware.universe/blob/main/perception/image_projection_based_fusion/config/roi_sync.param.yaml) to [here](https://github.com/autowarefoundation/autoware_launch/tree/main/autoware_launch/config/perception/object_recognition/detection), and pass those parameters to `tier4_perception_launch`

This PR and [another](https://github.com/autowarefoundation/autoware.universe/pull/3713) are intended to solve the problem mentioned  [here](https://github.com/orgs/autowarefoundation/discussions/3465#discussioncomment-5869137)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
