### PR TITLE
revert(autoware_launch): "feat(autoware_launch): use mrm handler by default (#1043)"

### DIFF
--- a/autoware_launch/launch/components/tier4_system_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_system_component.launch.xml
@@ -29,7 +29,7 @@
     <arg name="system_monitor_process_monitor_param_path" value="$(find-pkg-share autoware_launch)/config/system/system_monitor/process_monitor.param.yaml"/>
     <arg name="system_monitor_voltage_monitor_param_path" value="$(find-pkg-share autoware_launch)/config/system/system_monitor/voltage_monitor.param.yaml"/>
 
-    <arg name="use_emergency_handler" value="false"/>
+    <arg name="use_emergency_handler" value="true"/>
     <arg name="mrm_handler_param_path" value="$(find-pkg-share autoware_launch)/config/system/mrm_handler/mrm_handler.param.yaml"/>
     <arg name="diagnostic_graph_aggregator_param_path" value="$(var diagnostic_graph_aggregator_param_path)"/>
     <arg name="diagnostic_graph_aggregator_graph_path" value="$(var diagnostic_graph_aggregator_graph_path)"/>


### PR DESCRIPTION
This reverts commit d076aa5f93f4016bcd772a22094f44d93deeecaa.

## Description

My understanding is that previously there was a process to ignore the emergency state before route setting. However, by switching to the diagnostics graph, a problem arose where the state becomes emergency when scenario_simulator_v2 starts up, causing the simulation to fail.
I propose temporarily pending the switch to the diagnostics graph until this issue is fixed.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] [PASS TIERIV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/a6a34689-6107-5c1c-b4bb-672b4406e591?project_id=prd_jt)
- [x] run sceanrio_simulator_v2 in local environment

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
