### PR TITLE
feat: rename autoware_auto_perception_rviz_plugin to autoware_perception_rviz_plugin

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -687,7 +687,7 @@ Visualization Manager:
                   CYCLIST:
                     Alpha: 0.999
                     Color: 119; 11; 32
-                  Class: autoware_auto_perception_rviz_plugin/DetectedObjects
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
                   Display 3d polygon: true
                   Display Label: true
                   Display PoseWithCovariance: true
@@ -735,7 +735,7 @@ Visualization Manager:
                   CYCLIST:
                     Alpha: 0.999
                     Color: 119; 11; 32
-                  Class: autoware_auto_perception_rviz_plugin/TrackedObjects
+                  Class: autoware_perception_rviz_plugin/TrackedObjects
                   Display 3d polygon: true
                   Display Label: true
                   Display PoseWithCovariance: true
@@ -783,7 +783,7 @@ Visualization Manager:
                   CYCLIST:
                     Alpha: 0.999
                     Color: 119; 11; 32
-                  Class: autoware_auto_perception_rviz_plugin/PredictedObjects
+                  Class: autoware_perception_rviz_plugin/PredictedObjects
                   Display 3d polygon: true
                   Display Label: true
                   Display PoseWithCovariance: false
@@ -2748,7 +2748,7 @@ Visualization Manager:
               CYCLIST:
                 Alpha: 0.5
                 Color: 255; 255; 255
-              Class: autoware_auto_perception_rviz_plugin/DetectedObjects
+              Class: autoware_perception_rviz_plugin/DetectedObjects
               Display Acceleration: true
               Display Label: true
               Display PoseWithCovariance: true
@@ -2905,7 +2905,7 @@ Visualization Manager:
               CYCLIST:
                 Alpha: 0.9990000128746033
                 Color: 255; 138; 128
-              Class: autoware_auto_perception_rviz_plugin/DetectedObjects
+              Class: autoware_perception_rviz_plugin/DetectedObjects
               Display Acceleration: true
               Display Label: true
               Display PoseWithCovariance: true
@@ -2952,7 +2952,7 @@ Visualization Manager:
               CYCLIST:
                 Alpha: 0.9990000128746033
                 Color: 255; 82; 82
-              Class: autoware_auto_perception_rviz_plugin/DetectedObjects
+              Class: autoware_perception_rviz_plugin/DetectedObjects
               Display Acceleration: true
               Display Label: true
               Display PoseWithCovariance: true
@@ -2999,7 +2999,7 @@ Visualization Manager:
               CYCLIST:
                 Alpha: 0.9990000128746033
                 Color: 213; 0; 0
-              Class: autoware_auto_perception_rviz_plugin/DetectedObjects
+              Class: autoware_perception_rviz_plugin/DetectedObjects
               Display Acceleration: true
               Display Label: true
               Display PoseWithCovariance: true
@@ -3046,7 +3046,7 @@ Visualization Manager:
               CYCLIST:
                 Alpha: 0.9990000128746033
                 Color: 178; 255; 89
-              Class: autoware_auto_perception_rviz_plugin/DetectedObjects
+              Class: autoware_perception_rviz_plugin/DetectedObjects
               Display Acceleration: true
               Display Label: true
               Display PoseWithCovariance: true
@@ -3093,7 +3093,7 @@ Visualization Manager:
               CYCLIST:
                 Alpha: 0.9990000128746033
                 Color: 118; 255; 3
-              Class: autoware_auto_perception_rviz_plugin/DetectedObjects
+              Class: autoware_perception_rviz_plugin/DetectedObjects
               Display Acceleration: true
               Display Label: true
               Display PoseWithCovariance: true
@@ -3140,7 +3140,7 @@ Visualization Manager:
               CYCLIST:
                 Alpha: 0.9990000128746033
                 Color: 100; 221; 23
-              Class: autoware_auto_perception_rviz_plugin/DetectedObjects
+              Class: autoware_perception_rviz_plugin/DetectedObjects
               Display Acceleration: true
               Display Label: true
               Display PoseWithCovariance: true
@@ -3187,7 +3187,7 @@ Visualization Manager:
               CYCLIST:
                 Alpha: 0.9990000128746033
                 Color: 255; 145; 0
-              Class: autoware_auto_perception_rviz_plugin/DetectedObjects
+              Class: autoware_perception_rviz_plugin/DetectedObjects
               Display Acceleration: true
               Display Label: true
               Display PoseWithCovariance: true
@@ -3234,7 +3234,7 @@ Visualization Manager:
               CYCLIST:
                 Alpha: 0.9990000128746033
                 Color: 213; 0; 249
-              Class: autoware_auto_perception_rviz_plugin/DetectedObjects
+              Class: autoware_perception_rviz_plugin/DetectedObjects
               Display Acceleration: true
               Display Label: true
               Display PoseWithCovariance: true
@@ -3281,7 +3281,7 @@ Visualization Manager:
               CYCLIST:
                 Alpha: 0.9990000128746033
                 Color: 255; 255; 255
-              Class: autoware_auto_perception_rviz_plugin/DetectedObjects
+              Class: autoware_perception_rviz_plugin/DetectedObjects
               Display Acceleration: true
               Display Label: true
               Display PoseWithCovariance: true
@@ -3328,7 +3328,7 @@ Visualization Manager:
               CYCLIST:
                 Alpha: 0.9990000128746033
                 Color: 255; 234; 0
-              Class: autoware_auto_perception_rviz_plugin/DetectedObjects
+              Class: autoware_perception_rviz_plugin/DetectedObjects
               Display Acceleration: true
               Display Label: true
               Display PoseWithCovariance: true
@@ -3375,7 +3375,7 @@ Visualization Manager:
               CYCLIST:
                 Alpha: 0.9990000128746033
                 Color: 0; 230; 118
-              Class: autoware_auto_perception_rviz_plugin/TrackedObjects
+              Class: autoware_perception_rviz_plugin/TrackedObjects
               Display Acceleration: true
               Display Label: true
               Display PoseWithCovariance: true
@@ -3422,7 +3422,7 @@ Visualization Manager:
               CYCLIST:
                 Alpha: 0.9990000128746033
                 Color: 0; 176; 255
-              Class: autoware_auto_perception_rviz_plugin/PredictedObjects
+              Class: autoware_perception_rviz_plugin/PredictedObjects
               Display Acceleration: true
               Display Label: true
               Display PoseWithCovariance: false


### PR DESCRIPTION
## Description

Rename plugin name from autoware_auto_perception_rviz_plugin to autoware_perception_rviz_plugin
This must be merged with https://github.com/autowarefoundation/autoware.universe/pull/7221.

## Tests performed
Locally tested with planning_simulator that dummy obstacles are still visible after the update.
![image](https://github.com/autowarefoundation/autoware_launch/assets/43976834/267ba366-4826-4644-845e-77727ddbaa8e)



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
