### PR TITLE
feat(rviz): add acceleration meter for debugging which is disabled by default

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -86,6 +86,16 @@ Visualization Manager:
                 Value: /vehicle/status/velocity_status
               Value: true
               Value height offset: 0
+            - Class: rviz_plugins/AccelerationMeter
+              Enabled: false
+              Name: AccelerationMeter
+              Left: 896
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Reliable
+                Value: /localization/acceleration
             - Alpha: 0.999
               Class: rviz_plugins/VelocityHistory
               Color Border Vel Max: 3

--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -89,7 +89,6 @@ Visualization Manager:
             - Class: rviz_plugins/AccelerationMeter
               Enabled: false
               Name: AccelerationMeter
-              Left: 896
               Topic:
                 Depth: 5
                 Durability Policy: Volatile


### PR DESCRIPTION
## Description

Add acceleration meter for debugging, which should be aligned with the speed meter, and disabled by default. The Acceleration meter is implemented and discussed in https://github.com/autowarefoundation/autoware.universe/pull/4506

## Tests performed

PSim.
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

Please check the images in https://github.com/autowarefoundation/autoware.universe/pull/4506 .

The meter does not pop up by default and requires manual selection in system/vehicle to enable the plugin.

A new panel recording acceleration is expected to opened on the right of speed panel. (In the screenshot we manually select the checkbox to enable the acceleration meter)
![Screenshot from 2023-08-04 13-48-00](https://github.com/autowarefoundation/autoware.universe/assets/31618608/0d38173c-3724-4c1a-b6f5-0e2d5937a0e5)

The center text should turn red (by default) if acceleration is larger than a max-threshold (re-configurable on Rviz), or smaller than a min-threshold. (In the screenshot we manually reconfigured the thresholds to demonstrate the behaviour)
![Screenshot from 2023-08-04 13-48-45](https://github.com/autowarefoundation/autoware.universe/assets/31618608/db68c339-9ede-4fac-b65f-fb924bd41649)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
