### PR TITLE
fix: recovery default parameter

### DIFF
--- a/autoware_launch/config/perception/object_recognition/detection/lidar_model/pointpainting.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/lidar_model/pointpainting.param.yaml
@@ -26,7 +26,7 @@
       iou_nms_target_class_names: ["CAR"]
       iou_nms_search_distance_2d: 10.0
       iou_nms_threshold: 0.1
-      score_threshold: 0.4
+      score_threshold: 0.35
     omp_params:
       # omp params
       num_threads: 1


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Score_threshold parameter is mistakenly modified by  https://github.com/autowarefoundation/autoware.universe/commit/cc0b1081a74a265a3dac05d5830610242aa0ecd3, so I fixed them.
[TIER IV INTERNAL LINK](https://star4.slack.com/archives/C03S84LDJGG/p1708403287430539?thread_ts=1708400772.055019&cid=C03S84LDJGG)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I did not run autoware with this PR

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
