### PR TITLE
feat: add dummy doors for planning simulator

### DIFF
--- a/autoware_launch/launch/components/tier4_simulator_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_simulator_component.launch.xml
@@ -3,6 +3,7 @@
   <arg name="launch_dummy_perception"/>
   <arg name="launch_dummy_vehicle"/>
   <arg name="launch_dummy_localization"/>
+  <arg name="launch_dummy_doors"/>
   <arg name="launch_diagnostic_converter"/>
   <arg name="perception/enable_detection_failure"/>
   <arg name="perception/enable_object_recognition"/>
@@ -17,6 +18,7 @@
     <arg name="launch_dummy_perception" value="$(var launch_dummy_perception)"/>
     <arg name="launch_dummy_vehicle" value="$(var launch_dummy_vehicle)"/>
     <arg name="launch_dummy_localization" value="$(var launch_dummy_localization)"/>
+    <arg name="launch_dummy_doors" value="$(var launch_dummy_doors)"/>
     <arg name="launch_diagnostic_converter" value="$(var launch_diagnostic_converter)"/>
     <arg name="perception/enable_detection_failure" value="$(var perception/enable_detection_failure)"/>
     <arg name="perception/enable_object_recognition" value="$(var perception/enable_object_recognition)"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -16,6 +16,7 @@
   <let name="rviz_initial_pose_auto_fix_target" value="vector_map"/>
   <let name="gnss_initial_pose_auto_fix_target" value="vector_map"/>
   <!-- System -->
+  <arg name="launch_dummy_doors" default="true" description="launch dummy doors simulation"/>
   <arg name="launch_system_monitor" default="false" description="launch system monitor"/>
   <arg name="launch_dummy_diag_publisher" default="false" description="launch dummy diag publisher"/>
   <!-- Scenario simulation -->
@@ -86,6 +87,7 @@
       <arg name="launch_dummy_perception" value="$(var launch_dummy_perception)"/>
       <arg name="launch_dummy_vehicle" value="$(var launch_dummy_vehicle)"/>
       <arg name="launch_dummy_localization" value="$(var launch_dummy_localization)"/>
+      <arg name="launch_dummy_doors" value="$(var launch_dummy_doors)"/>
       <arg name="launch_diagnostic_converter" value="$(var launch_diagnostic_converter)"/>
       <arg name="perception/enable_detection_failure" value="$(var perception/enable_detection_failure)"/>
       <arg name="perception/enable_object_recognition" value="$(var perception/enable_object_recognition)"/>
@@ -95,10 +97,5 @@
       <arg name="initial_engage_state" value="$(var initial_engage_state)"/>
       <arg name="vehicle_info_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
     </include>
-  </group>
-
-  <!-- Dummy doors -->
-  <group>
-    <include file="$(find-pkg-share vehicle_door_simulator)/launch/vehicle_door_simulator.launch.xml"/>
   </group>
 </launch>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -96,4 +96,9 @@
       <arg name="vehicle_info_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
     </include>
   </group>
+
+  <!-- Dummy doors -->
+  <group>
+    <include file="$(find-pkg-share vehicle_door_simulator)/launch/vehicle_door_simulator.launch.xml"/>
+  </group>
 </launch>


### PR DESCRIPTION
## Description

Add dummy doors for planning simulator. See https://github.com/autowarefoundation/autoware.universe/pull/5737 for details.

## Tests performed

See https://github.com/autowarefoundation/autoware.universe/pull/5737.

## Effects on system behavior

Add door simulation.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
