### PR TITLE
feat(autoware_launch): add diagnostic graph config for awsim

### DIFF
--- a/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-awsim.yaml
+++ b/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-awsim.yaml
@@ -1,0 +1,6 @@
+files:
+  - { path: $(find-pkg-share system_diagnostic_monitor)/config/autoware-main.yaml }
+
+edits:
+  - { type: remove, path: /autoware/map/topic_rate_check/pointcloud_map }
+  - { type: remove, path: /autoware/system/duplicated_node_checker }

--- a/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-awsim.yaml
+++ b/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-awsim.yaml
@@ -2,5 +2,4 @@ files:
   - { path: $(find-pkg-share system_diagnostic_monitor)/config/autoware-main.yaml }
 
 edits:
-  - { type: remove, path: /autoware/map/topic_rate_check/pointcloud_map }
   - { type: remove, path: /autoware/system/duplicated_node_checker }

--- a/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-main.yaml
+++ b/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-main.yaml
@@ -1,0 +1,2 @@
+files:
+  - { path: $(find-pkg-share system_diagnostic_monitor)/config/autoware-main.yaml }

--- a/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-psim.yaml
+++ b/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-psim.yaml
@@ -1,0 +1,2 @@
+files:
+  - { path: $(find-pkg-share system_diagnostic_monitor)/config/autoware-psim.yaml }

--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -37,7 +37,7 @@
   <arg name="launch_system_monitor" default="true" description="launch system monitor"/>
   <arg name="launch_dummy_diag_publisher" default="false" description="launch dummy diag publisher"/>
   <arg name="system_error_monitor_param_path" default="$(find-pkg-share autoware_launch)/config/system/system_error_monitor/system_error_monitor.param.yaml"/>
-  <arg name="diagnostic_graph_aggregator_graph_path" default="$(find-pkg-share system_diagnostic_monitor)/config/autoware-main.yaml" description="diagnostic graph config"/>
+  <arg name="diagnostic_graph_aggregator_graph_path" default="$(find-pkg-share autoware_launch)/config/system/diagnostic_graph_aggregator/autoware-main.yaml" description="diagnostic graph config"/>
   <!-- Tools -->
   <arg name="rviz" default="true" description="launch rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share autoware_launch)/rviz/autoware.rviz" description="rviz config"/>

--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -37,6 +37,7 @@
   <arg name="launch_system_monitor" default="true" description="launch system monitor"/>
   <arg name="launch_dummy_diag_publisher" default="false" description="launch dummy diag publisher"/>
   <arg name="system_error_monitor_param_path" default="$(find-pkg-share autoware_launch)/config/system/system_error_monitor/system_error_monitor.param.yaml"/>
+  <arg name="diagnostic_graph_aggregator_graph_path" default="$(find-pkg-share system_diagnostic_monitor)/config/autoware-main.yaml" description="diagnostic graph config"/>
   <!-- Tools -->
   <arg name="rviz" default="true" description="launch rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share autoware_launch)/rviz/autoware.rviz" description="rviz config"/>

--- a/autoware_launch/launch/components/tier4_system_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_system_component.launch.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="system_error_monitor_param_path" default="$(find-pkg-share autoware_launch)/config/system/system_error_monitor/system_error_monitor.param.yaml"/>
+  <arg name="diagnostic_graph_aggregator_graph_path" default="$(find-pkg-share system_diagnostic_monitor)/config/autoware-main.yaml"/>
 
   <include file="$(find-pkg-share tier4_system_launch)/launch/system.launch.xml">
     <arg name="run_mode" value="$(var system_run_mode)"/>
@@ -30,7 +31,6 @@
     <arg name="use_emergency_handler" value="true"/>
     <arg name="mrm_handler_param_path" value="$(find-pkg-share autoware_launch)/config/system/mrm_handler/mrm_handler.param.yaml"/>
     <arg name="diagnostic_graph_aggregator_param_path" value="$(find-pkg-share diagnostic_graph_aggregator)/config/default.param.yaml"/>
-    <arg name="diagnostic_graph_aggregator_graph_path_main" value="$(find-pkg-share system_diagnostic_monitor)/config/autoware-main.yaml"/>
-    <arg name="diagnostic_graph_aggregator_graph_path_psim" value="$(find-pkg-share system_diagnostic_monitor)/config/autoware-psim.yaml"/>
+    <arg name="diagnostic_graph_aggregator_graph_path" value="$(var diagnostic_graph_aggregator_graph_path)"/>
   </include>
 </launch>

--- a/autoware_launch/launch/components/tier4_system_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_system_component.launch.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 <launch>
   <arg name="system_error_monitor_param_path" default="$(find-pkg-share autoware_launch)/config/system/system_error_monitor/system_error_monitor.param.yaml"/>
-  <arg name="diagnostic_graph_aggregator_graph_path" default="$(find-pkg-share system_diagnostic_monitor)/config/autoware-main.yaml"/>
+  <arg name="diagnostic_graph_aggregator_param_path" default="$(find-pkg-share diagnostic_graph_aggregator)/config/default.param.yaml"/>
+  <arg name="diagnostic_graph_aggregator_graph_path" default="$(find-pkg-share autoware_launch)/config/system/diagnostic_graph_aggregator/autoware-main.yaml"/>
 
   <include file="$(find-pkg-share tier4_system_launch)/launch/system.launch.xml">
     <arg name="run_mode" value="$(var system_run_mode)"/>
@@ -30,7 +31,7 @@
 
     <arg name="use_emergency_handler" value="true"/>
     <arg name="mrm_handler_param_path" value="$(find-pkg-share autoware_launch)/config/system/mrm_handler/mrm_handler.param.yaml"/>
-    <arg name="diagnostic_graph_aggregator_param_path" value="$(find-pkg-share diagnostic_graph_aggregator)/config/default.param.yaml"/>
+    <arg name="diagnostic_graph_aggregator_param_path" value="$(var diagnostic_graph_aggregator_param_path)"/>
     <arg name="diagnostic_graph_aggregator_graph_path" value="$(var diagnostic_graph_aggregator_graph_path)"/>
   </include>
 </launch>

--- a/autoware_launch/launch/e2e_simulator.launch.xml
+++ b/autoware_launch/launch/e2e_simulator.launch.xml
@@ -72,6 +72,7 @@
       <arg name="launch_system_monitor" value="$(var launch_system_monitor)"/>
       <arg name="launch_dummy_diag_publisher" value="$(var launch_dummy_diag_publisher)"/>
       <arg name="system_error_monitor_param_path" value="$(var system_error_monitor_param_path)"/>
+      <arg name="diagnostic_graph_aggregator_graph_path" value="$(find-pkg-share autoware_launch)/config/system/diagnostic_graph_aggregator/autoware-awsim.yaml"/>
       <!-- Sensing -->
       <arg name="launch_sensing_driver" value="false"/>
       <!-- Perception-->

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -63,6 +63,7 @@
       <arg name="system_run_mode" value="logging_simulation"/>
       <arg name="launch_system_monitor" value="$(var launch_system_monitor)"/>
       <arg name="launch_dummy_diag_publisher" value="$(var launch_dummy_diag_publisher)"/>
+      <arg name="diagnostic_graph_aggregator_graph_path" value="$(find-pkg-share system_diagnostic_monitor)/config/autoware-main.yaml"/>
       <!-- Map -->
       <arg name="lanelet2_map_file" value="$(var lanelet2_map_file)"/>
       <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -63,7 +63,7 @@
       <arg name="system_run_mode" value="logging_simulation"/>
       <arg name="launch_system_monitor" value="$(var launch_system_monitor)"/>
       <arg name="launch_dummy_diag_publisher" value="$(var launch_dummy_diag_publisher)"/>
-      <arg name="diagnostic_graph_aggregator_graph_path" value="$(find-pkg-share system_diagnostic_monitor)/config/autoware-main.yaml"/>
+      <arg name="diagnostic_graph_aggregator_graph_path" value="$(find-pkg-share autoware_launch)/config/system/diagnostic_graph_aggregator/autoware-main.yaml"/>
       <!-- Map -->
       <arg name="lanelet2_map_file" value="$(var lanelet2_map_file)"/>
       <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -61,7 +61,7 @@
       <arg name="system_run_mode" value="planning_simulation"/>
       <arg name="launch_system_monitor" value="$(var launch_system_monitor)"/>
       <arg name="launch_dummy_diag_publisher" value="$(var launch_dummy_diag_publisher)"/>
-      <arg name="diagnostic_graph_aggregator_graph_path" value="$(find-pkg-share system_diagnostic_monitor)/config/autoware-psim.yaml"/>
+      <arg name="diagnostic_graph_aggregator_graph_path" value="$(find-pkg-share autoware_launch)/config/system/diagnostic_graph_aggregator/autoware-psim.yaml"/>
       <!-- Map -->
       <arg name="lanelet2_map_file" value="$(var lanelet2_map_file)"/>
       <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -61,6 +61,7 @@
       <arg name="system_run_mode" value="planning_simulation"/>
       <arg name="launch_system_monitor" value="$(var launch_system_monitor)"/>
       <arg name="launch_dummy_diag_publisher" value="$(var launch_dummy_diag_publisher)"/>
+      <arg name="diagnostic_graph_aggregator_graph_path" value="$(find-pkg-share system_diagnostic_monitor)/config/autoware-psim.yaml"/>
       <!-- Map -->
       <arg name="lanelet2_map_file" value="$(var lanelet2_map_file)"/>
       <arg name="pointcloud_map_file" value="$(var pointcloud_map_file)"/>


### PR DESCRIPTION
## Description

Since `diagnostic_graph_aggregator_graph_path` depends on the simulator, I made it possible to specify the path from each launch file. This will replace `system_error_monitor_param_path`. See this [discussion](https://github.com/orgs/autowarefoundation/discussions/4176) for details.

This PR be merged with https://github.com/autowarefoundation/autoware.universe/pull/7133 at the same time.

## Tests performed

Diagnostics determine the transition to autonomous mode. So I confirmed whether it was possible to transition to autonomous mode in each simulation. (Logging simulation is not applicable as it does not require a mode change.)
- Run planning simulation (check if it can drive in autonomous mode)
- Run logging simulation (check if the rosbag is visualized with rviz)
- Run E2E simulation (check if it can drive in autonomous mode)

## Effects on system behavior

The new settings are made to be compatible with system_error_monitor's.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
