### PR TITLE
feat(behavior_path_planner): add flag to enable auto mode without rtc_auto_mode_manager

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
@@ -21,7 +21,7 @@
 
     lane_change_left:
       enable_module: true
-      enable_rtc: false
+      enable_rtc: true
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true
       priority: 6
@@ -29,7 +29,7 @@
 
     lane_change_right:
       enable_module: true
-      enable_rtc: false
+      enable_rtc: true
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true
       priority: 6
@@ -37,7 +37,7 @@
 
     pull_out:
       enable_module: true
-      enable_rtc: false
+      enable_rtc: true
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: false
       priority: 0
@@ -45,7 +45,7 @@
 
     side_shift:
       enable_module: true
-      enable_rtc: false
+      enable_rtc: true
       enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: false
       priority: 2
@@ -53,7 +53,7 @@
 
     goal_planner:
       enable_module: true
-      enable_rtc: false
+      enable_rtc: true
       enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: false
       priority: 1
@@ -61,7 +61,7 @@
 
     avoidance:
       enable_module: true
-      enable_rtc: false
+      enable_rtc: true
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: false
       priority: 5

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
@@ -21,7 +21,7 @@
 
     lane_change_left:
       enable_module: true
-      enable_rtc: false
+      enable_rtc: true
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true
       priority: 6
@@ -29,7 +29,7 @@
 
     lane_change_right:
       enable_module: true
-      enable_rtc: false
+      enable_rtc: true
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true
       priority: 6
@@ -61,7 +61,7 @@
 
     avoidance:
       enable_module: true
-      enable_rtc: false
+      enable_rtc: true
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: false
       priority: 5
@@ -70,7 +70,7 @@
     # NOTE: This module is unstable. Deprecated for now.
     avoidance_by_lc:
       enable_module: false
-      enable_rtc: false
+      enable_rtc: true
       enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: false
       priority: 4
@@ -78,7 +78,7 @@
 
     dynamic_avoidance:
       enable_module: false
-      enable_rtc: false
+      enable_rtc: true
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true
       priority: 3

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
@@ -5,6 +5,7 @@
   ros__parameters:
     external_request_lane_change_left:
       enable_module: false
+      enable_rtc: false
       enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: true
       priority: 7
@@ -12,6 +13,7 @@
 
     external_request_lane_change_right:
       enable_module: false
+      enable_rtc: false
       enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: true
       priority: 7
@@ -19,6 +21,7 @@
 
     lane_change_left:
       enable_module: true
+      enable_rtc: false
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true
       priority: 6
@@ -26,6 +29,7 @@
 
     lane_change_right:
       enable_module: true
+      enable_rtc: false
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true
       priority: 6
@@ -33,6 +37,7 @@
 
     pull_out:
       enable_module: true
+      enable_rtc: false
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: false
       priority: 0
@@ -40,6 +45,7 @@
 
     side_shift:
       enable_module: true
+      enable_rtc: false
       enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: false
       priority: 2
@@ -47,6 +53,7 @@
 
     goal_planner:
       enable_module: true
+      enable_rtc: false
       enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: false
       priority: 1
@@ -54,6 +61,7 @@
 
     avoidance:
       enable_module: true
+      enable_rtc: false
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: false
       priority: 5
@@ -62,6 +70,7 @@
     # NOTE: This module is unstable. Deprecated for now.
     avoidance_by_lc:
       enable_module: false
+      enable_rtc: false
       enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: false
       priority: 4
@@ -69,6 +78,7 @@
 
     dynamic_avoidance:
       enable_module: false
+      enable_rtc: false
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true
       priority: 3

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
@@ -61,7 +61,7 @@
 
     avoidance:
       enable_module: true
-      enable_rtc: true
+      enable_rtc: false
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: false
       priority: 5

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
@@ -5,7 +5,7 @@
   ros__parameters:
     external_request_lane_change_left:
       enable_module: false
-      enable_rtc: false
+      enable_rtc: true
       enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: true
       priority: 7
@@ -13,7 +13,7 @@
 
     external_request_lane_change_right:
       enable_module: false
-      enable_rtc: false
+      enable_rtc: true
       enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: true
       priority: 7
@@ -21,7 +21,7 @@
 
     lane_change_left:
       enable_module: true
-      enable_rtc: true
+      enable_rtc: false
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true
       priority: 6
@@ -29,7 +29,7 @@
 
     lane_change_right:
       enable_module: true
-      enable_rtc: true
+      enable_rtc: false
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true
       priority: 6


### PR DESCRIPTION
## Description

add parameter `enable_rtc`
if true, the scene modules should be approved by rtc. if false, the module can be run without approval from rtc.

merge with this [PR](https://github.com/autowarefoundation/autoware.universe/pull/3894)
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
