### PR TITLE
revert(map_based_prediction): use different time horizon (#967)

### DIFF
--- a/autoware_launch/config/perception/object_recognition/prediction/map_based_prediction.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/prediction/map_based_prediction.param.yaml
@@ -1,10 +1,7 @@
 /**:
   ros__parameters:
     enable_delay_compensation: true
-    prediction_time_horizon:
-      vehicle: 15.0 #[s]
-      pedestrian: 10.0 #[s]
-      unknown: 10.0 #[s]
+    prediction_time_horizon: 10.0 #[s]
     lateral_control_time_horizon: 5.0 #[s]
     prediction_sampling_delta_time: 0.5 #[s]
     min_velocity_for_map_based_prediction: 1.39 #[m/s]


### PR DESCRIPTION
## Description

this PR is not ready
https://github.com/autowarefoundation/autoware_launch/pull/967

## Related links

this PR is not ready
https://github.com/autowarefoundation/autoware_launch/pull/967

## Tests performed

this is revert

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

none

## Effects on system behavior

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [X] The PR follows the [pull request guidelines].
- [X] The PR has been properly tested.
- [X] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [X] There are no open discussions or they are tracked via tickets.
- [X] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
