### PR TITLE
fix(controller): align use_trajectory_for_pitch_calculation with slope compensation

### DIFF
--- a/autoware_launch/config/control/trajectory_follower/longitudinal/pid.param.yaml
+++ b/autoware_launch/config/control/trajectory_follower/longitudinal/pid.param.yaml
@@ -68,7 +68,7 @@
     min_jerk: -5.0
 
     # pitch
-    use_trajectory_for_pitch_calculation: false
+    use_trajectory_for_pitch_calculation: true
     lpf_pitch_gain: 0.95
     max_pitch_rad: 0.1
     min_pitch_rad: -0.1


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

## Related links

feature PR: https://github.com/autowarefoundation/autoware.universe/pull/5199

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none.

## Effects on system behavior

Psim will use the pitch angle of lanelet centerline as the pitch angle for ego vehicle in slope compensation.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
