### PR TITLE
feat(dynamic_obstacle_stop): split the duration buffer parameter in 2 (add/remove)

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/dynamic_obstacle_stop.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/dynamic_obstacle_stop.param.yaml
@@ -6,6 +6,7 @@
       stop_distance_buffer: 0.5  # [m] extra distance to add between the stop point and the collision point
       time_horizon: 5.0  # [s] time horizon used for collision checks
       hysteresis: 1.0  # [m] once a collision has been detected, this hysteresis is used on the collision detection
-      decision_duration_buffer : 1.0  # [s] duration between no collision being detected and the stop decision being cancelled
+      add_stop_duration_buffer : 0.5  # [s] duration where a collision must be continuously detected before a stop decision is added
+      remove_stop_duration_buffer : 1.0  # [s] duration between no collision being detected and the stop decision being remove 
       minimum_object_distance_from_ego_path: 1.0  # [m] minimum distance between the footprints of ego and an object to consider for collision
       ignore_unavoidable_collisions : true  # if true, ignore collisions that cannot be avoided by stopping (assuming the obstacle continues going straight)

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/dynamic_obstacle_stop.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/dynamic_obstacle_stop.param.yaml
@@ -7,6 +7,6 @@
       time_horizon: 5.0  # [s] time horizon used for collision checks
       hysteresis: 1.0  # [m] once a collision has been detected, this hysteresis is used on the collision detection
       add_stop_duration_buffer : 0.5  # [s] duration where a collision must be continuously detected before a stop decision is added
-      remove_stop_duration_buffer : 1.0  # [s] duration between no collision being detected and the stop decision being remove 
+      remove_stop_duration_buffer : 1.0  # [s] duration between no collision being detected and the stop decision being remove
       minimum_object_distance_from_ego_path: 1.0  # [m] minimum distance between the footprints of ego and an object to consider for collision
       ignore_unavoidable_collisions : true  # if true, ignore collisions that cannot be avoided by stopping (assuming the obstacle continues going straight)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Split the duration buffer of the `dynamic_obstacle_stop` into 2 parameters (for add/remove the decision).
Needed for https://github.com/autowarefoundation/autoware.universe/pull/6683

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
