### PR TITLE
feat(operation_transition_mannager): add param enable_engage_on_driving

### DIFF
--- a/autoware_launch/config/control/operation_mode_transition_manager/operation_mode_transition_manager.param.yaml
+++ b/autoware_launch/config/control/operation_mode_transition_manager/operation_mode_transition_manager.param.yaml
@@ -2,6 +2,10 @@
   ros__parameters:
     transition_timeout: 10.0
     frequency_hz: 10.0
+
+    # set true if you want to engage the autonomous driving mode while the vehicle is driving. If set to false, it will deny Engage in any situation where the vehicle speed is not zero. Note that if you use this feature without adjusting the parameters, it may cause issues like sudden deceleration. Before using, please ensure the engage condition and the vehicle_cmd_gate transition filter are appropriately adjusted.
+    enable_engage_on_driving: false
+
     check_engage_condition: false # set false if you do not want to care about the engage condition.
     nearest_dist_deviation_threshold: 3.0 # [m] for finding nearest index
     nearest_yaw_deviation_threshold: 1.57 # [rad] for finding nearest index


### PR DESCRIPTION
## Description

For https://github.com/autowarefoundation/autoware.universe/pull/4891

## Tests performed

see https://github.com/autowarefoundation/autoware.universe/pull/4891

## Effects on system behavior

see https://github.com/autowarefoundation/autoware.universe/pull/4891

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
