### PR TITLE
refactor(launch): add new option to select planning preset

### DIFF
--- a/autoware_launch/config/planning/preset/default_preset.yaml
+++ b/autoware_launch/config/planning/preset/default_preset.yaml
@@ -1,59 +1,87 @@
 launch:
-  # - arg:
-  #     name: behavior_path_planner_launch_modules
-  #     default: "[behavior_path_planner::Avoidance,
-  #       behavior_path_planner::AvoidanceByLaneChange,
-  #       behavior_path_planner::DynamicAvoidance,
-  #       behavior_path_planner::LaneChange,
-  #       behavior_path_planner::ExternalLaneChange,
-  #       behavior_path_planner::StartPlanner,
-  #       behavior_path_planner::GoalPlanner,
-  #       behavior_path_planner::SideShift]"
-  #     # option: behavior_path_planner::Avoidance
-  #     #         behavior_path_planner::AvoidanceByLaneChange
-  #     #         behavior_path_planner::DynamicAvoidance
-  #     #         behavior_path_planner::LaneChange
-  #     #         behavior_path_planner::ExternalLaneChange
-  #     #         behavior_path_planner::StartPlanner
-  #     #         behavior_path_planner::GoalPlanner
-  #     #         behavior_path_planner::SideShift"
-
+  # behavior path modules
   - arg:
-      name: behavior_velocity_planner_launch_modules
-      default: "[behavior_velocity_planner::CrosswalkModulePlugin,
-        behavior_velocity_planner::WalkwayModulePlugin,
-        behavior_velocity_planner::TrafficLightModulePlugin,
-        behavior_velocity_planner::IntersectionModulePlugin,
-        behavior_velocity_planner::MergeFromPrivateModulePlugin,
-        behavior_velocity_planner::BlindSpotModulePlugin,
-        behavior_velocity_planner::DetectionAreaModulePlugin,
-        behavior_velocity_planner::NoStoppingAreaModulePlugin,
-        behavior_velocity_planner::StopLineModulePlugin,
-        behavior_velocity_planner::OutOfLaneModulePlugin]"
-      # option: behavior_velocity_planner::CrosswalkModulePlugin
-      #         behavior_velocity_planner::WalkwayModulePlugin
-      #         behavior_velocity_planner::TrafficLightModulePlugin
-      #         behavior_velocity_planner::IntersectionModulePlugin
-      #         behavior_velocity_planner::MergeFromPrivateModulePlugin
-      #         behavior_velocity_planner::BlindSpotModulePlugin
-      #         behavior_velocity_planner::DetectionAreaModulePlugin
-      #         behavior_velocity_planner::VirtualTrafficLightModulePlugin
-      #         behavior_velocity_planner::NoStoppingAreaModulePlugin
-      #         behavior_velocity_planner::StopLineModulePlugin
-      #         behavior_velocity_planner::OcclusionSpotModulePlugin
-      #         behavior_velocity_planner::RunOutModulePlugin
-      #         behavior_velocity_planner::SpeedBumpModulePlugin
-      #         behavior_velocity_planner::OutOfLaneModulePlugin
-      #         behavior_velocity_planner::NoDrivableLaneModulePlugin"
-
+      name: launch_avoidance_module
+      default: "true"
+  - arg:
+      name: launch_avoidance_by_lane_change_module
+      default: "true"
+  - arg:
+      name: launch_dynamic_avoidance_module
+      default: "false"
+  - arg:
+      name: launch_lane_change_right_module
+      default: "true"
+  - arg:
+      name: launch_lane_change_left_module
+      default: "true"
+  - arg:
+      name: launch_external_request_lane_change_right_module
+      default: "false"
+  - arg:
+      name: launch_external_request_lane_change_left_module
+      default: "false"
+  - arg:
+      name: launch_goal_planner_module
+      default: "true"
+  - arg:
+      name: launch_start_planner_module
+      default: "true"
+  - arg:
+      name: launch_side_shift_module
+      default: "true"
   - arg:
       name: use_experimental_lane_change_function
       default: "true"
 
+  # behavior velocity modules
   - arg:
-      name: launch_surround_obstacle_checker
+      name: launch_crosswalk_module
       default: "true"
+  - arg:
+      name: launch_walkway_module
+      default: "true"
+  - arg:
+      name: launch_traffic_light_module
+      default: "true"
+  - arg:
+      name: launch_intersection_module
+      default: "true"
+  - arg:
+      name: launch_merge_from_private_module
+      default: "true"
+  - arg:
+      name: launch_blind_spot_module
+      default: "true"
+  - arg:
+      name: launch_detection_area_module
+      default: "true"
+  - arg:
+      name: launch_virtual_traffic_light_module
+      default: "false"
+  - arg:
+      name: launch_no_stopping_area_module
+      default: "true"
+  - arg:
+      name: launch_stop_line_module
+      default: "true"
+  - arg:
+      name: launch_occlusion_spot_module
+      default: "false"
+  - arg:
+      name: launch_run_out_module
+      default: "false"
+  - arg:
+      name: launch_speed_bump_module
+      default: "false"
+  - arg:
+      name: launch_out_of_lane_module
+      default: "true"
+  - arg:
+      name: launch_no_drivable_lane_module
+      default: "false"
 
+  # motion planning modules
   - arg:
       name: motion_path_smoother_type
       default: elastic_band
@@ -82,6 +110,11 @@ launch:
       #         Linf(Unstable)
       #         Analytical
 
+  - arg:
+      name: launch_surround_obstacle_checker
+      default: "true"
+
+  # parking modules
   - arg:
       name: launch_parking_module
       default: "true"

--- a/autoware_launch/config/planning/preset/default_preset.yaml
+++ b/autoware_launch/config/planning/preset/default_preset.yaml
@@ -1,0 +1,87 @@
+launch:
+  # - arg:
+  #     name: behavior_path_planner_launch_modules
+  #     default: "[behavior_path_planner::Avoidance,
+  #       behavior_path_planner::AvoidanceByLaneChange,
+  #       behavior_path_planner::DynamicAvoidance,
+  #       behavior_path_planner::LaneChange,
+  #       behavior_path_planner::ExternalLaneChange,
+  #       behavior_path_planner::StartPlanner,
+  #       behavior_path_planner::GoalPlanner,
+  #       behavior_path_planner::SideShift]"
+  #     # option: behavior_path_planner::Avoidance
+  #     #         behavior_path_planner::AvoidanceByLaneChange
+  #     #         behavior_path_planner::DynamicAvoidance
+  #     #         behavior_path_planner::LaneChange
+  #     #         behavior_path_planner::ExternalLaneChange
+  #     #         behavior_path_planner::StartPlanner
+  #     #         behavior_path_planner::GoalPlanner
+  #     #         behavior_path_planner::SideShift"
+
+  - arg:
+      name: behavior_velocity_planner_launch_modules
+      default: "[behavior_velocity_planner::CrosswalkModulePlugin,
+        behavior_velocity_planner::WalkwayModulePlugin,
+        behavior_velocity_planner::TrafficLightModulePlugin,
+        behavior_velocity_planner::IntersectionModulePlugin,
+        behavior_velocity_planner::MergeFromPrivateModulePlugin,
+        behavior_velocity_planner::BlindSpotModulePlugin,
+        behavior_velocity_planner::DetectionAreaModulePlugin,
+        behavior_velocity_planner::NoStoppingAreaModulePlugin,
+        behavior_velocity_planner::StopLineModulePlugin,
+        behavior_velocity_planner::OutOfLaneModulePlugin]"
+      # option: behavior_velocity_planner::CrosswalkModulePlugin
+      #         behavior_velocity_planner::WalkwayModulePlugin
+      #         behavior_velocity_planner::TrafficLightModulePlugin
+      #         behavior_velocity_planner::IntersectionModulePlugin
+      #         behavior_velocity_planner::MergeFromPrivateModulePlugin
+      #         behavior_velocity_planner::BlindSpotModulePlugin
+      #         behavior_velocity_planner::DetectionAreaModulePlugin
+      #         behavior_velocity_planner::VirtualTrafficLightModulePlugin
+      #         behavior_velocity_planner::NoStoppingAreaModulePlugin
+      #         behavior_velocity_planner::StopLineModulePlugin
+      #         behavior_velocity_planner::OcclusionSpotModulePlugin
+      #         behavior_velocity_planner::RunOutModulePlugin
+      #         behavior_velocity_planner::SpeedBumpModulePlugin
+      #         behavior_velocity_planner::OutOfLaneModulePlugin
+      #         behavior_velocity_planner::NoDrivableLaneModulePlugin"
+
+  - arg:
+      name: use_experimental_lane_change_function
+      default: "true"
+
+  - arg:
+      name: launch_surround_obstacle_checker
+      default: "true"
+
+  - arg:
+      name: motion_path_smoother_type
+      default: elastic_band
+      # option: elastic_band
+      #         none
+
+  - arg:
+      name: motion_path_planner_type
+      default: obstacle_avoidance_planner
+      # option: obstacle_avoidance_planner
+      #         path_sampler
+      #         none
+
+  - arg:
+      name: motion_stop_planner_type
+      default: obstacle_stop_planner
+      # option: obstacle_stop_planner
+      #         obstacle_cruise_planner
+      #         none
+
+  - arg:
+      name: motion_velocity_smoother_type
+      default: JerkFiltered
+      # option: JerkFiltered
+      #         L2
+      #         Linf(Unstable)
+      #         Analytical
+
+  - arg:
+      name: launch_parking_module
+      default: "true"

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -5,9 +5,6 @@
 
     traffic_light_signal_timeout: 1.0
 
-    groot_zmq_publisher_port: 1666
-    groot_zmq_server_port: 1667
-
     planning_hz: 10.0
     backward_path_length: 5.0
     forward_path_length: 300.0

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
@@ -4,7 +4,6 @@
 /**:
   ros__parameters:
     external_request_lane_change_left:
-      enable_module: false
       enable_rtc: false
       enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: true
@@ -13,7 +12,6 @@
       max_module_size: 1
 
     external_request_lane_change_right:
-      enable_module: false
       enable_rtc: false
       enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: true
@@ -22,7 +20,6 @@
       max_module_size: 1
 
     lane_change_left:
-      enable_module: true
       enable_rtc: false
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true
@@ -31,7 +28,6 @@
       max_module_size: 1
 
     lane_change_right:
-      enable_module: true
       enable_rtc: false
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true
@@ -40,7 +36,6 @@
       max_module_size: 1
 
     start_planner:
-      enable_module: true
       enable_rtc: false
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: false
@@ -49,7 +44,6 @@
       max_module_size: 1
 
     side_shift:
-      enable_module: true
       enable_rtc: false
       enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: false
@@ -58,7 +52,6 @@
       max_module_size: 1
 
     goal_planner:
-      enable_module: true
       enable_rtc: false
       enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: false
@@ -67,7 +60,6 @@
       max_module_size: 1
 
     avoidance:
-      enable_module: true
       enable_rtc: false
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: false
@@ -76,7 +68,6 @@
       max_module_size: 1
 
     avoidance_by_lc:
-      enable_module: true
       enable_rtc: false
       enable_simultaneous_execution_as_approved_module: false
       enable_simultaneous_execution_as_candidate_module: false
@@ -85,7 +76,6 @@
       max_module_size: 1
 
     dynamic_avoidance:
-      enable_module: false
       enable_rtc: false
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
@@ -8,19 +8,3 @@
     system_delay: 0.5
     delay_response_time: 0.5
     is_publish_debug_path: false # publish all debug path with lane id in each module
-    launch_modules:
-      - behavior_velocity_planner::CrosswalkModulePlugin
-      - behavior_velocity_planner::WalkwayModulePlugin
-      - behavior_velocity_planner::TrafficLightModulePlugin
-      - behavior_velocity_planner::IntersectionModulePlugin      # Intersection module should be before merge from private to declare intersection parameters.
-      - behavior_velocity_planner::MergeFromPrivateModulePlugin
-      - behavior_velocity_planner::BlindSpotModulePlugin
-      - behavior_velocity_planner::DetectionAreaModulePlugin
-      # behavior_velocity_planner::VirtualTrafficLightModulePlugin
-      - behavior_velocity_planner::NoStoppingAreaModulePlugin     # No stopping area module requires all the stop line. Therefore this modules should be placed at the bottom.
-      - behavior_velocity_planner::StopLineModulePlugin           # Permanent stop line module should be after no stopping area
-      # behavior_velocity_planner::OcclusionSpotModulePlugin
-      # behavior_velocity_planner::RunOutModulePlugin
-      # behavior_velocity_planner::SpeedBumpModulePlugin
-      - behavior_velocity_planner::OutOfLaneModulePlugin
-      # behavior_velocity_planner::NoDrivableLaneModulePlugin

--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -8,6 +8,9 @@
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
   <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
 
+  <!-- launch module preset -->
+  <arg name="planning_module_preset" default="default" description="planning module preset"/>
+
   <!-- Optional parameters -->
   <!-- Modules to be launched -->
   <arg name="launch_vehicle" default="true" description="launch vehicle"/>
@@ -98,7 +101,9 @@
 
   <!-- Planning -->
   <group if="$(var launch_planning)">
-    <include file="$(find-pkg-share autoware_launch)/launch/components/tier4_planning_component.launch.xml"/>
+    <include file="$(find-pkg-share autoware_launch)/launch/components/tier4_planning_component.launch.xml">
+      <arg name="module_preset" value="$(var planning_module_preset)"/>
+    </include>
   </group>
 
   <!-- Control -->

--- a/autoware_launch/launch/components/tier4_planning_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_planning_component.launch.xml
@@ -1,24 +1,8 @@
 <?xml version="1.0"?>
 <launch>
   <!-- NOTE: optional parameters are written here -->
-  <!-- behavior -->
-  <arg name="use_experimental_lane_change_function" default="true"/>
-  <!-- motion -->
-  <arg name="motion_path_smoother_type" default="elastic_band" description="options: elastic_band, none"/>
-  <arg name="motion_path_planner_type" default="obstacle_avoidance_planner" description="options: obstacle_avoidance_planner, path_sampler, none"/>
-  <arg name="motion_stop_planner_type" default="obstacle_stop_planner" description="options: obstacle_stop_planner, obstacle_cruise_planner, none"/>
-  <arg name="motion_velocity_smoother_type" default="JerkFiltered" description="options: JerkFiltered, L2, Analytical, Linf(Unstable)"/>
-  <arg name="enable_surround_check" default="true"/>
-
-  <!-- variables -->
-  <arg name="behavior_config_path" default="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning"/>
-  <arg name="behavior_path_config_path" default="$(var behavior_config_path)/behavior_path_planner"/>
-  <arg name="behavior_velocity_config_path" default="$(var behavior_config_path)/behavior_velocity_planner"/>
-  <arg name="motion_config_path" default="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/motion_planning"/>
-  <arg name="common_config_path" default="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/common"/>
-
-  <!-- parking module -->
-  <arg name="launch_parking_module" default="true"/>
+  <arg name="module_preset" default="default"/>
+  <include file="$(find-pkg-share autoware_launch)/config/planning/preset/$(var module_preset)_preset.yaml"/>
 
   <include file="$(find-pkg-share tier4_planning_launch)/launch/planning.launch.xml">
     <arg name="vehicle_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
@@ -26,6 +10,7 @@
     <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
 
     <!-- common -->
+    <arg name="common_config_path" value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/common"/>
     <arg name="common_param_path" value="$(var common_config_path)/common.param.yaml"/>
     <arg name="nearest_search_param_path" value="$(var common_config_path)/nearest_search.param.yaml"/>
     <arg name="costmap_generator_param_path" value="$(var common_config_path)/costmap_generator.param.yaml"/>
@@ -34,6 +19,7 @@
     <arg name="mission_planner_param_path" value="$(find-pkg-share autoware_launch)/config/planning/mission_planning/mission_planner/mission_planner.param.yaml"/>
 
     <!-- behavior path planner -->
+    <arg name="behavior_path_config_path" value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner"/>
     <arg name="behavior_path_planner_common_param_path" value="$(var behavior_path_config_path)/behavior_path_planner.param.yaml"/>
     <arg name="behavior_path_planner_scene_module_manager_param_path" value="$(var behavior_path_config_path)/scene_module_manager.param.yaml"/>
     <arg name="behavior_path_planner_side_shift_module_param_path" value="$(var behavior_path_config_path)/side_shift/side_shift.param.yaml"/>
@@ -46,6 +32,7 @@
     <arg name="behavior_path_planner_drivable_area_expansion_param_path" value="$(var behavior_path_config_path)/drivable_area_expansion.param.yaml"/>
 
     <!-- behavior velocity planner -->
+    <arg name="behavior_velocity_config_path" value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner"/>
     <arg name="behavior_velocity_smoother_type_param_path" value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/common/motion_velocity_smoother/Analytical.param.yaml"/>
     <arg name="behavior_velocity_planner_common_param_path" value="$(var behavior_velocity_config_path)/behavior_velocity_planner.param.yaml"/>
     <arg name="behavior_velocity_planner_blind_spot_module_param_path" value="$(var behavior_velocity_config_path)/blind_spot.param.yaml"/>
@@ -68,6 +55,7 @@
     <arg name="freespace_planner_param_path" value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/parking/freespace_planner/freespace_planner.param.yaml"/>
 
     <!-- motion -->
+    <arg name="motion_config_path" value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/lane_driving/motion_planning"/>
     <arg name="elastic_band_smoother_param_path" value="$(var motion_config_path)/path_smoother/elastic_band_smoother.param.yaml"/>
     <arg name="obstacle_avoidance_planner_param_path" value="$(var motion_config_path)/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml"/>
     <arg name="path_sampler_param_path" value="$(var motion_config_path)/path_sampler/path_sampler.param.yaml"/>

--- a/autoware_launch/launch/e2e_simulator.launch.xml
+++ b/autoware_launch/launch/e2e_simulator.launch.xml
@@ -6,6 +6,9 @@
   <arg name="sensor_model" description="sensor model name"/>
   <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
 
+  <!-- launch module preset -->
+  <arg name="planning_module_preset" default="default" description="planning module preset"/>
+
   <!-- Optional parameters -->
   <!-- Modules to be launched -->
   <arg name="vehicle" default="true" description="launch vehicle"/>
@@ -43,6 +46,8 @@
       <arg name="vehicle_model" value="$(var vehicle_model)"/>
       <arg name="sensor_model" value="$(var sensor_model)"/>
       <arg name="data_path" value="$(var data_path)"/>
+      <!-- launch module preset -->
+      <arg name="planning_module_preset" value="$(var planning_module_preset)"/>
       <!-- Modules to be launched -->
       <arg name="launch_vehicle" value="$(var vehicle)"/>
       <arg name="launch_map" value="$(var map)"/>

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -7,6 +7,9 @@
   <arg name="vehicle_id" default="$(env VEHICLE_ID default)" description="vehicle specific ID"/>
   <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
 
+  <!-- launch module preset -->
+  <arg name="planning_module_preset" default="default" description="planning module preset"/>
+
   <!-- Optional parameters -->
   <!-- Modules to be launched -->
   <arg name="vehicle" default="true" description="launch vehicle"/>
@@ -39,6 +42,8 @@
       <arg name="map_path" value="$(var map_path)"/>
       <arg name="vehicle_model" value="$(var vehicle_model)"/>
       <arg name="sensor_model" value="$(var sensor_model)"/>
+      <!-- launch module preset -->
+      <arg name="planning_module_preset" value="$(var planning_module_preset)"/>
       <!-- Modules to be launched -->
       <arg name="launch_vehicle" value="$(var vehicle)"/>
       <arg name="launch_map" value="$(var map)"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -6,6 +6,9 @@
   <arg name="sensor_model" description="sensor model name"/>
   <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
 
+  <!-- launch module preset -->
+  <arg name="planning_module_preset" default="default" description="planning module preset"/>
+
   <!-- Optional parameters -->
   <!-- Map -->
   <arg name="lanelet2_map_file" default="lanelet2_map.osm" description="lanelet2 map file name"/>
@@ -39,6 +42,8 @@
       <arg name="vehicle_model" value="$(var vehicle_model)"/>
       <arg name="sensor_model" value="$(var sensor_model)"/>
       <arg name="data_path" value="$(var data_path)"/>
+      <!-- launch module preset -->
+      <arg name="planning_module_preset" value="$(var planning_module_preset)"/>
       <!-- Modules to be launched -->
       <arg name="launch_sensing" value="false"/>
       <arg name="launch_localization" value="false"/>


### PR DESCRIPTION
## Description

Add new option `planning_module_preset` so that it is able to switch launch modules more easily and flexibly.

```
ros2 launch autoware_launch planning_simulator.launch.xml map_path:=foo vehicle_model:=bar sensor_model:=baz planning_module_preset:=default
```

```xml
  <!-- launch module preset -->
  <arg name="planning_module_preset" default="default" description="planning module preset"/>
```

We can select launch modules in preset yaml file as follow. In addition, since we can manage launch modules by only one file, we don't have to create new branch in order to change launch modules.

```yaml
...
  - arg:
      name: use_experimental_lane_change_function
      default: "true"

  - arg:
      name: launch_surround_obstacle_checker
      default: "true"

  - arg:
      name: motion_path_smoother_type
      default: elastic_band
      # option: elastic_band
      #         none

  - arg:
      name: motion_path_planner_type
      default: obstacle_avoidance_planner
      # option: obstacle_avoidance_planner
      #         path_sampler
      #         none

  - arg:
      name: motion_stop_planner_type
      default: obstacle_stop_planner
      # option: obstacle_stop_planner
      #         obstacle_cruise_planner
      #         none
...
```

### How to add preset?

1. create preset file `<identification_name>_preset.yaml`.
2. put it under `/autoware_launch/config/planning/preset/<identification_name>_preset.yaml`.
3. launch autoware with option `planning_module_preset:=<identification_name>`.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/8485e8c4-b875-50c0-a61e-6a29fc351c89?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
