### PR TITLE
feat: add option to launch mrm handler

### DIFF
--- a/autoware_launch/launch/components/tier4_system_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_system_component.launch.xml
@@ -26,5 +26,10 @@
     <arg name="system_monitor_ntp_monitor_param_path" value="$(find-pkg-share autoware_launch)/config/system/system_monitor/ntp_monitor.param.yaml"/>
     <arg name="system_monitor_process_monitor_param_path" value="$(find-pkg-share autoware_launch)/config/system/system_monitor/process_monitor.param.yaml"/>
     <arg name="system_monitor_voltage_monitor_param_path" value="$(find-pkg-share autoware_launch)/config/system/system_monitor/voltage_monitor.param.yaml"/>
+
+    <arg name="use_diagnostic_graph" value="false"/>
+    <arg name="mrm_handler_param_path" value="$(find-pkg-share autoware_launch)/config/system/mrm_handler/mrm_handler.param.yaml"/>
+    <!-- <arg name="diagnostic_graph_aggregator_param_path" value=""/>  Set the value if use_diagnostic_graph is true. -->
+    <!-- <arg name="diagnostic_graph_aggregator_graph_path" value=""/>  Set the value if use_diagnostic_graph is true. -->
   </include>
 </launch>


### PR DESCRIPTION
## Description

Add option to use mrm handler. This option is disabled by default.
https://github.com/orgs/autowarefoundation/discussions/4176

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

This is a sample parameter.

```
    <arg name="diagnostic_graph_aggregator_param_path" value="$(find-pkg-share diagnostic_graph_aggregator)/config/default.param.yaml"/>
    <arg name="diagnostic_graph_aggregator_graph_path" value="$(find-pkg-share diagnostic_graph_aggregator)/example/graph/main.yaml"/>
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
