### PR TITLE
feat(behavior_path_planner): relax margin_from_boundary in goal_planner param

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
@@ -18,7 +18,7 @@
         max_lateral_offset: 0.5
         lateral_offset_interval: 0.25
         ignore_distance_from_lane_start: 15.0
-        margin_from_boundary: 0.5
+        margin_from_boundary: 0.75
 
       # occupancy grid map
       occupancy_grid:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
`margin_from_boundary`: 0.5 -> 0.75
The motivation of this change is to prevent the ego from going out of the drivable area by control error.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Test with real vehicle

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
