### PR TITLE
fix(autoware.rviz): remove initial_pose_button_panel

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -16,8 +16,6 @@ Panels:
     Expanded: ~
     Name: Views
     Splitter Ratio: 0.5
-  - Class: tier4_localization_rviz_plugin/InitialPoseButtonPanel
-    Name: InitialPoseButtonPanel
   - Class: AutowareDateTimePanel
     Name: AutowareDateTimePanel
   - Class: rviz_plugins::AutowareStatePanel


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/issues/4848
rviz reports the following error:
```
[rviz2-74] [ERROR 1693558088.618417957] [rviz2]: PluginlibFactory: The plugin for class 'tier4_localization_rviz_plugin/InitialPose
```
This plugin was removed https://github.com/autowarefoundation/autoware.universe/pull/4519.
So I will also remove tier4_localization_rviz_plugin/InitialPoseButtonPanel from the autoware.rviz.


<!-- Write a brief description of this PR. -->

## Tests performed

LSim works well without an above error message.

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
