### PR TITLE
feat(autoware_launch): use hatched road markings in dynamic avoidance

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/dynamic_avoidance/dynamic_avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/dynamic_avoidance/dynamic_avoidance.param.yaml
@@ -44,6 +44,8 @@
       drivable_area_generation:
         lat_offset_from_obstacle: 0.8 # [m]
         max_lat_offset_to_avoid: 0.5 # [m]
+        max_time_for_object_lat_shift: 2.0 # [s]
+        lpf_gain_for_lat_avoid_to_offset: 0.9 # [-]
 
         # for same directional object
         overtaking_object:

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/dynamic_avoidance/dynamic_avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/dynamic_avoidance/dynamic_avoidance.param.yaml
@@ -44,7 +44,7 @@
       drivable_area_generation:
         lat_offset_from_obstacle: 0.8 # [m]
         max_lat_offset_to_avoid: 0.5 # [m]
-        max_time_for_object_lat_shift: 2.0 # [s]
+        max_time_for_object_lat_shift: 0.0 # [s]
         lpf_gain_for_lat_avoid_to_offset: 0.9 # [-]
 
         # for same directional object

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/dynamic_avoidance/dynamic_avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/dynamic_avoidance/dynamic_avoidance.param.yaml
@@ -3,6 +3,7 @@
     dynamic_avoidance:
       common:
         enable_debug_info: true
+        use_hatched_road_markings: true
 
       # avoidance is performed for the object type with true
       target_object:
@@ -53,6 +54,6 @@
 
         # for opposite directional object
         oncoming_object:
-          max_time_to_collision: 15.0 # [s]
+          max_time_to_collision: 40.0 # [s] This value should be the same as overtaking_object's one to suppress chattering of this value for parked vehicles
           start_duration_to_avoid: 12.0  # [s]
           end_duration_to_avoid: 0.0  # [s]


### PR DESCRIPTION
## Description

launcher PR for https://github.com/autowarefoundation/autoware.universe/pull/4566
- use hatched road markings in dynamic avoidance
- add minor ros parameters in dynamic avoidance
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

See https://github.com/autowarefoundation/autoware.universe/pull/4566

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

See https://github.com/autowarefoundation/autoware.universe/pull/4566

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
