### PR TITLE
feat(lane_change): change stuck velocity to 0.5

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -90,7 +90,7 @@
 
       # ego vehicle stuck detection
       stuck_detection:
-        velocity: 0.1 # [m/s]
+        velocity: 0.5 # [m/s]
         stop_time: 3.0 # [s]
 
       # lane change cancel


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

stational predicted objects sometimes have 0.3 velocity. so change the threshold for that to 0.5


![image](https://github.com/tier4/autoware_launch.x2/assets/39142679/fabacdc3-bb2a-4482-b06a-6dad9186c124)


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
