### PR TITLE
feat(start_planner): enable divide_pull_out_path

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -21,7 +21,7 @@
       maximum_curvature: 0.07
       # geometric pull out
       enable_geometric_pull_out: true
-      divide_pull_out_path: false
+      divide_pull_out_path: true
       geometric_pull_out_velocity: 1.0
       arc_path_interval: 1.0
       lane_departure_margin: 0.2


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

enable divide_pull_out_path 

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

2023/09/27 https://evaluation.tier4.jp/evaluation/reports/575a15e6-2dea-5564-912f-8b78ca5573c0/?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

stop at once the middle of two arc paths.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
