### PR TITLE
feat(avoidance): update avoidance params

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
@@ -132,7 +132,7 @@
       avoidance:
         # avoidance lateral parameters
         lateral:
-          lateral_execution_threshold: 0.499            # [m]
+          lateral_execution_threshold: 0.09             # [m]
           lateral_small_shift_threshold: 0.101          # [m]
           road_shoulder_safety_margin: 0.3              # [m]
           max_right_shift_length: 5.0
@@ -156,7 +156,7 @@
 
       constraints:
         # vehicle slows down under longitudinal constraints
-        use_constraints_for_decel: false                # [-]
+        use_constraints_for_decel: true                 # [-]
 
         # lateral constraints
         lateral:
@@ -181,7 +181,7 @@
 
       shift_line_pipeline:
         trim:
-          quantize_filter_threshold: 0.2
+          quantize_filter_threshold: 0.1
           same_grad_filter_1_threshold: 0.1
           same_grad_filter_2_threshold: 0.2
           same_grad_filter_3_threshold: 0.5


### PR DESCRIPTION
## Description

Update following params:

- use_constraints_for_decel: false -> true
  - don't allow sudden stop even when there is object that should be avoid.
- lateral_execution_threshold: 0.499 -> 0.09
  - it can output small shift avoidance path.
- quantize_filter_threshold: 0.2 -> 0.1
  - it can output small shift avoidance path.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/222ee33b-1bec-57fa-8e46-99e8fb111681?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

- don't allow sudden stop even when there is object that should be avoid.
- it can output small shift avoidance path.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
