### PR TITLE
perf(path_sampler): tune lateral_deviation_weight for more stable planning

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/path_sampler/path_sampler.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/path_sampler/path_sampler.param.yaml
@@ -16,7 +16,7 @@
         max_curvature: 0.1  # [m⁻¹] maximum curvature of a sampled path
         min_curvature: -0.1  # [m⁻¹] minimum curvature of a sampled path
       soft:
-        lateral_deviation_weight: 0.1  # cost weight for lateral deviation between the end of a sampled path and the reference path
+        lateral_deviation_weight: 1.0  # cost weight for lateral deviation between the end of a sampled path and the reference path
         length_weight: 1.0  # cost weight for the length of a sampled path
         curvature_weight: 1.0  # cost weight for the curvature of a sampled path
     sampling:


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR changes the `lateral_deviation_weight` so that the output trajectory is more likely to stay close to the reference path.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Evaluation platform: https://evaluation.tier4.jp/evaluation/reports/d45cfc83-e85d-5ff0-8251-a2603f30f5c6?project_id=prd_jt (TIER IV internal link)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Better trajectory when using the `path_sampler`.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
