### PR TITLE
refactor(ndt_scan_matcher): modified ndt_scan_matcher.param.yaml to match with the one in universe

### DIFF
--- a/autoware_launch/config/localization/ndt_scan_matcher.param.yaml
+++ b/autoware_launch/config/localization/ndt_scan_matcher.param.yaml
@@ -9,6 +9,9 @@
     # NDT reference frame
     ndt_base_frame: "ndt_base_link"
 
+    # map frame
+    map_frame: "map"
+
     # Subscriber queue size
     input_sensor_points_queue_size: 1
 
@@ -53,7 +56,7 @@
     num_threads: 4
 
     # The covariance of output pose
-    # Do note that this covariance matrix is empirically derived
+    # Note that this covariance matrix is empirically derived
     output_pose_covariance:
       [
         0.0225, 0.0,   0.0,   0.0,      0.0,      0.0,
@@ -86,5 +89,5 @@
     # If lidar_point.z - base_link.z <= this threshold , the point will be removed
     z_margin_for_ground_removal: 0.8
 
-    # The execution time which means probably NDT cannot matches scans properly
-    critical_upper_bound_exe_time_ms: 100 # [ms]
+    # The execution time which means probably NDT cannot matches scans properly. [ms]
+    critical_upper_bound_exe_time_ms: 100


### PR DESCRIPTION
## Description

Fixed ndt_scan_matcher.param.yaml to match with [the one in universe](https://github.com/autowarefoundation/autoware.universe/blob/main/localization/ndt_scan_matcher/config/ndt_scan_matcher.param.yaml).
Related: https://github.com/autowarefoundation/autoware.universe/pull/5155 

## Tests performed

autoware_launch successfully built, and [rosbag replay simulation in the tutorial](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/) has been tested in my environment.

## Effects on system behavior

This shouldn't affect the system behavior.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
