### PR TITLE
fix(system_error_monitor): changed settings of /autoware/localization/performance_monitoring

### DIFF
--- a/autoware_launch/config/system/system_error_monitor/system_error_monitor.awsim.param.yaml
+++ b/autoware_launch/config/system/system_error_monitor/system_error_monitor.awsim.param.yaml
@@ -24,6 +24,8 @@
         /autoware/localization/node_alive_monitoring: default
         /autoware/localization/performance_monitoring/matching_score: { sf_at: "warn", lf_at: "none", spf_at: "none" }
         /autoware/localization/performance_monitoring/localization_error_ellipse: { sf_at: "warn", lf_at: "none", spf_at: "none" }
+        /autoware/localization/performance_monitoring/localization_stability: { sf_at: "warn", lf_at: "none", spf_at: "none" }
+        /autoware/localization/performance_monitoring/sensor_fusion_status: { sf_at: "warn", lf_at: "none", spf_at: "none" }
 
         /autoware/map/node_alive_monitoring: default
 

--- a/autoware_launch/config/system/system_error_monitor/system_error_monitor.param.yaml
+++ b/autoware_launch/config/system/system_error_monitor/system_error_monitor.param.yaml
@@ -24,6 +24,7 @@
         /autoware/localization/node_alive_monitoring: default
         /autoware/localization/performance_monitoring/matching_score: { sf_at: "warn", lf_at: "none", spf_at: "none" }
         /autoware/localization/performance_monitoring/localization_error_ellipse: default
+        /autoware/localization/performance_monitoring/localization_stability: default
         /autoware/localization/performance_monitoring/sensor_fusion_status: { sf_at: "error", lf_at: "none", spf_at: "none" }
 
         /autoware/map/node_alive_monitoring: default


### PR DESCRIPTION
## Description

Changed settings in system_error_monitor

localization_stability is a feature added below.

* https://github.com/autowarefoundation/autoware.universe/pull/5935

This change was not reflected in `system_error_monitor.param.yaml`, so this pull request added it.

I also fixed `system_error_monitor.awsim.param.yaml` because it did not take into account other added metrics.

## Tests performed

AWSIM + Autoware works fine.

## Effects on system behavior

localization_stability has almost no effect as it does not output ERROR level diag.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
