### PR TITLE
feat(autoware_launch): enable emergency handling when resource monitoring state becomes error

### DIFF
--- a/autoware_launch/config/system/system_error_monitor/system_error_monitor.param.yaml
+++ b/autoware_launch/config/system/system_error_monitor/system_error_monitor.param.yaml
@@ -37,7 +37,7 @@
         /autoware/system/node_alive_monitoring: default
         /autoware/system/emergency_stop_operation: default
         /autoware/system/service_log_checker: { sf_at: "warn", lf_at: "none", spf_at: "none" }
-        /autoware/system/resource_monitoring: { sf_at: "warn", lf_at: "none", spf_at: "none" }
+        /autoware/system/resource_monitoring: { sf_at: "warn", lf_at: "error", spf_at: "none" }
 
         /autoware/vehicle/node_alive_monitoring: default
 


### PR DESCRIPTION
## Description
I made a change to set the diagnostic level to "latent fault" and change the state of Autoware to "Emergency" when the state of resource_monitoring becomes an error.
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
none
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
none
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
As the description,
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
