### PR TITLE
fix(rviz2): update traffic_light/debug/rois topic name

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -902,7 +902,7 @@ Visualization Manager:
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
-                Value: /perception/traffic_light_recognition/debug/rois
+                Value: /perception/traffic_light_recognition/traffic_light/debug/rois
               Value: true
             - Class: rviz_default_plugins/MarkerArray
               Enabled: true


### PR DESCRIPTION
## Description

I am testing on latest Autoware Universe main branch and the latest AWSIM.

I couldn't see the traffic light visualization on RViz2.

When I changed `/perception/traffic_light_recognition/debug/rois` to `/perception/traffic_light_recognition/traffic_light/debug/rois` it was working again.

- https://github.com/autowarefoundation/autoware_launch/pull/555
  - probably from this PR.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tested with AWSIM and now it works.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
