### PR TITLE
chore: add option to select graph path depending on running mode

### DIFF
--- a/autoware_launch/launch/components/tier4_system_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_system_component.launch.xml
@@ -31,5 +31,6 @@
     <arg name="mrm_handler_param_path" value="$(find-pkg-share autoware_launch)/config/system/mrm_handler/mrm_handler.param.yaml"/>
     <!-- <arg name="diagnostic_graph_aggregator_param_path" value=""/>  Set the value if use_diagnostic_graph is true. -->
     <!-- <arg name="diagnostic_graph_aggregator_graph_path" value=""/>  Set the value if use_diagnostic_graph is true. -->
+    <!-- <arg name="diagnostic_graph_aggregator_planning_simulator_graph_path" value=""/>  Set the value if use_diagnostic_graph is true. -->
   </include>
 </launch>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

This PR adds option to select the graph path file depending on the mode (planning simulator, logging simulator, real vehicle) [like system_error_monitor](https://github.com/tier4/autoware.universe/blob/79280dd3a3c3e4d9256d0049c1fc7369e46341db/launch/tier4_system_launch/launch/system.launch.xml#L66-L68).


PR for universe
- https://github.com/autowarefoundation/autoware.universe/pull/6700

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

See https://github.com/autowarefoundation/autoware.universe/pull/6700

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
