### PR TITLE
feat(component_state_monitor): monitor traffic light recognition output

### DIFF
--- a/autoware_launch/config/system/component_state_monitor/topics.yaml
+++ b/autoware_launch/config/system/component_state_monitor/topics.yaml
@@ -89,6 +89,19 @@
     error_rate: 1.0
     timeout: 1.0
 
+- module: perception
+  mode: [online, logging_simulation]
+  type: autonomous
+  args:
+    node_name_suffix: traffic_light_recognition_traffic_signals
+    topic: /perception/traffic_light_recognition/traffic_signals
+    topic_type: autoware_perception_msgs/msg/TrafficSignalArray
+    best_effort: false
+    transient_local: false
+    warn_rate: 5.0
+    error_rate: 1.0
+    timeout: 1.0
+
 - module: planning
   mode: [online, logging_simulation, planning_simulation]
   type: autonomous


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

I propose adding a topic monitor for the output of the traffic light recognition system. 
Please see the https://github.com/autowarefoundation/autoware.universe/pull/5778 for more details.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

See https://github.com/autowarefoundation/autoware.universe/pull/5778

## Effects on system behavior

If traffic signal messages are not received or its topic rate is decreased, the vehicle will enter the emergency state.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
