### PR TITLE
fix(rviz): remove StringStampedOverlayDisplay reference

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -3608,22 +3608,6 @@ Visualization Manager:
                   Value: true
               Enabled: true
               Name: Objects Of Interest
-            - Class: rviz_plugins/StringStampedOverlayDisplay
-              Enabled: true
-              Font Size: 15
-              Left: 1024
-              Max Letter Num: 100
-              Name: StringStampedOverlayDisplay
-              Text Color: 25; 255; 240
-              Top: 128
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Reliable
-                Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/internal_state
-              Value: true
-              Value height offset: 0
           Enabled: true
           Name: Planning
         - Class: rviz_common/Group


### PR DESCRIPTION
## Description

### How to reproduce the bug

Compile Autoware, run planning_sim demo.
(with `ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit`)

### Bug

You will get this red rviz error. (But it will still work)
```console
[rviz2-43] [ERROR 1716801553.757691599] [rviz2]: PluginlibFactory: The plugin for class 'rviz_plugins/StringStampedOverlayDisplay' failed to load. Error: According to the loaded plugin descriptions the class rviz_plugins/StringStampedOverlayDisplay with base class type rviz_common::Display does not exist. Declared types are  autoware_auto_perception_rviz_plugin/DetectedObjects autoware_auto_perception_rviz_plugin/PredictedObjects autoware_auto_perception_rviz_plugin/TrackedObjects autoware_mission_details_overlay_rviz_plugin/MissionDetailsDisplay autoware_overlay_rviz_plugin/SignalDisplay grid_map_rviz_plugin/GridMap rviz_default_plugins/AccelStamped rviz_default_plugins/Axes rviz_default_plugins/Camera rviz_default_plugins/DepthCloud rviz_default_plugins/Effort rviz_default_plugins/FluidPressure rviz_default_plugins/Grid rviz_default_plugins/GridCells rviz_default_plugins/Illuminance rviz_default_plugins/Image rviz_default_plugins/InteractiveMarkers rviz_default_plugins/LaserScan rviz_default_plugins/Map rviz_default_plugins/Marker rviz_default_plugins/MarkerArray rviz_default_plugins/Odometry rviz_default_plugins/Path rviz_default_plugins/PointCloud rviz_default_plugins/PointCloud2 rviz_default_plugins/PointStamped rviz_default_plugins/Polygon rviz_default_plugins/Pose rviz_default_plugins/PoseArray rviz_default_plugins/PoseWithCovariance rviz_default_plugins/Range rviz_default_plugins/RelativeHumidity rviz_default_plugins/RobotModel rviz_default_plugins/TF rviz_default_plugins/Temperature rviz_default_plugins/TwistStamped rviz_default_plugins/Wrench rviz_plugins/AccelerationMeter rviz_plugins/ConsoleMeter rviz_plugins/MaxVelocity rviz_plugins/MrmSummaryOverlayDisplay rviz_plugins/Path rviz_plugins/PathWithLaneId rviz_plugins/PolarGridDisplay rviz_plugins/PoseWithUuidStamped rviz_plugins/SteeringAngle rviz_plugins/Trajectory rviz_plugins/TurnSignal rviz_plugins/VelocityHistory rviz_plugins::PoseHistory rviz_plugins::PoseHistoryFootprint (operator()() at ./src/main.cpp:68)
```

### Cause

When this PR merged:
- https://github.com/autowarefoundation/autoware.universe/pull/7015

It removed so many plugins from universe. And moved them to tools.repos file.

`common/tier4_debug_rviz_plugin/include/tier4_debug_rviz_plugin/string_stamped.hpp` This package specifically.

If you don't have tools.repos downloaded, it will give this error now.

### Fix

If something is not in the autoware.repos, it should not be referenced from the default rviz. So I'm removing this.

## Tests performed

Ran the planning sim demo, it worked without errors ✅

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
