### PR TITLE
chore(rviz): hide interseciton area polygon as default

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -401,6 +401,7 @@ Visualization Manager:
             walkway_lanelets: true
             hatched_road_markings_bound: true
             hatched_road_markings_area: false
+            intersection_area: false
           Topic:
             Depth: 5
             Durability Policy: Transient Local


### PR DESCRIPTION
## Description

Hide intersection area.

![Screenshot from 2023-10-25 09-07-16](https://github.com/autowarefoundation/autoware_launch/assets/44889564/b8b0cc7c-c99d-424e-bcab-d77eeef88a9e)

related PRs:

- https://github.com/autowarefoundation/autoware.universe/pull/5401
- https://github.com/autowarefoundation/autoware_common/pull/211

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
