### PR TITLE
fix(behavior_path_planner): change safety check default disable

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
@@ -153,7 +153,7 @@
         # For safety check
         safety_check_params:
           # safety check configuration
-          enable_safety_check: true
+          enable_safety_check: false
           # collision check parameters
           check_all_predicted_path: true
           publish_debug_marker: false

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
@@ -153,7 +153,7 @@
         # For safety check
         safety_check_params:
           # safety check configuration
-          enable_safety_check: false
+          enable_safety_check: false # Don't set to true if auto_mode is enabled
           # collision check parameters
           check_all_predicted_path: true
           publish_debug_marker: false

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -120,7 +120,7 @@
         # For safety check
         safety_check_params:
           # safety check configuration
-          enable_safety_check: false
+          enable_safety_check: false # Don't set to true if auto_mode is enabled
           # collision check parameters
           check_all_predicted_path: true
           publish_debug_marker: false

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -120,7 +120,7 @@
         # For safety check
         safety_check_params:
           # safety check configuration
-          enable_safety_check: true
+          enable_safety_check: false
           # collision check parameters
           check_all_predicted_path: true
           publish_debug_marker: false


### PR DESCRIPTION
## Description

Default disable feature of safety check against dynamic objects, because this feature is unstable at the moment.


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
