### PR TITLE
feat(routing_no_drivable_lane_when_module_enabled): add solution for routing no_drivable_lane only when module enabled

### DIFF
--- a/autoware_launch/config/planning/mission_planning/mission_planner/mission_planner.param.yaml
+++ b/autoware_launch/config/planning/mission_planning/mission_planner/mission_planner.param.yaml
@@ -9,4 +9,3 @@
     reroute_time_threshold: 10.0
     minimum_reroute_length: 30.0
     consider_no_drivable_lanes: false # This flag is for considering no_drivable_lanes in planning or not.
-                                      # Set to true when behavior_velocity_planner::NoDrivableLaneModulePlugin in uncommented in autoware_launch

--- a/autoware_launch/config/planning/mission_planning/mission_planner/mission_planner.param.yaml
+++ b/autoware_launch/config/planning/mission_planning/mission_planner/mission_planner.param.yaml
@@ -10,4 +10,3 @@
     minimum_reroute_length: 30.0
     consider_no_drivable_lanes: false # This flag is for considering no_drivable_lanes in planning or not.
                                       # Set to true when behavior_velocity_planner::NoDrivableLaneModulePlugin in uncommented in autoware_launch
-

--- a/autoware_launch/config/planning/mission_planning/mission_planner/mission_planner.param.yaml
+++ b/autoware_launch/config/planning/mission_planning/mission_planner/mission_planner.param.yaml
@@ -8,3 +8,6 @@
     enable_correct_goal_pose: false
     reroute_time_threshold: 10.0
     minimum_reroute_length: 30.0
+    consider_no_drivable_lanes: false # This flag is for considering no_drivable_lanes in planning or not.
+                                      # Set to true when behavior_velocity_planner::NoDrivableLaneModulePlugin in uncommented in autoware_launch
+

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
@@ -23,4 +23,4 @@
       # behavior_velocity_planner::RunOutModulePlugin
       # behavior_velocity_planner::SpeedBumpModulePlugin
       - behavior_velocity_planner::OutOfLaneModulePlugin
-      # behavior_velocity_planner::NoDrivableLaneModulePlugin     # If enabled, set consider_no_drivable_lanes to true in mission_planner.param.yaml
+      # behavior_velocity_planner::NoDrivableLaneModulePlugin

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
@@ -23,4 +23,4 @@
       # behavior_velocity_planner::RunOutModulePlugin
       # behavior_velocity_planner::SpeedBumpModulePlugin
       - behavior_velocity_planner::OutOfLaneModulePlugin
-      # behavior_velocity_planner::NoDrivableLaneModulePlugin
+      # behavior_velocity_planner::NoDrivableLaneModulePlugin     # If enabled, set consider_no_drivable_lanes to true in mission_planner.param.yaml


### PR DESCRIPTION
## Description
This PR is to add as solution for routing `no_drivable_lane(s)` only when the module is enabled.
Related to this [Task](https://github.com/autowarefoundation/autoware.universe/issues/4307)
<!-- Write a brief description of this PR. -->

## Tests performed
Using planning simulator :
- When `no_drivable_lane` is disabled, the routing for `no_drivable_lane(s)` is not considered
- When When `no_drivable_lane` is enabled, routing for `no_drivable_lane(s)` is considered
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


## Effects on system behavior
Routing for `no_drivable_lane(s)` is considered only when the module is enabled.
<!-- Describe how this PR affects the system behavior. -->


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
