### PR TITLE
fix(avoidance): tune safety check params

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
@@ -192,7 +192,7 @@
         check_all_predicted_path: false                  # [-]
         safety_check_backward_distance: 100.0            # [m]
         hysteresis_factor_expand_rate: 1.5               # [-]
-        hysteresis_factor_safe_count: 10                 # [-]
+        hysteresis_factor_safe_count: 3                  # [-]
         # predicted path parameters
         min_velocity: 1.38                               # [m/s]
         max_velocity: 50.0                               # [m/s]
@@ -208,7 +208,7 @@
         rear_vehicle_safety_time_margin: 1.0             # [s]
         lateral_distance_max_threshold: 2.0              # [m]
         longitudinal_distance_min_threshold: 3.0         # [m]
-        longitudinal_velocity_delta_time: 0.8            # [s]
+        longitudinal_velocity_delta_time: 0.0            # [s]
 
       # For avoidance maneuver
       avoidance:


### PR DESCRIPTION
## Description

Tune safety check parameter to fix too conservative unsafe judge in situation where the target object is in front of ego.

![image](https://github.com/autowarefoundation/autoware_launch/assets/44889564/91ed6b60-edbf-4d53-9ef8-53f6743eb09d)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/608403b1-bcce-5841-ad38-8522cfd2bfdb?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Improve avoidance behavior.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
