### PR TITLE
feat(start_planner): tune lateral_distance_max_threshold 2m->3m

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -143,7 +143,7 @@
           rss_params:
             rear_vehicle_reaction_time: 2.0
             rear_vehicle_safety_time_margin: 1.0
-            lateral_distance_max_threshold: 2.0
+            lateral_distance_max_threshold: 3.0
             longitudinal_distance_min_threshold: 3.0
             longitudinal_velocity_delta_time: 0.8
           # hysteresis factor to expand/shrink polygon


### PR DESCRIPTION
## Description
Universe PR: https://github.com/autowarefoundation/autoware.universe/pull/6884
Currently, lateral_distance_max_threshold is set to 2m by default. However, recent tests have proven that 2m is not enough in some cases. After some parameter tuning, 3m was determined to be better.

Examples:
lateral_distance_max_threshold = 2m -> path turns green before time. 
[Screencast from 2024年04月25日 00時57分18秒.webm](https://github.com/autowarefoundation/autoware_launch/assets/25967964/c7725bde-892e-4037-9adc-325c85132b01)

With this PR (lateral_distance_max_threshold = 3m), that does not happen:
[Screencast from 2024年04月25日 00時56分11秒.webm](https://github.com/autowarefoundation/autoware_launch/assets/25967964/f9d6de8f-79fb-41b2-b82d-e0fa991410ec)

## Tests performed

[TIER IV INTERNAL LINK: AUTOMATED TESTS](https://evaluation.tier4.jp/evaluation/reports/db6019ca-0467-522c-89fb-428cb698d378?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
