### PR TITLE
chore(pointcloud_container): fix output log from screen to both

### DIFF
--- a/autoware_launch/launch/pointcloud_container.launch.py
+++ b/autoware_launch/launch/pointcloud_container.launch.py
@@ -43,7 +43,7 @@ def generate_launch_description():
         package="rclcpp_components",
         executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=[],
-        output="screen",
+        output="both",
     )
 
     return LaunchDescription(


### PR DESCRIPTION
## Description

Fix logger configuration of pointcloud_container from "screen" to "both" so that stdout+stderr are both output to log and terminal.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Now the output of the pointcloud_container will be written both in log and terminal

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
