### PR TITLE
feat: add traffic light recogition namespace to e2e sim launch

### DIFF
--- a/autoware_launch/launch/e2e_simulator.launch.xml
+++ b/autoware_launch/launch/e2e_simulator.launch.xml
@@ -18,6 +18,8 @@
   <!-- Map -->
   <arg name="lanelet2_map_file" default="lanelet2_map.osm" description="lanelet2 map file name"/>
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>
+  <!-- Perception -->
+  <arg name="traffic_light_namespace" default="traffic_light" description="traffic light recognition namespace1"/>
   <!-- Control -->
   <!-- Vehicle -->
   <arg name="launch_vehicle_interface" default="false"/>
@@ -56,6 +58,7 @@
       <arg name="launch_sensing_driver" value="false"/>
       <!-- Perception-->
       <arg name="traffic_light_recognition/enable_fine_detection" value="false"/>
+      <arg name="namespace1" value="$(var traffic_light_namespace)"/>
       <!-- Tools -->
       <arg name="rviz" value="$(var rviz)"/>
       <arg name="rviz_config" value="$(var rviz_config)"/>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

## Tests performed
Confirmed that traffic light recognition is working by `ros2 launch autoware_launch e2e_simulator.launch.xml ` with AWSIM_v1.1.0 
by this tutorial https://tier4.github.io/AWSIM/GettingStarted/QuickStartDemo/)

![image](https://github.com/autowarefoundation/autoware_launch/assets/37187849/9fba0cc1-a498-4f58-a667-29eac1d3602c)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
