### PR TITLE
feat(autonomous_emergency_braking): add params to enable or disable PC and predicted objects

### DIFF
--- a/autoware_launch/config/control/autoware_autonomous_emergency_braking/autonomous_emergency_braking.param.yaml
+++ b/autoware_launch/config/control/autoware_autonomous_emergency_braking/autonomous_emergency_braking.param.yaml
@@ -3,6 +3,8 @@
     # Ego path calculation
     use_predicted_trajectory: true
     use_imu_path: false
+    use_pointcloud_data: true
+    use_predicted_object_data: true
     use_object_velocity_calculation: true
     min_generated_path_length: 0.5
     imu_prediction_time_horizon: 1.5

--- a/autoware_launch/config/control/autoware_autonomous_emergency_braking/autonomous_emergency_braking.param.yaml
+++ b/autoware_launch/config/control/autoware_autonomous_emergency_braking/autonomous_emergency_braking.param.yaml
@@ -4,7 +4,7 @@
     use_predicted_trajectory: true
     use_imu_path: false
     use_pointcloud_data: true
-    use_predicted_object_data: true
+    use_predicted_object_data: false
     use_object_velocity_calculation: true
     min_generated_path_length: 0.5
     imu_prediction_time_horizon: 1.5


### PR DESCRIPTION
## Description

Required by https://github.com/autowarefoundation/autoware.universe/pull/7548

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
