### PR TITLE
feat(perception): add lidar_detection_model option

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -42,6 +42,7 @@
   <arg name="rviz_respawn" default="true"/>
   <!-- Perception -->
   <arg name="perception_mode" default="lidar" description="select perception mode. camera_lidar_radar_fusion, camera_lidar_fusion, lidar_radar_fusion, lidar, radar"/>
+  <arg name="lidar_detection_model" default="centerpoint" description="options: `centerpoint`, `apollo`, `pointpainting`, `clustering`"/>
   <arg name="traffic_light_recognition/enable_fine_detection" default="true" description="enable traffic light fine detection"/>
   <!-- Auto mode setting-->
   <arg name="enable_all_modules_auto_mode" default="false" description="enable all module's auto mode"/>

--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -43,6 +43,7 @@
   <!-- Perception -->
   <arg name="perception_mode" default="lidar" description="select perception mode. camera_lidar_radar_fusion, camera_lidar_fusion, lidar_radar_fusion, lidar, radar"/>
   <arg name="lidar_detection_model" default="centerpoint" description="options: `centerpoint`, `apollo`, `pointpainting`, `clustering`"/>
+  <arg name="centerpoint_model_name" default="centerpoint_tiny" description="options: `centerpoint` or `centerpoint_tiny`"/>
   <arg name="traffic_light_recognition/enable_fine_detection" default="true" description="enable traffic light fine detection"/>
   <!-- Auto mode setting-->
   <arg name="enable_all_modules_auto_mode" default="false" description="enable all module's auto mode"/>

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -20,6 +20,7 @@
     <arg name="objects_filter_method" value="$(var detected_objects_filter_method)"/>
     <arg name="objects_validation_method" value="$(var detected_objects_validation_method)"/>
     <arg name="data_path" value="$(var data_path)"/>
+    <arg name="centerpoint_model_name" value="$(var centerpoint_model_name)"/>
 
     <!-- object recognition -->
     <arg

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -12,6 +12,7 @@
 
   <include file="$(find-pkg-share tier4_perception_launch)/launch/perception.launch.xml">
     <arg name="mode" value="$(var perception_mode)"/>
+    <arg name="lidar_detection_model" value="$(var lidar_detection_model)"/>
     <arg name="vehicle_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
     <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
     <arg name="occupancy_grid_map_method" value="$(var occupancy_grid_map_method)"/>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

add lidar_detection_model option

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

```
ros2 launch autoware_launch logging_simulator.launch.xml map_path:=/home/kosuke55/data/map/bs/ vehicle_model:=lexus sensor_model:=aip_xx1 rviz:=true perception:=true
```

change to apollo
```
<arg name="lidar_detection_model" default="apollo" description="options: `centerpoint`, `apollo`, `pointpainting`, `clustering`"/>
```

check apollo works instead of centerpoint
```
~/auto-evaluator.murooka (main %=)
$ ros2 topic list |rg apollo
/perception/object_recognition/detection/apollo/objects
/perception/object_recognition/detection/apollo/objects_with_feature
/perception/object_recognition/detection/apollo/validation/objects
~/auto-evaluator.murooka (main %=)
$ ros2 topic list |rg center
/sensing/radar/front_center/detected_objects
/sensing/radar/front_center/filtered_objects
/sensing/radar/front_center/from_can_bus
/sensing/radar/front_center/noise_objects
/sensing/radar/front_center/objects_raw
/sensing/radar/front_center/scan_raw
/sensing/radar/front_center/tracked_objects
```


----

```
<arg name="centerpoint_model_name" default="centerpoint" description="options: `centerpoint` or `centerpoint_tiny`"/>

[component_container_mt-1] [I] [TRT] Input filename:   /home/kosuke55/autoware_data/lidar_centerpoint/pts_voxel_encoder_centerpoint.onnx
```

```
<arg name="centerpoint_model_name" default="centerpoint_tiny" description="options: `centerpoint` or `centerpoint_tiny`"/>

[component_container_mt-1] [I] [TRT] Input filename:   /home/kosuke55/autoware_data/lidar_centerpoint/pts_voxel_encoder_centerpoint_tiny.onnx
```


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
