### PR TITLE
feat: lane_departure_checker with curbstones

### DIFF
--- a/autoware_launch/config/control/lane_departure_checker/lane_departure_checker.param.yaml
+++ b/autoware_launch/config/control/lane_departure_checker/lane_departure_checker.param.yaml
@@ -1,9 +1,9 @@
 /**:
   ros__parameters:
     # Enable feature
-    will_out_of_lane_checker: true
-    out_of_lane_checker: true
-    boundary_departure_checker: false
+    will_out_of_lane_checker: false
+    out_of_lane_checker: false
+    boundary_departure_checker: true
 
     # Node
     update_rate: 10.0
@@ -12,7 +12,7 @@
     include_left_lanes: false
     include_opposite_lanes: false
     include_conflicting_lanes: false
-    boundary_types_to_detect: [road_border]
+    boundary_types_to_detect: [curbstone]
 
     # Core
     footprint_margin_scale: 1.0


### PR DESCRIPTION
## Description

The current lane_departure_checker unnecessarily publishes the diag even when it is not dangerous.

A better logic for the real use-case was implemented here checking if the ego's predicted trajectory will collide with the curbstones.
https://github.com/autowarefoundation/autoware.universe/pull/4607
This PR enables this logic and disables the previous logic.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

What lane_departure_checker detects will be whether the ego's predicted trajectory will collide with the curbstones.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
