### PR TITLE
feat(rviz): add marker to show bpp internal state

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -3649,6 +3649,22 @@ Visualization Manager:
                   Value: true
               Enabled: true
               Name: Objects Of Interest
+            - Class: rviz_plugins/StringStampedOverlayDisplay
+              Enabled: true
+              Font Size: 15
+              Left: 1024
+              Max Letter Num: 100
+              Name: StringStampedOverlayDisplay
+              Text Color: 25; 255; 240
+              Top: 128
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Reliable
+                Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/internal_state
+              Value: true
+              Value height offset: 0
           Enabled: true
           Name: Planning
         - Class: rviz_common/Group


### PR DESCRIPTION
## Description
![Screenshot from 2024-01-17 16-55-34](https://github.com/autowarefoundation/autoware_launch/assets/44889564/6941a1e3-a106-427d-97f9-4744cec1938b)

Add debug marker config to show bpp internal state.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
