### PR TITLE
fix(autoware_launch): add missing parameter in autonmous emergency braking

### DIFF
--- a/autoware_launch/config/control/autonomous_emergency_braking/autonomous_emergency_braking.param.yaml
+++ b/autoware_launch/config/control/autonomous_emergency_braking/autonomous_emergency_braking.param.yaml
@@ -13,4 +13,5 @@
     a_obj_min: -1.0
     prediction_time_horizon: 1.5
     prediction_time_interval: 0.1
+    collision_keeping_sec: 0.0
     aeb_hz: 10.0


### PR DESCRIPTION
## Description
https://github.com/autowarefoundation/autoware.universe/pull/3292
Add missing parameter in autonomous_emergency_braking.param.yaml for fixing the following error.
```
'autoware::motion::control::autonomous_emergency_braking::AEB' in container '/control/control_container': Component constructor threw an exception: Statically typed parameter 'collision_keeping_sec' must be initialized.
```

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable. (AEB can start normally by this fix. )

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
