### PR TITLE
revert: feat(autoware_launch): set use_sim_time parameter equal to true when (#746)

### DIFF
--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -41,8 +41,6 @@
     <let name="launch_vehicle_interface" value="true" unless="$(var vehicle_simulation)"/>
 
     <include file="$(find-pkg-share autoware_launch)/launch/autoware.launch.xml">
-      <!-- Global parameters -->
-      <arg name="use_sim_time" value="$(var scenario_simulation)"/>
       <!-- Common -->
       <arg name="map_path" value="$(var map_path)"/>
       <arg name="vehicle_model" value="$(var vehicle_model)"/>


### PR DESCRIPTION
## Description

This reverts commit 2b510453aa2ea950513067b62248f7aedfbf1b41.
cc. @pawellech1

Related PR:
- https://github.com/autowarefoundation/autoware_launch/pull/746

[Reason from](https://github.com/autowarefoundation/autoware_launch/pull/746#issuecomment-1958721559) @maxime-clem :

> This change prevents from using `use_sim_time:=true` outside of using the `scenario_simulation`.
> Previously I would add the argument to my launch command `ros2 launch ... use_sim_time:=true` but this is no longer possible and I had to revert the changes of this PR.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
