### PR TITLE
chore(tier4_simulator_component): add traffic light arbiter param path

### DIFF
--- a/autoware_launch/launch/components/tier4_simulator_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_simulator_component.launch.xml
@@ -43,5 +43,6 @@
     <arg name="laserscan_based_occupancy_grid_map_param_path" value="$(find-pkg-share autoware_launch)/config/perception/occupancy_grid_map/laserscan_based_occupancy_grid_map.param.yaml"/>
     <arg name="occupancy_grid_map_updater" value="$(var occupancy_grid_map_updater)"/>
     <arg name="occupancy_grid_map_updater_param_path" value="$(find-pkg-share autoware_launch)/config/perception/occupancy_grid_map/$(var occupancy_grid_map_updater)_updater.param.yaml"/>
+    <arg name="traffic_light_arbiter_param_path" value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_arbiter/traffic_light_arbiter.param.yaml"/>
   </include>
 </launch>


### PR DESCRIPTION
## Description

This PR adds `traffic_light_arbiter_param_path` to configure parameter of `traffic_light_arbiter` in scenario simulation.

Related PR
- https://github.com/autowarefoundation/autoware.universe/pull/4522

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I confirmed the parameters is set in simple planning simulator.

Changed parameter file in autoware launch.
```
/**:
  ros__parameters:
    external_time_tolerance: 5.0
    perception_time_tolerance: 1.1
    external_priority: true
```

The result of ros2 param dump.
```
$ ros2 param dump /perception/traffic_light_recognition/traffic_light_arbiter/arbiter
/perception/traffic_light_recognition/traffic_light_arbiter/arbiter:
  ros__parameters:
    external_priority: true
    external_time_tolerance: 5.0
    perception_time_tolerance: 1.1
    qos_overrides:
      /parameter_events:
        publisher:
          depth: 1000
          durability: volatile
          history: keep_last
          reliability: reliable
    use_sim_time: false
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
