### PR TITLE
feat: add use_conservative_buffer_longitudinal in avoidance

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
@@ -37,6 +37,7 @@
           avoid_margin_lateral: 1.0                    # [m]
           safety_buffer_lateral: 0.7                   # [m]
           safety_buffer_longitudinal: 0.0              # [m]
+          use_conservative_buffer_longitudinal: true   # [-] When set to true, the base_link2front is added to the longitudinal buffer before avoidance.
         truck:
           is_target: true
           execute_num: 1
@@ -47,6 +48,7 @@
           avoid_margin_lateral: 1.0
           safety_buffer_lateral: 0.7
           safety_buffer_longitudinal: 0.0
+          use_conservative_buffer_longitudinal: true
         bus:
           is_target: true
           execute_num: 1
@@ -57,6 +59,7 @@
           avoid_margin_lateral: 1.0
           safety_buffer_lateral: 0.7
           safety_buffer_longitudinal: 0.0
+          use_conservative_buffer_longitudinal: true
         trailer:
           is_target: true
           execute_num: 1
@@ -67,6 +70,7 @@
           avoid_margin_lateral: 1.0
           safety_buffer_lateral: 0.7
           safety_buffer_longitudinal: 0.0
+          use_conservative_buffer_longitudinal: true
         unknown:
           is_target: true
           execute_num: 1
@@ -77,6 +81,7 @@
           avoid_margin_lateral: 1.0
           safety_buffer_lateral: 0.7
           safety_buffer_longitudinal: 0.0
+          use_conservative_buffer_longitudinal: true
         bicycle:
           is_target: true
           execute_num: 1
@@ -87,6 +92,7 @@
           avoid_margin_lateral: 1.0
           safety_buffer_lateral: 1.0
           safety_buffer_longitudinal: 1.0
+          use_conservative_buffer_longitudinal: true
         motorcycle:
           is_target: true
           execute_num: 1
@@ -97,6 +103,7 @@
           avoid_margin_lateral: 1.0
           safety_buffer_lateral: 1.0
           safety_buffer_longitudinal: 1.0
+          use_conservative_buffer_longitudinal: true
         pedestrian:
           is_target: true
           execute_num: 1
@@ -107,6 +114,7 @@
           avoid_margin_lateral: 1.0
           safety_buffer_lateral: 1.0
           safety_buffer_longitudinal: 1.0
+          use_conservative_buffer_longitudinal: true
         lower_distance_for_polygon_expansion: 30.0      # [m]
         upper_distance_for_polygon_expansion: 100.0     # [m]
 


### PR DESCRIPTION
## Description

launcher PR for https://github.com/autowarefoundation/autoware.universe/pull/5405
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

See https://github.com/autowarefoundation/autoware.universe/pull/5405

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

See https://github.com/autowarefoundation/autoware.universe/pull/5405
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
