### PR TITLE
feat(remaining_dist_eta): add MissionDetailsDisplay plugin rviz configuration

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -930,9 +930,9 @@ Visualization Manager:
               Value: true
             - Class: autoware_mission_details_overlay_rviz_plugin/MissionDetailsDisplay
               Name: MissionDetailsDisplay
-              Width: 225
+              Width: 170
               Height: 100
-              Left: 10
+              Right: 10
               Top: 10
               Remaining Distance and Time Topic: /planning/mission_remaining_distance_time
               Enabled: true

--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -935,7 +935,7 @@ Visualization Manager:
               Left: 10
               Top: 10
               Remaining Distance and Time Topic: /planning/mission_remaining_distance_time
-              Enabled: false
+              Enabled: true
           Enabled: true
           Name: MissionPlanning
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -278,14 +278,6 @@ Visualization Manager:
             Value: /system/emergency/hazard_status
           Value: false
           Value height offset: 0
-        - Class: autoware_mission_details_overlay_rviz_plugin/MissionDetailsDisplay
-          Enabled: true
-          Name: MissionDetailsDisplay
-          Width: 300
-          Height: 100
-          Left: 800
-          Top: 10
-          Remaining Distance and ETA Topic: vehicle/status/velocity_status 
       Enabled: true
       Name: System
     - Class: rviz_common/Group
@@ -936,6 +928,14 @@ Visualization Manager:
                 Reliability Policy: Reliable
                 Value: /planning/mission_planning/echo_back_goal_pose
               Value: true
+            - Class: autoware_mission_details_overlay_rviz_plugin/MissionDetailsDisplay
+              Name: MissionDetailsDisplay
+              Width: 300
+              Height: 100
+              Left: 800
+              Top: 10
+              Remaining Distance and ETA Topic: /planning/mission_remaining_distance_time
+              Enabled: false
           Enabled: true
           Name: MissionPlanning
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -278,6 +278,14 @@ Visualization Manager:
             Value: /system/emergency/hazard_status
           Value: false
           Value height offset: 0
+        - Class: autoware_mission_details_overlay_rviz_plugin/MissionDetailsDisplay
+          Enabled: true
+          Name: MissionDetailsDisplay
+          Width: 300
+          Height: 100
+          Left: 800
+          Top: 10
+          Remaining Distance and ETA Topic: vehicle/status/velocity_status 
       Enabled: true
       Name: System
     - Class: rviz_common/Group

--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -930,11 +930,11 @@ Visualization Manager:
               Value: true
             - Class: autoware_mission_details_overlay_rviz_plugin/MissionDetailsDisplay
               Name: MissionDetailsDisplay
-              Width: 300
+              Width: 225
               Height: 100
-              Left: 800
+              Left: 10
               Top: 10
-              Remaining Distance and ETA Topic: /planning/mission_remaining_distance_time
+              Remaining Distance and Time Topic: /planning/mission_remaining_distance_time
               Enabled: false
           Enabled: true
           Name: MissionPlanning


### PR DESCRIPTION
## Description
This PR aims to add a the implementation needed for mission remaining mission distance and estimated time of arrival (ETA) (or estimated time left)
<!-- Write a brief description of this PR. -->

## Related links
Part of:
- https://github.com/autowarefoundation/autoware/issues/4593

Depends on :
- https://github.com/autowarefoundation/autoware_internal_msgs/pull/10
- https://github.com/autowarefoundation/autoware.universe/pull/6855
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
Please check the tests performed in [autoware.universe PR](https://github.com/autowarefoundation/autoware.universe/pull/6855)
<!-- Describe how you have tested this PR. -->

## Notes for reviewers
For successful compilation and testing, please take into consideration the msg definition in [autoware_internal_msgs PR](https://github.com/autowarefoundation/autoware_internal_msgs/pull/10) and the implementation in [autoware.universe PR](https://github.com/autowarefoundation/autoware.universe/pull/6855).
<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
Adding rviz plugin for displaying mission details (remaining distance and time)
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
Along with the [autoware.universe PR](https://github.com/autowarefoundation/autoware.universe/pull/6855) and  [autoware_internal_msgs PR](https://github.com/autowarefoundation/autoware_internal_msgs/pull/10) , Autoware will have the feature to report the mission remaining distance and time.
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
