### PR TITLE
feat: enable MRM comfortable stop

### DIFF
--- a/autoware_launch/config/system/emergency_handler/emergency_handler.param.yaml
+++ b/autoware_launch/config/system/emergency_handler/emergency_handler.param.yaml
@@ -7,7 +7,7 @@
     timeout_takeover_request: 10.0
     use_takeover_request: false
     use_parking_after_stopped: false
-    use_comfortable_stop: false
+    use_comfortable_stop: true
 
     # setting whether to turn hazard lamp on for each situation
     turning_hazard_on:


### PR DESCRIPTION
## Description

Enabled MRM comfortable stop.
Which diag to perform MRM comfortable stop is written in the following files.
- simulation: https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_launch/config/system/system_error_monitor/system_error_monitor.planning_simulation.param.yaml
- real vehicle: https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_launch/config/system/system_error_monitor/system_error_monitor.param.yaml

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

scenario test:https://evaluation.tier4.jp/evaluation/reports?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

MRM comfortable stop is enabled

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
