### PR TITLE
fix(planning_launch): parameterize scale for lc safety check

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -31,6 +31,7 @@
 
     lateral_distance_max_threshold: 1.7
     longitudinal_distance_min_threshold: 3.0
+    longitudinal_velocity_delta_time: 0.8
 
     expected_front_deceleration: -1.0
     expected_rear_deceleration: -1.0


### PR DESCRIPTION
## Description

Parameterize `longitudinal_velocity_delta_time` in the behavior path planner node for safe lane change. 

RSS check only secure the future distance, therefore, even when RSS logic returns safe, we cannot guarantee that the physical distance between real vehicle is safe. Originally the value is fixed to `0.8` but there might be necessity to reduce or increase the value depending on situation.

Update the YAML file, the parameter struct, the node constructor, and the safety check function to use the new parameter.
## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
