### PR TITLE
fix: update traffic topic in autoware.rviz 

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -256,7 +256,7 @@ Visualization Manager:
               Speed Topic: /vehicle/status/velocity_status
               Steering Topic: /vehicle/status/steering_status
               Top: 10
-              Traffic Topic: /perception/traffic_light_recognition/traffic_signals
+              Traffic Topic: /planning/scenario_planning/lane_driving/behavior_planning/debug/traffic_signal
               Turn Signals Topic: /vehicle/status/turn_indicators_status
               Value: true
               Width: 517


### PR DESCRIPTION
## Description

Update the signal display's traffic display topic to : /planning/scenario_planning/lane_driving/behavior_planning/debug/traffic_signal

## Effects on system behavior

Listens to the topic publishing the correct traffic signals data

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
