### PR TITLE
feat: switch to obstacle_cruise_planner

### DIFF
--- a/autoware_launch/config/planning/preset/default_preset.yaml
+++ b/autoware_launch/config/planning/preset/default_preset.yaml
@@ -94,7 +94,7 @@ launch:
 
   - arg:
       name: motion_stop_planner_type
-      default: obstacle_stop_planner
+      default: obstacle_cruise_planner
       # option: obstacle_stop_planner
       #         obstacle_cruise_planner
       #         none


### PR DESCRIPTION
## Description

Based on the action items in https://github.com/orgs/autowarefoundation/discussions/4052, this PR switches from obstacle_stop_planner to obstacle_cruise_planner.
<!-- Write a brief description of this PR. -->

Part of
- https://github.com/autowarefoundation/autoware/issues/4520
- https://github.com/orgs/autowarefoundation/discussions/3964

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

planning simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

The cruise planner will be replaced with obstacle_cruise_planner.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
