### PR TITLE
feat(surround_obstacle_checker): disable the surround obstacle checker

### DIFF
--- a/autoware_launch/launch/components/tier4_planning_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_planning_component.launch.xml
@@ -8,6 +8,7 @@
     <arg name="vehicle_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
     <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
     <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
+    <arg name="launch_surround_obstacle_checker" value="false"/>
 
     <!-- common -->
     <arg name="common_config_path" value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/common"/>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
During the [Planning & Control working group](https://github.com/orgs/autowarefoundation/discussions/3831) it was decided to disable the surround_obstacle_checker by default.
Original discussion: https://github.com/orgs/autowarefoundation/discussions/3799

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

The Autoware vehicle will no longer stop if an obstacle is close to its footprint.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
