### PR TITLE
feat(reroute-static-obstacle): rerouting static obstacle using a selected point by the user

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -2489,6 +2489,14 @@ Visualization Manager:
       Z position: 0
     - Class: rviz_plugins/DeleteAllObjectsTool
       Pose Topic: /simulation/dummy_perception_publisher/object_info
+    - Class: rviz_plugins/RerouteStaticObstacleTool
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /simulation/planning/reroute_static_obstacle_point_publisher/point
   Value: true
   Views:
     Current:

--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -2489,7 +2489,7 @@ Visualization Manager:
       Z position: 0
     - Class: rviz_plugins/DeleteAllObjectsTool
       Pose Topic: /simulation/dummy_perception_publisher/object_info
-    - Class: rviz_plugins/RerouteStaticObstacleTool
+    - Class: rviz_plugins/RerouteStaticObstaclePointPublish
       Single click: true
       Topic:
         Depth: 5


### PR DESCRIPTION
## Description
This PR is the autoware_launch changes that must be merged along with with [autoware_universe](https://github.com/autowarefoundation/autoware.universe/pull/4524) changes for [rerouting a static obstacle](https://github.com/orgs/autowarefoundation/discussions/3599).
<!-- Write a brief description of this PR. -->

## Related links
[Discussion / Idea](https://github.com/orgs/autowarefoundation/discussions/3599)
[Issue](https://github.com/autowarefoundation/autoware.universe/issues/4523)
[autoware_universe PR](https://github.com/autowarefoundation/autoware.universe/pull/4524)
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
Using planning simulator :
- let the reroute static obstacle point publisher plugin appear for ease of use
- select a point through the route of the vehicle
- if alternative route is available, vehicle should be able to change route and does not go through the selected point.

This [video demo](https://youtu.be/7oKjy4SdTjc) shows this testing procedure.
<!-- Describe how you have tested this PR. -->

## Notes for reviewers
- Please follow the same procedure as show in the video above for testing
- :exclamation: **This PR mush be merged with** [autoware_universe PR](https://github.com/autowarefoundation/autoware.universe/pull/4524) :exclamation: 
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
N.A
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
Autoware will be able to reroute for road blockage based on input from the user (human driver/operator)
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
