### PR TITLE
feat: tune parameters for optimization path planning

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
@@ -3,7 +3,7 @@
     option:
       enable_skip_optimization: false                              # skip elastic band and model predictive trajectory
       enable_reset_prev_optimization: false                        # If true, optimization has no fix constraint to the previous result.
-      enable_outside_drivable_area_stop: false                     # stop if the ego's trajectory footprint is outside the drivable area
+      enable_outside_drivable_area_stop: true                      # stop if the ego's trajectory footprint is outside the drivable area
       use_footprint_polygon_for_outside_drivable_area_check: false # If false, only the footprint's corner points are considered.
 
       debug:

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
@@ -40,7 +40,7 @@
         steer_limit_constraint: false
         visualize_sampling_num: 1
         enable_manual_warm_start: false
-        enable_warm_start: true
+        enable_warm_start: false
         enable_optimization_validation: false
 
       common:

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner/obstacle_avoidance_planner.param.yaml
@@ -3,7 +3,7 @@
     option:
       enable_skip_optimization: false                              # skip elastic band and model predictive trajectory
       enable_reset_prev_optimization: false                        # If true, optimization has no fix constraint to the previous result.
-      enable_outside_drivable_area_stop: true                      # stop if the ego's trajectory footprint is outside the drivable area
+      enable_outside_drivable_area_stop: false                     # stop if the ego's trajectory footprint is outside the drivable area
       use_footprint_polygon_for_outside_drivable_area_check: false # If false, only the footprint's corner points are considered.
 
       debug:
@@ -31,7 +31,7 @@
       max_ego_moving_dist: 5.0                 # threshold of ego's moving distance for replan [m]
       # make max_goal_moving_dist long to keep start point fixed for pull over
       max_goal_moving_dist: 15.0               # threshold of goal's moving distance for replan [m]
-      max_delta_time_sec: 1.0                  # threshold of delta time for replan [second]
+      max_delta_time_sec: 0.0                  # threshold of delta time for replan [second]
 
     # mpt param
     mpt:
@@ -62,7 +62,7 @@
       # weight parameter for optimization
       weight:
         # collision free
-        soft_collision_free_weight: 1000.0        # soft weight for lateral error around the middle point
+        soft_collision_free_weight: 1.0        # soft weight for lateral error around the middle point
 
         # tracking error
         lat_error_weight: 1.0       # weight for lateral error

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/path_smoother/elastic_band_smoother.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/path_smoother/elastic_band_smoother.param.yaml
@@ -44,4 +44,4 @@
       max_ego_moving_dist: 5.0                 # threshold of ego's moving distance for replan [m]
       # make max_goal_moving_dist long to keep start point fixed for pull over
       max_goal_moving_dist: 15.0               # threshold of goal's moving distance for replan [m]
-      max_delta_time_sec: 1.0                  # threshold of delta time for replan [second]
+      max_delta_time_sec: 0.0                  # threshold of delta time for replan [second]


### PR DESCRIPTION
## Description

Tune parameters for the optimization path planning (obstacle_avoidance_planner and path_smoother packages)
- Solve the optimization every timestep
    - Without this PR, the optimization is solved every 1 second due to the calculation cost. Now the calculation cost decreased enough.
- Tune the collision-free weight so that the trajectory's footprint will be inside the drivable area
    - The current weight is too large to do the optimization-based avoidance.
- The ego will not stop when the trajectory's footprint is outside the drivable area.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- psim
- scenario test:
    - https://evaluation.tier4.jp/evaluation/reports/84c10a27-0536-5f60-b561-596aa1ecc626?project_id=prd_jt
    - https://evaluation.tier4.jp/evaluation/reports/2785c233-a59e-5566-b942-8f582b09c91e?project_id=prd_jt
- real JapanTaxi vehicle at TIER IV

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Optimization is solved every timestep.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
