### PR TITLE
refactor(start_planner): remove unused parameters in start planner module

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -26,7 +26,6 @@
       allow_check_shift_path_lane_departure_override: false
       shift_collision_check_distance_from_end: -10.0
       minimum_shift_pull_out_distance: 0.0
-      deceleration_interval: 15.0
       maximum_longitudinal_deviation: 1.0 # Note, should be the same or less than planning validator's "longitudinal_distance_deviation"
       lateral_jerk: 0.5
       lateral_acceleration_sampling_num: 3
@@ -38,7 +37,6 @@
       geometric_collision_check_distance_from_end: 0.0
       divide_pull_out_path: true
       geometric_pull_out_velocity: 1.0
-      arc_path_interval: 1.0
       lane_departure_margin: 0.2
       lane_departure_check_expansion_margin: 0.0
       backward_velocity: -1.0
@@ -52,9 +50,6 @@
       ignore_distance_from_lane_end: 15.0
       # turns signal
       prepare_time_before_start: 0.0
-      th_turn_signal_on_lateral_offset: 1.0
-      intersection_search_length: 30.0
-      length_ratio_for_turn_signal_deactivation_near_intersection: 0.5
       # freespace planner
       freespace_planner:
         enable_freespace_planner: true


### PR DESCRIPTION
## Description

- remove unused param
  - deceleration_interval
  - arc_path_interval
  - th_turn_signal_on_lateral_offset
  - intersection_search_length
  - length_ratio_for_turn_signal_deactivation_near_intersection

related with the [PR](https://github.com/autowarefoundation/autoware.universe/pull/7430)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

run psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
