### PR TITLE
fix(control_validator): default false for publishing diag and display terminal

### DIFF
--- a/autoware_launch/config/control/control_validator/control_validator.param.yaml
+++ b/autoware_launch/config/control/control_validator/control_validator.param.yaml
@@ -1,14 +1,14 @@
 /**:
   ros__parameters:
 
-    publish_diag: true  # if true, diagnostic msg is published
+    publish_diag: false  # if true, diagnostic msg is published
 
     # If the number of consecutive invalid predicted_path exceeds this threshold, the Diag will be set to ERROR.
     # (For example, threshold = 1 means, even if the predicted_path is invalid, Diag will not be ERROR if
     #  the next predicted_path is valid.)
     diag_error_count_threshold: 0
 
-    display_on_terminal: true # show error msg on terminal
+    display_on_terminal: false # show error msg on terminal
 
     thresholds:
       max_distance_deviation: 1.0


### PR DESCRIPTION
## Description

suppress warning message and publish diag for now.
Apparently it has problem with code.
I will revert this PR's change after solve the problem.

<!-- Write a brief description of this PR. -->

## Tests performed

Checked no warning is shown in terminal.

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
