### PR TITLE
fix: ground_segmentation.param for vls16

### DIFF
--- a/autoware_launch/config/perception/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml
+++ b/autoware_launch/config/perception/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml
@@ -28,4 +28,4 @@
         grid_mode_switch_radius: 20.0
         gnd_grid_buffer_size: 4
         detection_range_z_max: 2.5
-        elevation_grid_mode: true
+        elevation_grid_mode: false


### PR DESCRIPTION
## Description
because elevation grid is too small for vls 16 I fix this bug for awsim

/perception/obstacle_segmentation/range_cropped/pointcloud
![image](https://github.com/autowarefoundation/autoware_launch/assets/65527974/c8808348-6eec-45da-8c2e-c3d82ea4eaf3)

/perception/obstacle_segmentation/single_frame/pointcloud_raw
before this PR
![image](https://github.com/autowarefoundation/autoware_launch/assets/65527974/c03f48c5-3c97-496a-8ed4-b9f8157e34df)

after this PR

https://github.com/autowarefoundation/autoware_launch/assets/65527974/b1f3dd4a-bf80-43c1-bdb9-c5008f4fb125

[Internal](https://tier4.atlassian.net/browse/AT-136)

## Tests performed

by awsim


## Effects on system behavior

perception module

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
