### PR TITLE
fix(tier4_control_component_launch): fix duplicate declaration of controller parameter paths

### DIFF
--- a/autoware_launch/launch/components/tier4_control_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_control_component.launch.xml
@@ -32,8 +32,6 @@
     <arg name="nearest_search_param_path" value="$(find-pkg-share autoware_launch)/config/control/common/nearest_search.param.yaml"/>
 
     <!-- package param path -->
-    <arg name="lat_controller_param_path" value="$(var lat_controller_param_path)"/>
-    <arg name="lon_controller_param_path" value="$(var lon_controller_param_path)"/>
     <arg name="vehicle_cmd_gate_param_path" value="$(find-pkg-share autoware_launch)/config/control/vehicle_cmd_gate/vehicle_cmd_gate.param.yaml"/>
     <arg name="lane_departure_checker_param_path" value="$(find-pkg-share autoware_launch)/config/control/lane_departure_checker/lane_departure_checker.param.yaml"/>
     <arg name="control_validator_param_path" value="$(find-pkg-share autoware_launch)/config/control/control_validator/control_validator.param.yaml"/>


### PR DESCRIPTION
## Description

see https://github.com/autowarefoundation/autoware_launch/issues/728

## Tests performed

In `autoware.launch.xml`:

```launch
  <arg name="lat_controller_param_path" default="<path_to_arbitrary_lateral_controller_param_file>" description="lateral controller configuration file location"/>
  <arg name="lon_controller_param_path" default="<path_to_arbitrary_longitudinal_controller_param_file>" description="longitudinal controller configuration file location"/>
  <!-- Control -->
  <group if="$(var launch_control)">
    <include file="$(find-pkg-share autoware_launch)/launch/components/tier4_control_component.launch.xml"/>
      <arg name="lat_controller_param_path" value="$(var lat_controller_param_path)"/>
      <arg name="lon_controller_param_path" value="$(var lon_controller_param_path)"/>
  </group>
```

## Effects on system behavior

After fixing, arbitrary lateral and longitudinal controller parameter file paths can be specified in the group `Control` in `autoware.launch.xml` and can be passed to `tier4_control_component.launch.xml`

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
