### PR TITLE
fix(roi_pointcloud_fusion): add param

### DIFF
--- a/autoware_launch/config/perception/object_recognition/detection/image_projection_based_fusion/roi_pointcloud_fusion.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/image_projection_based_fusion/roi_pointcloud_fusion.param.yaml
@@ -2,4 +2,5 @@
   ros__parameters:
     fuse_unknown_only: true
     min_cluster_size: 2
+    max_cluster_size: 20
     cluster_2d_tolerance: 0.5


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- To add parameter for `roi_pointcloud_fusion` as changed in https://github.com/autowarefoundation/autoware.universe/pull/6860
- Since Euclidean_Cluster covers the cluster with [`minimum 10 points`](https://github.com/autowarefoundation/autoware_launch/blob/112e7e6b6f4886a87dd64d573b87efdf189eadc5/autoware_launch/config/perception/object_recognition/detection/clustering/voxel_grid_based_euclidean_cluster.param.yaml#L6), so roi_pointcloud_fusion covering until 20 points should be enough. 



## Tests performed


<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
