### PR TITLE
fix: updated pre-commit-hooks-ros version from v0.8.0 to v0.9.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
       - id: yamllint
 
   - repo: https://github.com/tier4/pre-commit-hooks-ros
-    rev: v0.8.0
+    rev: v0.9.0
     hooks:
       - id: flake8-ros
       - id: prettier-xacro


### PR DESCRIPTION
## Description

Updated pre-commit-hooks-ros version from v0.8.0 to v0.9.0

Related issue
* https://github.com/autowarefoundation/autoware_launch/issues/970

I created a tag v0.9.0 in the pre-commit-hooks-ros repository.

https://github.com/tier4/pre-commit-hooks-ros/commit/6f4c0d233fe9901c61c26e0723e93b8144fe5589

This pull request will change to point to it.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
