### PR TITLE
feat(emergeny_handler): update config of emergency_handler

### DIFF
--- a/autoware_launch/config/system/emergency_handler/emergency_handler.param.yaml
+++ b/autoware_launch/config/system/emergency_handler/emergency_handler.param.yaml
@@ -3,10 +3,13 @@
 /**:
   ros__parameters:
     update_rate: 10
-    timeout_hazard_status: 0.5
+    timeout_operation_mode_availability: 0.5
+    use_emergency_holding: false
+    timeout_emergency_recovery: 5.0
     timeout_takeover_request: 10.0
     use_takeover_request: false
     use_parking_after_stopped: false
+    use_pull_over: false
     use_comfortable_stop: false
 
     # setting whether to turn hazard lamp on for each situation


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Replaced hazard_status with operation_mode_availability in emergency_handler.
This pull request updates params of emergency_handler following [the PR](https://github.com/autowarefoundation/autoware.universe/pull/6352).

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
