### PR TITLE
feat(obstacle_cruise_planner): add parameters for a new feature

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
@@ -110,7 +110,7 @@
       # Both the lateral error and the yaw error are assumed to decrease to zero by the time duration "time_to_convergence"
       # The both errors decrease with constant rates against the time.
       consider_current_pose:
-        enable_to_consider_current_pose: true
+        enable_to_consider_current_pose: false
         time_to_convergence: 1.5 #[s]
 
     cruise:

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
@@ -108,7 +108,7 @@
 
       # consider the current ego pose (it is not the nearest pose on the reference trajectory)
       # Both the lateral error and the yaw error are assumed to decrease to zero by the time duration "time_to_convergence"
-      # Both decreasing rates against the time are constant.
+      # The both errors decrease with constant rates against the time.
       consider_current_pose:
         enable_to_consider_current_pose: true
         time_to_convergence: 1.5 #[s]

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
@@ -110,7 +110,7 @@
       # Both the lateral error and the yaw error are assumed to decrease to zero by the time duration "time_to_convergence"
       # The both errors decrease with constant rates against the time.
       consider_current_pose:
-        enable_to_consider_current_pose: false
+        enable_to_consider_current_pose: true
         time_to_convergence: 1.5 #[s]
 
     cruise:

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
@@ -106,6 +106,13 @@
         successive_num_to_entry_slow_down_condition: 5
         successive_num_to_exit_slow_down_condition: 5
 
+      # consider the current ego pose (it is not the nearest pose on the reference trajectory)
+      # Both the lateral error and the yaw error are assumed to decrease to zero by the time duration "time_to_convergence"
+      # Both decreasing rates against the time are constant.
+      consider_current_pose:
+        enable_to_consider_current_pose: true
+        time_to_convergence: 1.5 #[s]
+
     cruise:
       pid_based_planner:
         use_velocity_limit_based_planner: true

--- a/autoware_launch/launch/components/tier4_planning_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_planning_component.launch.xml
@@ -4,7 +4,7 @@
   <!-- behavior -->
   <arg name="use_experimental_lane_change_function" default="true"/>
   <!-- motion -->
-  <arg name="cruise_planner_type" default="obstacle_stop_planner" description="options: obstacle_stop_planner, obstacle_cruise_planner, none"/>
+  <arg name="cruise_planner_type" default="obstacle_cruise_planner" description="options: obstacle_stop_planner, obstacle_cruise_planner, none"/>
   <arg name="use_surround_obstacle_check" default="true"/>
   <arg name="path_smoother_type" default="elastic_band" description="options: elastic_band, none"/>
   <arg name="velocity_smoother_type" default="JerkFiltered" description="options: JerkFiltered, L2, Analytical, Linf(Unstable)"/>

--- a/autoware_launch/launch/components/tier4_planning_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_planning_component.launch.xml
@@ -4,7 +4,7 @@
   <!-- behavior -->
   <arg name="use_experimental_lane_change_function" default="true"/>
   <!-- motion -->
-  <arg name="cruise_planner_type" default="obstacle_cruise_planner" description="options: obstacle_stop_planner, obstacle_cruise_planner, none"/>
+  <arg name="cruise_planner_type" default="obstacle_stop_planner" description="options: obstacle_stop_planner, obstacle_cruise_planner, none"/>
   <arg name="use_surround_obstacle_check" default="true"/>
   <arg name="path_smoother_type" default="elastic_band" description="options: elastic_band, none"/>
   <arg name="velocity_smoother_type" default="JerkFiltered" description="options: JerkFiltered, L2, Analytical, Linf(Unstable)"/>


### PR DESCRIPTION
## Description
We add two parameters corresponding to the new feature https://github.com/autowarefoundation/autoware.universe/pull/5036
This PR should be merged BEFORE the corresponding PR in the autoware.univverse is merged.

## Tests performed
Tests are performed in Psim, and the all of new parameters work well.

## Effects on system behavior
`obstacle_cruise_planner` will not be launched with the default settings, so there is no effects when this PR is merged.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
