### PR TITLE
refactor(behavior_velocity_planner): load all module parameters

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
@@ -23,3 +23,4 @@
       # behavior_velocity_planner::RunOutModulePlugin
       # behavior_velocity_planner::SpeedBumpModulePlugin
       - behavior_velocity_planner::OutOfLaneModulePlugin
+      # behavior_velocity_planner::NoDrivableLaneModulePlugin

--- a/autoware_launch/launch/components/tier4_planning_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_planning_component.launch.xml
@@ -55,8 +55,13 @@
               $(var behavior_velocity_config_path)/intersection.param.yaml,
               $(var behavior_velocity_config_path)/stop_line.param.yaml,
               $(var behavior_velocity_config_path)/traffic_light.param.yaml,
+              $(var behavior_velocity_config_path)/virtual_traffic_light.param.yaml,
+              $(var behavior_velocity_config_path)/occlusion_spot.param.yaml,
               $(var behavior_velocity_config_path)/no_stopping_area.param.yaml,
-              $(var behavior_velocity_config_path)/out_of_lane.param.yaml]"
+              $(var behavior_velocity_config_path)/run_out.param.yaml,
+              $(var behavior_velocity_config_path)/speed_bump.param.yaml,
+              $(var behavior_velocity_config_path)/out_of_lane.param.yaml,
+              $(var behavior_velocity_config_path)/no_drivable_lane.param.yaml]"
     />
 
     <!-- parking -->


### PR DESCRIPTION
## Description

From this comment: https://github.com/autowarefoundation/autoware_launch/pull/369#issuecomment-1581173744. Load all module parameters by default. The user only needs to edit `launch_modules`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
