### PR TITLE
chore(eagleye): add septentrio msg option in eagleye_config

### DIFF
--- a/autoware_launch/config/localization/eagleye_config.param.yaml
+++ b/autoware_launch/config/localization/eagleye_config.param.yaml
@@ -10,7 +10,7 @@
       twist_topic: /sensing/vehicle_velocity_converter/twist_with_covariance
     imu_topic: /sensing/imu/imu_data
     gnss:
-      velocity_source_type: 2 # rtklib_msgs/RtklibNav: 0, nmea_msgs/Sentence: 1, ublox_msgs/NavPVT: 2, geometry_msgs/TwistWithCovarianceStamped: 3
+      velocity_source_type: 2 # rtklib_msgs/RtklibNav: 0, nmea_msgs/Sentence: 1, ublox_msgs/NavPVT: 2, geometry_msgs/TwistWithCovarianceStamped: 3, septentrio_gnss_driver/PVTGeodetic: 4
       velocity_source_topic: /sensing/gnss/ublox/navpvt
       llh_source_type: 2 # rtklib_msgs/RtklibNav: 0, nmea_msgs/Sentence: 1, sensor_msgs/NavSatFix: 2
       llh_source_topic: /sensing/gnss/ublox/nav_sat_fix


### PR DESCRIPTION
## Description

From today, Eagleye has been applicable to `septentrio_gnss_driver/PVTGeodetic` type topic messages as a velocity source.
https://github.com/MapIV/eagleye/pull/334

So, I wrote that down to the comment in `eagleye_config.param.yaml` file.

## Tests performed

I've tested this against a driving data that uses septentrio GNSS sensors by setting the `velocity_source_type` to 4, and confirmed that the latest Eagleye works well with this. [[INTERNAL_LINK(TIER IV)](https://tier4.atlassian.net/wiki/x/CwFRvg)]

## Effects on system behavior

You can use `septentrio_gnss_driver/PVTGeodetic` type messages to give ENU velocity to Eagleye.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
