### PR TITLE
feat(AEB): add detection range params

### DIFF
--- a/autoware_launch/config/control/autonomous_emergency_braking/autonomous_emergency_braking.param.yaml
+++ b/autoware_launch/config/control/autonomous_emergency_braking/autonomous_emergency_braking.param.yaml
@@ -2,7 +2,7 @@
   ros__parameters:
     publish_debug_pointcloud: false
     use_predicted_trajectory: true
-    use_imu_path: false
+    use_imu_path: true
     detection_range_min_height: 0.0
     detection_range_max_height_margin: 0.0
     voxel_grid_x: 0.05

--- a/autoware_launch/config/control/autonomous_emergency_braking/autonomous_emergency_braking.param.yaml
+++ b/autoware_launch/config/control/autonomous_emergency_braking/autonomous_emergency_braking.param.yaml
@@ -2,7 +2,9 @@
   ros__parameters:
     publish_debug_pointcloud: false
     use_predicted_trajectory: true
-    use_imu_path: true
+    use_imu_path: false
+    detection_range_min_height: 0.0
+    detection_range_max_height_margin: 0.0
     voxel_grid_x: 0.05
     voxel_grid_y: 0.05
     voxel_grid_z: 100000.0


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

I want to add new parameters corresponding to https://github.com/autowarefoundation/autoware.universe/pull/6637

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I checked params in https://github.com/autowarefoundation/autoware.universe/pull/6637

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

- When obstacle point clouds appear below the detection_range_min_height, AEB may no longer be able to activate braking.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
