### PR TITLE
feat(behavior_path_planner): set param ignore_object_velocity_threshold

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
@@ -126,7 +126,7 @@
           # detection range
           object_check_forward_distance: 10.0
           object_check_backward_distance: 100.0
-          ignore_object_velocity_threshold: 0.0
+          ignore_object_velocity_threshold: 1.0
           # ObjectTypesToCheck
           object_types_to_check:
             check_car: true

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -93,7 +93,7 @@
           # detection range
           object_check_forward_distance: 10.0
           object_check_backward_distance: 100.0
-          ignore_object_velocity_threshold: 0.0
+          ignore_object_velocity_threshold: 1.0
           # ObjectTypesToCheck
           object_types_to_check:
             check_car: true


### PR DESCRIPTION
## Description

Set param of `ignore_object_velocity_threshold` from 0.0 to 1.0.
This temporal value is to avoida chattering and should be tuned properly depends on the use case.
Before:

https://github.com/autowarefoundation/autoware_launch/assets/32741405/712f129f-6864-4b47-9862-055b82fb0226

After:

https://github.com/autowarefoundation/autoware_launch/assets/32741405/4f046031-6d3b-40f8-ad34-e178ac478dd0
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
