### PR TITLE
feat(rviz): make rviz2 background lighter, lower the contrast

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -3613,7 +3613,7 @@ Visualization Manager:
       Name: Debug
   Enabled: true
   Global Options:
-    Background Color: 10; 10; 10
+    Background Color: 42; 42; 42
     Default Light: true
     Fixed Frame: map
     Frame Rate: 30


### PR DESCRIPTION
## Description

This PR increases the lightness level of the rviz2 config of the background.

![Screenshot from 2024-02-22 18-17-12](https://github.com/autowarefoundation/autoware_launch/assets/10751153/57849842-ba1b-4297-812b-c731bb3354b6)

This should lower the contrast and make things easier on the eye.

Also lets the top overlay interface pop out more.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
