### PR TITLE
feat(autoware_launch): use mrm handler by default

### DIFF
--- a/autoware_launch/launch/components/tier4_system_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_system_component.launch.xml
@@ -29,7 +29,7 @@
     <arg name="system_monitor_process_monitor_param_path" value="$(find-pkg-share autoware_launch)/config/system/system_monitor/process_monitor.param.yaml"/>
     <arg name="system_monitor_voltage_monitor_param_path" value="$(find-pkg-share autoware_launch)/config/system/system_monitor/voltage_monitor.param.yaml"/>
 
-    <arg name="use_emergency_handler" value="true"/>
+    <arg name="use_emergency_handler" value="false"/>
     <arg name="mrm_handler_param_path" value="$(find-pkg-share autoware_launch)/config/system/mrm_handler/mrm_handler.param.yaml"/>
     <arg name="diagnostic_graph_aggregator_param_path" value="$(var diagnostic_graph_aggregator_param_path)"/>
     <arg name="diagnostic_graph_aggregator_graph_path" value="$(var diagnostic_graph_aggregator_graph_path)"/>


### PR DESCRIPTION
## Description

See https://github.com/autowarefoundation/autoware.universe/pull/7728.

## Related links

**Parent Issue:**

- https://github.com/orgs/autowarefoundation/discussions/4176
- https://github.com/autowarefoundation/autoware.universe/pull/7728

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
