### PR TITLE
feat(autoware_launch): move dynamic_avoidance last

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
@@ -9,7 +9,7 @@
       enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: true
       keep_last: false
-      priority: 7
+      priority: 6
       max_module_size: 1
 
     external_request_lane_change_right:
@@ -18,7 +18,7 @@
       enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: true
       keep_last: false
-      priority: 7
+      priority: 6
       max_module_size: 1
 
     lane_change_left:
@@ -27,7 +27,7 @@
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true
       keep_last: false
-      priority: 6
+      priority: 5
       max_module_size: 1
 
     lane_change_right:
@@ -36,7 +36,7 @@
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true
       keep_last: false
-      priority: 6
+      priority: 5
       max_module_size: 1
 
     start_planner:
@@ -72,7 +72,7 @@
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: false
       keep_last: false
-      priority: 5
+      priority: 4
       max_module_size: 1
 
     avoidance_by_lc:
@@ -81,7 +81,7 @@
       enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: false
       keep_last: false
-      priority: 4
+      priority: 3
       max_module_size: 1
 
     dynamic_avoidance:
@@ -89,6 +89,6 @@
       enable_rtc: true
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true
-      keep_last: false
-      priority: 3
+      keep_last: true
+      priority: 7
       max_module_size: 1


### PR DESCRIPTION
## Description

The dynamic avoidance module should be launched at last since the algorithm will not fix the path requesting the approval as other modules do.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Nothing (dynamic avoidance is not used by default)
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
