### PR TITLE
feat(multi_object_tracker): add multi object input config file

### DIFF
--- a/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
@@ -49,13 +49,14 @@
           short_name: "Lpp"
       lidar_pointpainting_validated:
         topic: "/perception/object_recognition/detection/pointpainting/validation/objects"
+        can_spawn_new_tracker: true
         optional:
           name: "pointpainting"
           short_name: "Lpp"
       # CAMERA-LIDAR
       camera_lidar_fusion:
         topic: "/perception/object_recognition/detection/clustering/camera_lidar_fusion/objects"
-        can_spawn_new_tracker: false
+        can_spawn_new_tracker: true
         optional:
           name: "camera_lidar_fusion"
           short_name: "CLf"

--- a/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
@@ -1,0 +1,81 @@
+/**:
+  ros__parameters:
+    input_channels:
+      detected_objects:
+        topic: "/perception/object_recognition/detection/objects"
+        expected_interval: 0.1
+        optional:
+          name: "detected_objects"
+          short_name: "all"
+      # LIDAR - rule-based
+      lidar_clustering:
+        topic: "/perception/object_recognition/detection/clustering/objects"
+        expected_interval: 0.1
+        optional:
+          name: "clustering"
+          short_name: "Lcl"
+      # LIDAR - DNN
+      lidar_centerpoint:
+        topic: "/perception/object_recognition/detection/centerpoint/objects"
+        expected_interval: 0.1
+        optional:
+          name: "centerpoint"
+          short_name: "Lcp"
+      lidar_centerpoint_validated:
+        topic: "/perception/object_recognition/detection/centerpoint/validation/objects"
+        expected_interval: 0.1
+        optional:
+          name: "centerpoint"
+          short_name: "Lcp"
+      lidar_apollo:
+        topic: "/perception/object_recognition/detection/apollo/objects"
+        expected_interval: 0.1
+        optional:
+          name: "apollo"
+          short_name: "Lap"
+      lidar_apollo_validated:
+        topic: "/perception/object_recognition/detection/apollo/validation/objects"
+        expected_interval: 0.1
+        optional:
+          name: "apollo"
+          short_name: "Lap"
+      # LIDAR-CAMERA - DNN
+      lidar_pointpainitng:
+        topic: "/perception/object_recognition/detection/pointpainting/objects"
+        expected_interval: 0.1
+        optional:
+          name: "pointpainting"
+          short_name: "Lpp"
+      lidar_pointpainting_validated:
+        topic: "/perception/object_recognition/detection/pointpainting/validation/objects"
+        expected_interval: 0.1
+        optional:
+          name: "pointpainting"
+          short_name: "Lpp"
+      # CAMERA-LIDAR
+      camera_lidar_fusion:
+        topic: "/perception/object_recognition/detection/clustering/camera_lidar_fusion/objects"
+        expected_interval: 0.1
+        optional:
+          name: "camera_lidar_fusion"
+          short_name: "CLf"
+      # CAMERA-LIDAR+TRACKER
+      detection_by_tracker:
+        topic: "/perception/object_recognition/detection/detection_by_tracker/objects"
+        expected_interval: 0.1
+        optional:
+          name: "detection_by_tracker"
+          short_name: "dbT"
+      # RADAR
+      radar:
+        topic: "/sensing/radar/detected_objects"
+        expected_interval: 0.0333
+        optional:
+          name: "radar"
+          short_name: "R"
+      radar_far:
+        topic: "/perception/object_recognition/detection/radar/far_objects"
+        expected_interval: 0.0333
+        optional:
+          name: "radar_far"
+          short_name: "Rf"

--- a/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
@@ -3,79 +3,79 @@
     input_channels:
       detected_objects:
         topic: "/perception/object_recognition/detection/objects"
-        expected_interval: 0.1
+        can_spawn_new_tracker: true
         optional:
           name: "detected_objects"
           short_name: "all"
       # LIDAR - rule-based
       lidar_clustering:
         topic: "/perception/object_recognition/detection/clustering/objects"
-        expected_interval: 0.1
+        can_spawn_new_tracker: true
         optional:
           name: "clustering"
           short_name: "Lcl"
       # LIDAR - DNN
       lidar_centerpoint:
         topic: "/perception/object_recognition/detection/centerpoint/objects"
-        expected_interval: 0.1
+        can_spawn_new_tracker: true
         optional:
           name: "centerpoint"
           short_name: "Lcp"
       lidar_centerpoint_validated:
         topic: "/perception/object_recognition/detection/centerpoint/validation/objects"
-        expected_interval: 0.1
+        can_spawn_new_tracker: true
         optional:
           name: "centerpoint"
           short_name: "Lcp"
       lidar_apollo:
         topic: "/perception/object_recognition/detection/apollo/objects"
-        expected_interval: 0.1
+        can_spawn_new_tracker: true
         optional:
           name: "apollo"
           short_name: "Lap"
       lidar_apollo_validated:
         topic: "/perception/object_recognition/detection/apollo/validation/objects"
-        expected_interval: 0.1
+        can_spawn_new_tracker: true
         optional:
           name: "apollo"
           short_name: "Lap"
       # LIDAR-CAMERA - DNN
+      # cspell:ignore lidar_pointpainitng pointpainting
       lidar_pointpainitng:
         topic: "/perception/object_recognition/detection/pointpainting/objects"
-        expected_interval: 0.1
+        can_spawn_new_tracker: true
         optional:
           name: "pointpainting"
           short_name: "Lpp"
       lidar_pointpainting_validated:
         topic: "/perception/object_recognition/detection/pointpainting/validation/objects"
-        expected_interval: 0.1
         optional:
           name: "pointpainting"
           short_name: "Lpp"
       # CAMERA-LIDAR
       camera_lidar_fusion:
         topic: "/perception/object_recognition/detection/clustering/camera_lidar_fusion/objects"
-        expected_interval: 0.1
+        can_spawn_new_tracker: false
         optional:
           name: "camera_lidar_fusion"
           short_name: "CLf"
       # CAMERA-LIDAR+TRACKER
       detection_by_tracker:
         topic: "/perception/object_recognition/detection/detection_by_tracker/objects"
-        expected_interval: 0.1
+        can_spawn_new_tracker: false
         optional:
           name: "detection_by_tracker"
           short_name: "dbT"
       # RADAR
       radar:
         topic: "/sensing/radar/detected_objects"
-        expected_interval: 0.0333
+        can_spawn_new_tracker: true
         optional:
           name: "radar"
           short_name: "R"
       radar_far:
         topic: "/perception/object_recognition/detection/radar/far_objects"
-        expected_interval: 0.0333
+        can_spawn_new_tracker: true
         optional:
           name: "radar_far"
           short_name: "Rf"

--- a/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/multi_object_tracker_node.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/multi_object_tracker_node.param.yaml
@@ -13,11 +13,10 @@
     publish_rate: 10.0
     world_frame_id: map
     enable_delay_compensation: true
-    pass_through_unknown_objects: false
-    publish_untracked_objects: false
 
     # debug parameters
     publish_processing_time: true
     publish_tentative_objects: false
+    publish_debug_markers: true
     diagnostics_warn_delay: 0.5      # [sec]
     diagnostics_error_delay: 1.0     # [sec]

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -117,6 +117,10 @@
       value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/tracking/multi_object_tracker/data_association_matrix.param.yaml"
     />
     <arg
+      name="object_recognition_tracking_multi_object_tracker_input_channels_param_path"
+      value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml"
+    />
+    <arg
       name="object_recognition_tracking_multi_object_tracker_node_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/tracking/multi_object_tracker/multi_object_tracker_node.param.yaml"
     />

--- a/autoware_launch/launch/components/tier4_simulator_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_simulator_component.launch.xml
@@ -42,6 +42,10 @@
       value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/tracking/multi_object_tracker/data_association_matrix.param.yaml"
     />
     <arg
+      name="object_recognition_tracking_multi_object_tracker_input_channels_param_path"
+      value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml"
+    />
+    <arg
       name="object_recognition_tracking_multi_object_tracker_node_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/tracking/multi_object_tracker/multi_object_tracker_node.param.yaml"
     />


### PR DESCRIPTION
## Description

Add channel configurations for multi-input multi_object_tracker.

AUTOWARE UNIVERSE PR: https://github.com/autowarefoundation/autoware.universe/pull/6820

[TIER IV INTERNAL](https://tier4.atlassian.net/browse/RT1-6021)

## Tests performed
Test with and without the universe update is performed in a local recompute environment.

## Effects on system behavior
Default value is single input. 
The overall perception pipeline will work as same as before.


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
