### PR TITLE
fix(avoidance): add target filtering threshold for merging/deviating vehicle

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/avoidance/avoidance.param.yaml
@@ -132,6 +132,10 @@
           th_shiftable_ratio: 0.8                       # [-]
           min_road_shoulder_width: 0.5                  # [m] FOR DEVELOPER
 
+        # for merging/deviating vehicle
+        merging_vehicle:
+          th_overhang_distance: 0.0                     # [m]
+
         # params for avoidance of vehicle type objects that are ambiguous as to whether they are parked.
         avoidance_for_ambiguous_vehicle:
           enable: true                                  # [-]


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

See https://github.com/autowarefoundation/autoware.universe/pull/6808.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/5caaab91-a83a-57a7-90bb-3e1a1a660519?project_id=prd_jt)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
