### PR TITLE
feat(surround_obstacle_checker): disable the surround obstacle checker

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/surround_obstacle_checker.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/surround_obstacle_checker.param.yaml
@@ -9,42 +9,42 @@
       surround_check_side_distance: 0.5
       surround_check_back_distance: 0.5
     unknown:
-      enable_check: true
+      enable_check: false
       surround_check_front_distance: 0.5
       surround_check_side_distance: 0.5
       surround_check_back_distance: 0.5
     car:
-      enable_check: true
+      enable_check: false
       surround_check_front_distance: 0.5
       surround_check_side_distance: 0.0
       surround_check_back_distance: 0.5
     truck:
-      enable_check: true
+      enable_check: false
       surround_check_front_distance: 0.5
       surround_check_side_distance: 0.0
       surround_check_back_distance: 0.5
     bus:
-      enable_check: true
+      enable_check: false
       surround_check_front_distance: 0.5
       surround_check_side_distance: 0.0
       surround_check_back_distance: 0.5
     trailer:
-      enable_check: true
+      enable_check: false
       surround_check_front_distance: 0.5
       surround_check_side_distance: 0.0
       surround_check_back_distance: 0.5
     motorcycle:
-      enable_check: true
+      enable_check: false
       surround_check_front_distance: 0.5
       surround_check_side_distance: 0.0
       surround_check_back_distance: 0.5
     bicycle:
-      enable_check: true
+      enable_check: false
       surround_check_front_distance: 0.5
       surround_check_side_distance: 0.5
       surround_check_back_distance: 0.5
     pedestrian:
-      enable_check: true
+      enable_check: false
       surround_check_front_distance: 0.5
       surround_check_side_distance: 0.5
       surround_check_back_distance: 0.5


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
During the [Planning & Control working group](https://github.com/orgs/autowarefoundation/discussions/3831) it was decided to disable the `surround_obstacle_checker` by default.
Original discussion: https://github.com/orgs/autowarefoundation/discussions/3799

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

The Autoware vehicle will no longer stop if an obstacle is close to its footprint.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
