### PR TITLE
feat(duplicated_node_checker): disable duplicated_node_checker

### DIFF
--- a/autoware_launch/config/system/system_error_monitor/system_error_monitor.param.yaml
+++ b/autoware_launch/config/system/system_error_monitor/system_error_monitor.param.yaml
@@ -38,7 +38,7 @@
         /autoware/system/emergency_stop_operation: default
         /autoware/system/service_log_checker: { sf_at: "warn", lf_at: "none", spf_at: "none" }
         /autoware/system/resource_monitoring: { sf_at: "warn", lf_at: "error", spf_at: "none" }
-        /autoware/system/duplicated_node_checker: default
+        # /autoware/system/duplicated_node_checker: default
 
         /autoware/vehicle/node_alive_monitoring: default
 

--- a/autoware_launch/config/system/system_error_monitor/system_error_monitor.param.yaml
+++ b/autoware_launch/config/system/system_error_monitor/system_error_monitor.param.yaml
@@ -38,7 +38,7 @@
         /autoware/system/emergency_stop_operation: default
         /autoware/system/service_log_checker: { sf_at: "warn", lf_at: "none", spf_at: "none" }
         /autoware/system/resource_monitoring: { sf_at: "warn", lf_at: "error", spf_at: "none" }
-        # /autoware/system/duplicated_node_checker: default
+        /autoware/system/duplicated_node_checker: default
 
         /autoware/vehicle/node_alive_monitoring: default
 

--- a/autoware_launch/config/system/system_error_monitor/system_error_monitor.planning_simulation.param.yaml
+++ b/autoware_launch/config/system/system_error_monitor/system_error_monitor.planning_simulation.param.yaml
@@ -39,7 +39,7 @@
         /autoware/system/emergency_stop_operation: default
         /autoware/system/service_log_checker: { sf_at: "warn", lf_at: "none", spf_at: "none" }
         # /autoware/system/resource_monitoring: { sf_at: "warn", lf_at: "error", spf_at: "none" }
-        /autoware/system/duplicated_node_checker: default
+        # /autoware/system/duplicated_node_checker: default
 
         /autoware/vehicle/node_alive_monitoring: default
 


### PR DESCRIPTION
## Description

disable `duplicated_node_checker` for now.
The reason for this is that simulation fails by enabling this feature.
It should be fixed by preventing double launch, but for now, disable it.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
