### PR TITLE
feat(probabilistic_occupancy_grid_map): add downsample filter option to ogm creation 

### DIFF
--- a/autoware_launch/config/perception/occupancy_grid_map/multi_lidar_pointcloud_based_occupancy_grid_map.param.yaml
+++ b/autoware_launch/config/perception/occupancy_grid_map/multi_lidar_pointcloud_based_occupancy_grid_map.param.yaml
@@ -12,6 +12,10 @@
         map_length_x: 150.0 # [m]
         map_length_y: 150.0 # [m]
 
+      # downsample input pointcloud
+      downsample_input_pointcloud: true
+      downsample_voxel_size: 0.125 # [m]
+
       # each grid map parameters
       ogm_creation_config:
         height_filter:

--- a/autoware_launch/config/perception/occupancy_grid_map/multi_lidar_pointcloud_based_occupancy_grid_map.param.yaml
+++ b/autoware_launch/config/perception/occupancy_grid_map/multi_lidar_pointcloud_based_occupancy_grid_map.param.yaml
@@ -14,7 +14,7 @@
 
       # downsample input pointcloud
       downsample_input_pointcloud: true
-      downsample_voxel_size: 0.125 # [m]
+      downsample_voxel_size: 0.25 # [m]
 
       # each grid map parameters
       ogm_creation_config:

--- a/autoware_launch/config/perception/occupancy_grid_map/multi_lidar_pointcloud_based_occupancy_grid_map.param.yaml
+++ b/autoware_launch/config/perception/occupancy_grid_map/multi_lidar_pointcloud_based_occupancy_grid_map.param.yaml
@@ -24,7 +24,7 @@
           max_height: 2.0
         enable_single_frame_mode: true
         # use sensor pointcloud to filter obstacle pointcloud
-        filter_obstacle_pointcloud_by_raw_pointcloud: true
+        filter_obstacle_pointcloud_by_raw_pointcloud: false
 
         grid_map_type: "OccupancyGridMapFixedBlindSpot"
         OccupancyGridMapFixedBlindSpot:

--- a/autoware_launch/config/perception/occupancy_grid_map/pointcloud_based_occupancy_grid_map.param.yaml
+++ b/autoware_launch/config/perception/occupancy_grid_map/pointcloud_based_occupancy_grid_map.param.yaml
@@ -8,6 +8,10 @@
       min_height: -1.0
       max_height: 2.0
 
+    # downsample input pointcloud
+    downsample_input_pointcloud: true
+    downsample_voxel_size: 0.125 # [m]
+
     enable_single_frame_mode: false
     # use sensor pointcloud to filter obstacle pointcloud
     filter_obstacle_pointcloud_by_raw_pointcloud: false


### PR DESCRIPTION
## Description

Related https://github.com/autowarefoundation/autoware.universe/pull/6865, this feature add option to accelerate occupancy grid map creation process.


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
