### PR TITLE
feat(planning_simulator): default use_sim_time arg to scenario_simulation

### DIFF
--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -34,6 +34,8 @@
   <arg name="vehicle_simulation" default="true" description="use vehicle simulation"/>
   <!-- Auto mode setting-->
   <arg name="enable_all_modules_auto_mode" default="$(var scenario_simulation)" description="enable all module's auto mode"/>
+  <!-- Simulated time -->
+  <arg name="use_sim_time" default="$(var scenario_simulation)"/>
 
   <group scoped="false">
     <!-- Vehicle -->


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Try to achieve the same thing as https://github.com/autowarefoundation/autoware_launch/pull/746
> In order to set global use_sim_time parameter value to True by default when the simulation is run the use_sim_time argument in the planning_simulator launch file was declared. Its value is set to be equal to the scenario_simulation parameter value.

The issue with the previous PR is that it was overriding any `use_sim_time` argument passed as launch argument, preventing users from running Autoware with `ros2 launch ... use_sim_time:=true`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
I tested the following with Psim.
| launch argument | `use_sim_time` |
| --- | --- |
| - | `false` |
| `use_sim_time:=true` | `true` |
| `use_sim_time:=false` | `false` |
| `scenario_simulation:=true` | `true` |
| `scenario_simulation:=false` | `false` | 


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
