### PR TITLE
feat(intersection): fill all path point velocity to 0 when approached stopline

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
@@ -58,6 +58,9 @@
           object_expected_deceleration: 2.0 # [m/ss]
         ignore_on_red_traffic_light:
           object_margin_to_path: 2.0
+        force_stop: # insert zero velocity to entire path points when approached stop line
+          enable: false
+          distance_margin_to_stop_line: 0.5 # [m]
 
       occlusion:
         enable: false

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
@@ -58,7 +58,7 @@
           object_expected_deceleration: 2.0 # [m/ss]
         ignore_on_red_traffic_light:
           object_margin_to_path: 2.0
-        force_stop_distance_margin_to_stop_line: -0.5 # [m] insert zero velocity to entire path points
+        force_stop_distance_margin_to_stop_line: 0.5 # [m] insert zero velocity to entire path points
 
       occlusion:
         enable: false

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/intersection.param.yaml
@@ -58,9 +58,7 @@
           object_expected_deceleration: 2.0 # [m/ss]
         ignore_on_red_traffic_light:
           object_margin_to_path: 2.0
-        force_stop: # insert zero velocity to entire path points when approached stop line
-          enable: false
-          distance_margin_to_stop_line: 0.5 # [m]
+        force_stop_distance_margin_to_stop_line: -0.5 # [m] insert zero velocity to entire path points
 
       occlusion:
         enable: false


### PR DESCRIPTION
## Description

When ego approached collision stop line, insert zero velocity to all path points.

feature PR: https://github.com/autowarefoundation/autoware.universe/pull/5428
## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

see https://github.com/autowarefoundation/autoware.universe/pull/5428

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none.

## Effects on system behavior

none.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
