### PR TITLE
fix(tracking_object_merger): fix unknown is not associated problem

### DIFF
--- a/autoware_launch/config/perception/object_recognition/tracking/tracking_object_merger/data_association_matrix.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/tracking_object_merger/data_association_matrix.param.yaml
@@ -3,7 +3,7 @@
     lidar-lidar:
       can_assign_matrix:
         #UNKNOWN, CAR, TRUCK, BUS,  TRAILER, MOTORBIKE, BICYCLE,PEDESTRIAN
-        [0,       0,   0,     0,    0,       0,         0,      0,         #UNKNOWN
+        [1,       0,   0,     0,    0,       0,         0,      0,         #UNKNOWN
         0,       1,   1,     1,    1,       0,         0,      0,         #CAR
         0,       1,   1,     1,    1,       0,         0,      0,         #TRUCK
         0,       1,   1,     1,    1,       0,         0,      0,         #BUS
@@ -59,7 +59,7 @@
     lidar-radar:
       can_assign_matrix:
         #UNKNOWN, CAR, TRUCK, BUS,  TRAILER, MOTORBIKE, BICYCLE,PEDESTRIAN
-        [0,       0,   0,     0,    0,       0,         0,      0,         #UNKNOWN
+        [1,       0,   0,     0,    0,       0,         0,      0,         #UNKNOWN
         0,       1,   1,     1,    1,       0,         0,      0,         #CAR
         0,       1,   1,     1,    1,       0,         0,      0,         #TRUCK
         0,       1,   1,     1,    1,       0,         0,      0,         #BUS
@@ -115,7 +115,7 @@
     radar-radar:
       can_assign_matrix:
         #UNKNOWN, CAR, TRUCK, BUS,  TRAILER, MOTORBIKE, BICYCLE,PEDESTRIAN
-        [0,       0,   0,     0,    0,       0,         0,      0,         #UNKNOWN
+        [1,       0,   0,     0,    0,       0,         0,      0,         #UNKNOWN
         0,       1,   1,     1,    1,       0,         0,      0,         #CAR
         0,       1,   1,     1,    1,       0,         0,      0,         #TRUCK
         0,       1,   1,     1,    1,       0,         0,      0,         #BUS


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR fixes wrong association settings for tracking object merger.

- before: unknown class was not associated each other
- after: unknown objects will associated each other


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tested lsim.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Less unknown objects.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
