### PR TITLE
feat(behavior_path_planner): remove max_module_size param

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
@@ -9,7 +9,6 @@
       enable_simultaneous_execution_as_candidate_module: true
       keep_last: false
       priority: 6
-      max_module_size: 1
 
     external_request_lane_change_right:
       enable_rtc: false
@@ -17,7 +16,6 @@
       enable_simultaneous_execution_as_candidate_module: true
       keep_last: false
       priority: 6
-      max_module_size: 1
 
     lane_change_left:
       enable_rtc: false
@@ -25,7 +23,6 @@
       enable_simultaneous_execution_as_candidate_module: true
       keep_last: false
       priority: 5
-      max_module_size: 1
 
     lane_change_right:
       enable_rtc: false
@@ -33,7 +30,6 @@
       enable_simultaneous_execution_as_candidate_module: true
       keep_last: false
       priority: 5
-      max_module_size: 1
 
     start_planner:
       enable_rtc: false
@@ -41,7 +37,6 @@
       enable_simultaneous_execution_as_candidate_module: false
       keep_last: false
       priority: 0
-      max_module_size: 1
 
     side_shift:
       enable_rtc: false
@@ -49,7 +44,6 @@
       enable_simultaneous_execution_as_candidate_module: false
       keep_last: false
       priority: 2
-      max_module_size: 1
 
     goal_planner:
       enable_rtc: false
@@ -57,7 +51,6 @@
       enable_simultaneous_execution_as_candidate_module: false
       keep_last: true
       priority: 1
-      max_module_size: 1
 
     static_obstacle_avoidance:
       enable_rtc: false
@@ -65,7 +58,6 @@
       enable_simultaneous_execution_as_candidate_module: false
       keep_last: false
       priority: 4
-      max_module_size: 1
 
     avoidance_by_lane_change:
       enable_rtc: false
@@ -73,7 +65,6 @@
       enable_simultaneous_execution_as_candidate_module: false
       keep_last: false
       priority: 3
-      max_module_size: 1
 
     dynamic_obstacle_avoidance:
       enable_rtc: false
@@ -81,7 +72,6 @@
       enable_simultaneous_execution_as_candidate_module: true
       keep_last: true
       priority: 7
-      max_module_size: 1
 
     sampling_planner:
       enable_module: true
@@ -90,4 +80,3 @@
       enable_simultaneous_execution_as_candidate_module: false
       keep_last: false
       priority: 16
-      max_module_size: 1


### PR DESCRIPTION
## Description
The max_module_size param has been removed from the behavior_path_planner scene_module_manager.param.yaml file. This param was unnecessary and has been removed to simplify the configuration.

parameter change for the [PR](https://github.com/autowarefoundation/autoware.universe/pull/7764)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] run psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
