### PR TITLE
feat(start_planner): enable safety check for start planner

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -125,7 +125,7 @@
         # For safety check
         safety_check_params:
           # safety check configuration
-          enable_safety_check: false # Don't set to true if auto_mode is enabled
+          enable_safety_check: true
           # collision check parameters
           check_all_predicted_path: true
           publish_debug_marker: false


### PR DESCRIPTION
## Description

enable safety check feature for start_planner with this PR

<!-- Write a brief description of this PR. -->

## Tests performed

- [x] [PASS TIERIV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/bcd5c5ea-e44a-5ed4-9b0b-9aefdd36ada1?project_id=prd_jt)
- [x] test with psim 
  - [x] check engage is impossible when path is not safe in following scenes
    - [x] geometric pull out
    ![image](https://github.com/autowarefoundation/autoware_launch/assets/32741405/87373e95-f7bc-4073-b087-bdf630c8b6f9)
    - [x] shift pull out
    ![image](https://github.com/autowarefoundation/autoware_launch/assets/32741405/f3ccbd2e-b3dd-4777-9994-dcab7d602e89)
    - [x] backward driving → pull out
    ![image](https://github.com/autowarefoundation/autoware_launch/assets/32741405/e1d9485a-e3d2-4734-bd43-8f0425bcfcfa)
    ![image](https://github.com/autowarefoundation/autoware_launch/assets/32741405/565637ec-33dc-46b4-ba97-9eaf85354326)

  - [x] check stop point can be inserted in following scenes
    - [x] geometric pull out
    [Screencast from 2023年11月24日 16時30分50秒.webm](https://github.com/autowarefoundation/autoware_launch/assets/32741405/6927da56-4a70-44d7-9125-f88d1be2a391)
    - [x] shift pull out
    [Screencast from 2023年11月24日 16時19分04秒.webm](https://github.com/autowarefoundation/autoware_launch/assets/32741405/1d4e7f40-7a2b-4f74-afd4-7ac05efb7be1)
    - [x] backward driving → pull out
    [Screencast from 2023年11月24日 16時17分20秒.webm](https://github.com/autowarefoundation/autoware_launch/assets/32741405/68c8b2a0-6638-40f5-994a-f9fc9ca0508b)


<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
