### PR TITLE
fix(pointpainting): update parameter

### DIFF
--- a/autoware_launch/config/perception/object_recognition/detection/lidar_model/pointpainting.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/lidar_model/pointpainting.param.yaml
@@ -1,7 +1,6 @@
 /**:
   ros__parameters:
     trt_precision: fp16
-    build_only: false
     encoder_onnx_path: "$(var model_path)/pts_voxel_encoder_$(var model_name).onnx"
     encoder_engine_path: "$(var model_path)/pts_voxel_encoder_$(var model_name).engine"
     head_onnx_path: "$(var model_path)/pts_backbone_neck_head_$(var model_name).onnx"


### PR DESCRIPTION
## Description
Remove unnecessary parameter from pointpainting.param.yaml, `build_only`, which was mistakenly introduced in https://github.com/autowarefoundation/autoware.universe/pull/6169
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
