### PR TITLE
feat(crosswalk): increase minimum occlusion size that causes slowdown to 1m

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/crosswalk.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/crosswalk.param.yaml
@@ -75,7 +75,7 @@
         occluded_object_velocity: 1.0 # [m/s] assumed velocity of objects that may come out of the occluded space
         slow_down_velocity: 1.0  # [m/s]
         time_buffer: 0.5  # [s] consecutive time with/without an occlusion to add/remove the slowdown
-        min_size: 0.5  # [m] minimum size of an occlusion (square side size)
+        min_size: 1.0  # [m] minimum size of an occlusion (square side size)
         free_space_max: 43  # [-] maximum value of a free space cell in the occupancy grid
         occupied_min: 58    # [-] minimum value of an occupied cell in the occupancy grid
         ignore_with_red_traffic_light: true  # [-] if true, occlusions at crosswalks with traffic lights are ignored


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
increase minimum occlusion size that causes slowdown to 1m.
This prevents false occlusion detection caused by noise in the occupancy grid.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Evaluator (TIER IV INTERNAL LINK): https://evaluation.tier4.jp/evaluation/reports/9fe632ec-59a6-53ea-84f3-c147be539013?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Slowdown at crosswalk are less likely to be false positives.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
