### PR TITLE
feat(pid_longitudinal_controller): re-organize diff limit structure

### DIFF
--- a/autoware_launch/config/control/trajectory_follower/longitudinal/pid.param.yaml
+++ b/autoware_launch/config/control/trajectory_follower/longitudinal/pid.param.yaml
@@ -58,6 +58,7 @@
     # emergency state
     emergency_vel: 0.0
     emergency_acc: -5.0 # denotes acceleration
+    emergency_jerk: -3.0
 
     # acceleration limit
     max_acc: 3.0
@@ -66,7 +67,7 @@
     # jerk limit
     max_jerk: 2.0
     min_jerk: -5.0
-    max_pedal_pos_diff_rate: 50.0 # [m/s^2 * s^-1]
+    max_acc_cmd_diff_rate: 50.0 # [m/s^2 * s^-1]
 
     # slope compensation
     lpf_pitch_gain: 0.95

--- a/autoware_launch/config/control/trajectory_follower/longitudinal/pid.param.yaml
+++ b/autoware_launch/config/control/trajectory_follower/longitudinal/pid.param.yaml
@@ -67,7 +67,7 @@
     # jerk limit
     max_jerk: 2.0
     min_jerk: -5.0
-    max_acc_cmd_diff_rate: 50.0 # [m/s^2 * s^-1]
+    max_acc_cmd_diff: 50.0 # [m/s^2 * s^-1]
 
     # slope compensation
     lpf_pitch_gain: 0.95

--- a/autoware_launch/config/control/trajectory_follower/longitudinal/pid.param.yaml
+++ b/autoware_launch/config/control/trajectory_follower/longitudinal/pid.param.yaml
@@ -66,7 +66,7 @@
     # jerk limit
     max_jerk: 2.0
     min_jerk: -5.0
-    max_pedal_pos_diff_rate: 30.0 # [m/s^2 * s^-1]
+    max_pedal_pos_diff_rate: 50.0 # [m/s^2 * s^-1]
 
     # slope compensation
     lpf_pitch_gain: 0.95

--- a/autoware_launch/config/control/trajectory_follower/longitudinal/pid.param.yaml
+++ b/autoware_launch/config/control/trajectory_follower/longitudinal/pid.param.yaml
@@ -53,13 +53,11 @@
 
     # stopped state
     stopped_vel: 0.0
-    stopped_acc: -3.4
-    stopped_jerk: -5.0
+    stopped_acc: -3.4 # denotes pedal position
 
     # emergency state
     emergency_vel: 0.0
-    emergency_acc: -5.0
-    emergency_jerk: -3.0
+    emergency_acc: -5.0 # denotes acceleration
 
     # acceleration limit
     max_acc: 3.0
@@ -68,6 +66,7 @@
     # jerk limit
     max_jerk: 2.0
     min_jerk: -5.0
+    max_pedal_pos_diff_rate: 30.0 # [m/s^2 * s^-1]
 
     # slope compensation
     lpf_pitch_gain: 0.95


### PR DESCRIPTION
## Description
launch side PR corresponds to a universe PR https://github.com/autowarefoundation/autoware.universe/pull/7720

## Tests performed
see universe PR

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
