### PR TITLE
feat(run_out): add parameter to decide whether to use the object's velocity

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/run_out.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/run_out.param.yaml
@@ -21,14 +21,17 @@
 
       # parameter to create abstracted dynamic obstacles
       dynamic_obstacle:
-        use_mandatory_area: false  # [-] whether to use mandatory detection area
-        min_vel_kmph: 0.0          # [km/h] minimum velocity for dynamic obstacles
-        max_vel_kmph: 5.0          # [km/h] maximum velocity for dynamic obstacles
-        diameter: 0.1              # [m] diameter of obstacles. used for creating dynamic obstacles from points
-        height: 2.0                # [m] height of obstacles. used for creating dynamic obstacles from points
-        max_prediction_time: 10.0  # [sec] create predicted path until this time
-        time_step: 0.5             # [sec] time step for each path step. used for creating dynamic obstacles from points or objects without path
-        points_interval: 0.1       # [m] divide obstacle points into groups with this interval, and detect only lateral nearest point. used only for Points method
+        use_mandatory_area: false # [-] whether to use mandatory detection area
+        assume_fixed_velocity:
+          enable: false           # [-] If enabled, the obstacle's velocity is assumed to be within the minimum and maximum velocity values specified below
+          min_vel_kmph: 0.0       # [km/h] minimum velocity for dynamic obstacles
+          max_vel_kmph: 5.0       # [km/h] maximum velocity for dynamic obstacles
+        std_dev_multiplier: 1.96  # [-] min and max velocity of the obstacles are calculated from this value and covariance
+        diameter: 0.1             # [m] diameter of obstacles. used for creating dynamic obstacles from points
+        height: 2.0               # [m] height of obstacles. used for creating dynamic obstacles from points
+        max_prediction_time: 10.0 # [sec] create predicted path until this time
+        time_step: 0.5            # [sec] time step for each path step. used for creating dynamic obstacles from points or objects without path
+        points_interval: 0.1      # [m] divide obstacle points into groups with this interval, and detect only lateral nearest point. used only for Points method
 
       # approach if ego has stopped in the front of the obstacle for a certain amount of time
       approaching:


### PR DESCRIPTION
## Description

Added parameter for this PR.
- https://github.com/autowarefoundation/autoware.universe/pull/5672

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

PSim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
