### PR TITLE
feat(lane_change): check prepare phase in turn direction lanes

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -81,6 +81,7 @@
       enable_collision_check_for_prepare_phase:
         general_lanes: false
         intersection: true
+        turns: true
       prepare_segment_ignore_object_velocity_thresh: 0.1 # [m/s]
       check_objects_on_current_lanes: false
       check_objects_on_other_lanes: false


### PR DESCRIPTION
## Description

[universe:feat(lane_change): check prepare phase in turn direction lanes #6726
](https://github.com/autowarefoundation/autoware.universe/pull/6726)

Make lane change check more stricter in when performing lane change after making a turn.
This is done by performing collision check in the prepare phase.

## Before PR

https://github.com/autowarefoundation/autoware.universe/assets/93502286/6155e1f3-7bc7-4da1-886d-919fbcf6c4c2

## After PR

https://github.com/autowarefoundation/autoware.universe/assets/93502286/6437f693-f734-4c17-8c7e-4e1eae64a61d


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
