### PR TITLE
feat(obstacle_cruise): change stop lateral margin

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
@@ -87,7 +87,7 @@
         obstacle_traj_angle_threshold : 1.22 # [rad] = 70 [deg], yaw threshold of crossing obstacle against the nearest trajectory point for cruise or stop
 
       stop:
-        max_lat_margin: 0.2 # lateral margin between obstacle and trajectory band with ego's width
+        max_lat_margin: 0.5 # lateral margin between obstacle and trajectory band with ego's width    0.2(obstacle's mirror) + 0.1 addtional ego pose error in the future + margin 0.2
         crossing_obstacle:
           collision_time_margin : 4.0 # time threshold of collision between obstacle adn ego for cruise or stop [s]
 
@@ -187,12 +187,12 @@
         - "default"
       default:
         moving:
-          min_lat_margin: 0.2
+          min_lat_margin: 0.5
           max_lat_margin: 1.0
           min_ego_velocity: 2.0
           max_ego_velocity: 8.0
         static:
-          min_lat_margin: 0.2
+          min_lat_margin: 0.5
           max_lat_margin: 1.0
           min_ego_velocity: 4.0
           max_ego_velocity: 8.0

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
@@ -87,7 +87,7 @@
         obstacle_traj_angle_threshold : 1.22 # [rad] = 70 [deg], yaw threshold of crossing obstacle against the nearest trajectory point for cruise or stop
 
       stop:
-        max_lat_margin: 0.3 # lateral margin between obstacle and trajectory band with ego's width    0.1(obstacle's mirror) + margin 0.2
+        max_lat_margin: 0.3 # lateral margin between obstacle and trajectory band with ego's width
         crossing_obstacle:
           collision_time_margin : 4.0 # time threshold of collision between obstacle adn ego for cruise or stop [s]
 

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
@@ -187,12 +187,12 @@
         - "default"
       default:
         moving:
-          min_lat_margin: 0.3
+          min_lat_margin: 0.2
           max_lat_margin: 1.0
           min_ego_velocity: 2.0
           max_ego_velocity: 8.0
         static:
-          min_lat_margin: 0.3
+          min_lat_margin: 0.2
           max_lat_margin: 1.0
           min_ego_velocity: 4.0
           max_ego_velocity: 8.0

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
@@ -87,7 +87,7 @@
         obstacle_traj_angle_threshold : 1.22 # [rad] = 70 [deg], yaw threshold of crossing obstacle against the nearest trajectory point for cruise or stop
 
       stop:
-        max_lat_margin: 0.5 # lateral margin between obstacle and trajectory band with ego's width    0.2(obstacle's mirror) + 0.1 addtional ego pose error in the future + margin 0.2
+        max_lat_margin: 0.3 # lateral margin between obstacle and trajectory band with ego's width    0.1(obstacle's mirror) + margin 0.2
         crossing_obstacle:
           collision_time_margin : 4.0 # time threshold of collision between obstacle adn ego for cruise or stop [s]
 
@@ -187,12 +187,12 @@
         - "default"
       default:
         moving:
-          min_lat_margin: 0.5
+          min_lat_margin: 0.3
           max_lat_margin: 1.0
           min_ego_velocity: 2.0
           max_ego_velocity: 8.0
         static:
-          min_lat_margin: 0.5
+          min_lat_margin: 0.3
           max_lat_margin: 1.0
           min_ego_velocity: 4.0
           max_ego_velocity: 8.0


### PR DESCRIPTION
## Description
change lateral margin for stop planning 

This PR is related to https://github.com/autowarefoundation/autoware.universe/pull/6754

## Tests performed
psim and tier4 internal tests
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
