### PR TITLE
refactor(ndt_scan_matcher): match ndt_scan_matcher.param.yaml

### DIFF
--- a/autoware_launch/config/localization/ndt_scan_matcher.param.yaml
+++ b/autoware_launch/config/localization/ndt_scan_matcher.param.yaml
@@ -6,6 +6,9 @@
     # Vehicle reference frame
     base_frame: "base_link"
 
+    # NDT reference frame
+    ndt_base_frame: "ndt_base_link"
+
     # Subscriber queue size
     input_sensor_points_queue_size: 1
 
@@ -45,10 +48,6 @@
 
     # Tolerance of distance difference between two initial poses used for linear interpolation. [m]
     initial_pose_distance_tolerance_m: 10.0
-
-    # neighborhood search method
-    # 0=KDTREE, 1=DIRECT26, 2=DIRECT7, 3=DIRECT1
-    neighborhood_search_method: 0
 
     # Number of threads used for parallel computing
     num_threads: 4

--- a/autoware_launch/config/localization/ndt_scan_matcher.param.yaml
+++ b/autoware_launch/config/localization/ndt_scan_matcher.param.yaml
@@ -67,7 +67,7 @@
     # Regularization switch
     regularization_enabled: false
 
-    # Regularization scale factor
+    # regularization scale factor
     regularization_scale_factor: 0.01
 
     # Dynamic map loading distance
@@ -79,6 +79,7 @@
     # Radius of input LiDAR range (used for diagnostics of dynamic map loading)
     lidar_radius: 100.0
 
+    # cspell: ignore degrounded
     # A flag for using scan matching score based on de-grounded LiDAR scan
     estimate_scores_for_degrounded_scan: false
 

--- a/autoware_launch/config/localization/ndt_scan_matcher.param.yaml
+++ b/autoware_launch/config/localization/ndt_scan_matcher.param.yaml
@@ -67,7 +67,7 @@
     # Regularization switch
     regularization_enabled: false
 
-    # regularization scale factor
+    # Regularization scale factor
     regularization_scale_factor: 0.01
 
     # Dynamic map loading distance


### PR DESCRIPTION
## Description

Fixed ndt_scan_matcher.param.yaml to match to [the one in universe](https://github.com/autowarefoundation/autoware.universe/blob/main/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml), where autoware_launch misses `ndt_base_frame` and has an unneeded `neighborhood_search_method`.

## Tests performed

Successfully built, autoware_launch, and [rosbag replay simulation in the tutorial](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/) has been tested in my environment too.

## Effects on system behavior

This shouldn't affect the system behavior.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
