### PR TITLE
feat(tier4_localization_component_launch): change the default input pointcloud of localization into the concatenated pointcloud

### DIFF
--- a/autoware_launch/launch/components/tier4_localization_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_localization_component.launch.xml
@@ -3,11 +3,11 @@
   <let name="loc_config_path" value="$(find-pkg-share autoware_launch)/config/localization"/>
   <arg name="pose_source" default="ndt" description="select pose_estimator: ndt, yabloc, eagleye"/>
   <arg name="twist_source" default="gyro_odom" description="select twist_estimator. gyro_odom, eagleye"/>
-  <arg name="input_pointcloud" default="/sensing/lidar/top/pointcloud" description="The topic will be used in the localization util module"/>
+  <arg name="input_pointcloud" default="/sensing/lidar/concatenated/pointcloud" description="The topic will be used in the localization util module"/>
   <arg
-    name="lidar_container_name"
-    default="/sensing/lidar/top/pointcloud_preprocessor/pointcloud_container"
-    description="The target container to which lidar preprocessing nodes in localization be attached"
+    name="localization_pointcloud_container_name"
+    default="/pointcloud_container"
+    description="The target container to which pointcloud preprocessing nodes in localization be attached"
   />
 
   <group>
@@ -16,7 +16,7 @@
       <arg name="twist_source" value="$(var twist_source)"/>
       <arg name="system_run_mode" value="$(var system_run_mode)"/>
       <arg name="input_pointcloud" value="$(var input_pointcloud)"/>
-      <arg name="lidar_container_name" value="$(var lidar_container_name)"/>
+      <arg name="localization_pointcloud_container_name" value="$(var localization_pointcloud_container_name)"/>
 
       <!-- parameter paths for common -->
       <arg name="localization_error_monitor_param_path" value="$(var loc_config_path)/localization_error_monitor.param.yaml"/>

--- a/autoware_launch/launch/components/tier4_localization_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_localization_component.launch.xml
@@ -4,11 +4,7 @@
   <arg name="pose_source" default="ndt" description="select pose_estimator: ndt, yabloc, eagleye"/>
   <arg name="twist_source" default="gyro_odom" description="select twist_estimator. gyro_odom, eagleye"/>
   <arg name="input_pointcloud" default="/sensing/lidar/concatenated/pointcloud" description="The topic will be used in the localization util module"/>
-  <arg
-    name="localization_pointcloud_container_name"
-    default="/pointcloud_container"
-    description="The target container to which pointcloud preprocessing nodes in localization be attached"
-  />
+  <arg name="localization_pointcloud_container_name" default="/pointcloud_container" description="The target container to which pointcloud preprocessing nodes in localization be attached"/>
 
   <group>
     <include file="$(find-pkg-share tier4_localization_launch)/launch/localization.launch.xml">


### PR DESCRIPTION
## Description

[Autoware should cover the use cases where the concatenated pointcloud will be applied as an input to the localization, and we expect that the number of vehicles that use multiple LiDARs will increase.](https://github.com/orgs/autowarefoundation/discussions/4172). 

**Therefore, this PR will change the default `input_pointcloud` to `/sensing/lidar/concatenated/pointcloud` instead of `/sensing/lidar/top/pointcloud`, and change the pointcloud container to `/pointcloud_container` due to this change.**

Plus, I also refactored the name of the argument `lidar_container_name` to `localization_pointcloud_container_name` since the candidate pointcloud container may not be specific to such LiDAR (just like this case), and it makes the argument more clear that it is for the localization component.

Of course, this is just a modification of the *default* `input_pointcloud`, so one can choose to use a single LiDAR by changing the `input_pointcloud` to `/sensing/lidar/***/pointcloud`.

## Related links

**This PR must be merged with https://github.com/autowarefoundation/autoware.universe/pull/6528!!**

## Tests performed

Confirmed that the localization worked with the concatenated pointcloud in [the logging_simulator tutorial](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/).
Also tested with internal driving data, and evaluated through [CARET](https://github.com/tier4/caret) that it hardly affected the system latency. [[TIER IV INTERNAL LINK](https://tier4.atlassian.net/l/cp/NnV9esn7)]

## Notes for reviewers

**This PR must be merged with https://github.com/autowarefoundation/autoware.universe/pull/6528!!**

## Interface changes

The localization component will use `/sensing/lidar/concatenated/pointcloud` by default.
The pointcloud preprocessing nodes in the localization component will join the `pointcloud_container` by default.

## Effects on system behavior

The localization component will use `/sensing/lidar/concatenated/pointcloud` by default.
The pointcloud preprocessing nodes in the localization component will join the `pointcloud_container` by default.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
