### PR TITLE
feat: add system monitor param file for awsim

### DIFF
--- a/autoware_launch/config/system/system_error_monitor/system_error_monitor.awsim.param.yaml
+++ b/autoware_launch/config/system/system_error_monitor/system_error_monitor.awsim.param.yaml
@@ -1,0 +1,52 @@
+# Description:
+#   name: diag name
+#   sf_at: diag level where it becomes Safe Fault
+#   lf_at: diag level where it becomes Latent Fault
+#   spf_at: diag level where it becomes Single Point Fault
+#   auto_recovery: Determines whether the system will automatically recover when it recovers from an error.
+#
+# Note:
+# empty-value for sf_at, lf_at and spf_at is "none"
+# default values are:
+#   sf_at: "none"
+#   lf_at: "warn"
+#   spf_at: "error"
+#   auto_recovery: "true"
+---
+/**:
+  ros__parameters:
+    required_modules:
+      autonomous_driving:
+        /autoware/control/autonomous_driving/node_alive_monitoring: default
+        /autoware/control/autonomous_driving/performance_monitoring/lane_departure: default
+        /autoware/control/control_command_gate/node_alive_monitoring: default
+
+        /autoware/localization/node_alive_monitoring: default
+        /autoware/localization/performance_monitoring/matching_score: { sf_at: "warn", lf_at: "none", spf_at: "none" }
+        /autoware/localization/performance_monitoring/localization_accuracy: { sf_at: "warn", lf_at: "none", spf_at: "none" }
+
+        /autoware/map/node_alive_monitoring: default
+
+        /autoware/perception/node_alive_monitoring: default
+
+        /autoware/planning/node_alive_monitoring: default
+        /autoware/planning/performance_monitoring/trajectory_validation: default
+
+        # /autoware/sensing/node_alive_monitoring: default
+
+        /autoware/system/node_alive_monitoring: default
+        /autoware/system/emergency_stop_operation: default
+        /autoware/system/service_log_checker: { sf_at: "warn", lf_at: "none", spf_at: "none" }
+        # /autoware/system/resource_monitoring: { sf_at: "warn", lf_at: "none", spf_at: "none" }
+
+        /autoware/vehicle/node_alive_monitoring: default
+
+      external_control:
+        /autoware/control/control_command_gate/node_alive_monitoring: default
+        /autoware/control/external_control/external_command_selector/node_alive_monitoring: default
+
+        /autoware/system/node_alive_monitoring: default
+        /autoware/system/emergency_stop_operation: default
+        /autoware/system/service_log_checker: { sf_at: "warn", lf_at: "none", spf_at: "none" }
+
+        /autoware/vehicle/node_alive_monitoring: default

--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -33,6 +33,7 @@
   <arg name="system_run_mode" default="online" description="run mode in system"/>
   <arg name="launch_system_monitor" default="true" description="launch system monitor"/>
   <arg name="launch_dummy_diag_publisher" default="false" description="launch dummy diag publisher"/>
+  <arg name="system_error_monitor_param_path" default="$(find-pkg-share autoware_launch)/config/system/system_error_monitor/system_error_monitor.param.yaml"/>
   <!-- Tools -->
   <arg name="rviz" default="true" description="launch rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share autoware_launch)/rviz/autoware.rviz" description="rviz config"/>

--- a/autoware_launch/launch/components/tier4_system_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_system_component.launch.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="system_error_monitor_param_path" default="$(find-pkg-share autoware_launch)/config/system/system_error_monitor/system_error_monitor.param.yaml"/>
+
   <include file="$(find-pkg-share tier4_system_launch)/launch/system.launch.xml">
     <arg name="run_mode" value="$(var system_run_mode)"/>
     <arg name="launch_system_monitor" value="$(var launch_system_monitor)"/>
@@ -10,7 +12,7 @@
     <arg name="emergency_handler_param_path" value="$(find-pkg-share autoware_launch)/config/system/emergency_handler/emergency_handler.param.yaml"/>
     <arg name="mrm_comfortable_stop_operator_param_path" value="$(find-pkg-share autoware_launch)/config/system/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator.param.yaml"/>
     <arg name="mrm_emergency_stop_operator_param_path" value="$(find-pkg-share autoware_launch)/config/system/mrm_emergency_stop_operator/mrm_emergency_stop_operator.param.yaml"/>
-    <arg name="system_error_monitor_param_path" value="$(find-pkg-share autoware_launch)/config/system/system_error_monitor/system_error_monitor.param.yaml"/>
+    <arg name="system_error_monitor_param_path" value="$(var system_error_monitor_param_path)"/>
     <arg name="system_error_monitor_planning_simulator_param_path" value="$(find-pkg-share autoware_launch)/config/system/system_error_monitor/system_error_monitor.planning_simulation.param.yaml"/>
     <arg name="diagnostic_aggregator_vehicle_param_path" value="$(find-pkg-share autoware_launch)/config/system/system_error_monitor/diagnostic_aggregator/vehicle.param.yaml"/>
     <arg name="diagnostic_aggregator_system_param_path" value="$(find-pkg-share autoware_launch)/config/system/system_error_monitor/diagnostic_aggregator/system.param.yaml"/>

--- a/autoware_launch/launch/e2e_simulator.launch.xml
+++ b/autoware_launch/launch/e2e_simulator.launch.xml
@@ -27,6 +27,11 @@
   <!-- System -->
   <arg name="launch_system_monitor" default="false" description="launch system monitor"/>
   <arg name="launch_dummy_diag_publisher" default="false" description="launch dummy diag publisher"/>
+  <arg
+    name="system_error_monitor_param_path"
+    default="$(find-pkg-share autoware_launch)/config/system/system_error_monitor/system_error_monitor.awsim.param.yaml"
+    description="system error monitor param path"
+  />
   <!-- Tools -->
   <arg name="rviz" default="true" description="launch rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share autoware_launch)/rviz/autoware.rviz" description="rviz config"/>
@@ -56,6 +61,7 @@
       <!-- System -->
       <arg name="launch_system_monitor" value="$(var launch_system_monitor)"/>
       <arg name="launch_dummy_diag_publisher" value="$(var launch_dummy_diag_publisher)"/>
+      <arg name="system_error_monitor_param_path" value="$(var system_error_monitor_param_path)"/>
       <!-- Sensing -->
       <arg name="launch_sensing_driver" value="false"/>
       <!-- Perception-->


### PR DESCRIPTION
## Description
We added a system_monitor configuration file specifically for AWSIM, as there are differences between the real-world environment and the AWSIM environment

<!-- Write a brief description of this PR. -->

## Tests performed
Not yet
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

To enable Autoware to drive in the AWSIM environment without being in an emergency state.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
