### PR TITLE
feat(start_planner): add length_ratio_for_turn_signal_deactivation_near_intersection

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -4,7 +4,6 @@
       th_arrived_distance: 1.0
       th_stopped_velocity: 0.01
       th_stopped_time: 1.0
-      th_blinker_on_lateral_offset: 1.0
       collision_check_margin: 1.0
       collision_check_distance_from_end: 1.0
       # shift pull out
@@ -30,3 +29,7 @@
       backward_search_resolution: 2.0
       backward_path_update_duration: 3.0
       ignore_distance_from_lane_end: 15.0
+      # turns signal
+      th_turn_signal_on_lateral_offset: 1.0
+      intersection_search_length: 30.0
+      length_ratio_for_turn_signal_deactivation_near_intersection: 0.5


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

update for  https://github.com/autowarefoundation/autoware.universe/pull/4026

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

https://github.com/autowarefoundation/autoware.universe/pull/4026

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

none 
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
none
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
