### PR TITLE
feat(radar_object_clustering): move radar object clustering params to autoware_launch

### DIFF
--- a/autoware_launch/config/perception/object_recognition/detection/clustering/radar_object_clustering.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/clustering/radar_object_clustering.param.yaml
@@ -1,0 +1,15 @@
+/**:
+  ros__parameters:
+    # clustering parameter
+    angle_threshold: 0.174 # [rad] (10 deg)
+    distance_threshold: 10.0 # [m]
+    velocity_threshold: 4.0 # [m/s]
+
+    # output object settings
+    # set false if you want to use the object information from radar
+    is_fixed_label: true
+    fixed_label: "CAR"
+    is_fixed_size: true
+    size_x: 4.0 # [m]
+    size_y: 1.5 # [m]
+    size_z: 1.5 # [m]

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -71,7 +71,7 @@
     <arg
       name="object_recognition_detection_radar_object_clustering_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/clustering/radar_object_clustering.param.yaml"
-    />  
+    />
     <arg name="object_recognition_detection_lidar_model_param_path" value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/lidar_model"/>
     <arg
       name="object_recognition_tracking_multi_object_tracker_data_association_matrix_param_path"

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -68,6 +68,10 @@
       name="object_recognition_detection_radar_lanelet_filtering_range_param"
       value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/object_filter/radar_lanelet_filter.param.yaml"
     />
+    <arg
+      name="object_recognition_detection_radar_object_clustering_param_path"
+      value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/clustering/radar_object_clustering.param.yaml"
+    />  
     <arg name="object_recognition_detection_lidar_model_param_path" value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/lidar_model"/>
     <arg
       name="object_recognition_tracking_multi_object_tracker_data_association_matrix_param_path"


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Move `radar_object_clustering` parameter to autoware_launch so that each pilot.auto project can change these parameters.

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

Show universe pr here later.

## Tests performed

Tested with lsim and checked with ros2 param.
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
