### PR TITLE
refactor(rviz): update the class name and turn signal color

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -244,14 +244,14 @@ Visualization Manager:
               Value: true
               Wave Color: 255; 255; 255
               Wave Velocity: 40
-            - Class: awf_2d_overlay_vehicle/SignalDisplay
+            - Class: autoware_overlay_rviz_plugin/SignalDisplay
               Enabled: true
               Gear Topic Test: /vehicle/status/gear_status
               Hazard Lights Topic: /vehicle/status/hazard_lights_status
               Height: 175
               Left: 10
               Name: SignalDisplay
-              Signal Color: 94; 130; 255
+              Signal Color: 0; 230; 120
               Speed Limit Topic: /planning/scenario_planning/current_max_velocity
               Speed Topic: /vehicle/status/velocity_status
               Steering Topic: /vehicle/status/steering_status


### PR DESCRIPTION
## Description

Changing class name of the overlay plugin + turn signals default color

Part of:
- https://github.com/autowarefoundation/autoware/issues/4146

Should be merged with:
- https://github.com/autowarefoundation/autoware.universe/pull/6323

## Tests performed

Not applicable.

## Effects on system behavior

This will correctly load the plugin into the display

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
