### PR TITLE
ci(pre-commit-autoupdate): add new workflow

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -1,0 +1,37 @@
+name: pre-commit-autoupdate
+
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+
+jobs:
+  check-secret:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/check-secret.yaml@v1
+    secrets:
+      secret: ${{ secrets.APP_ID }}
+
+  pre-commit-autoupdate:
+    needs: check-secret
+    if: ${{ needs.check-secret.outputs.set == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Run pre-commit-autoupdate
+        uses: autowarefoundation/autoware-github-actions/pre-commit-autoupdate@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          pre-commit-config: .pre-commit-config.yaml
+          pr-labels: |
+            tag:bot
+            tag:pre-commit-autoupdate
+          pr-branch: pre-commit-autoupdate
+          pr-title: "ci(pre-commit): autoupdate"
+          pr-commit-message: "ci(pre-commit): autoupdate"
+          auto-merge-method: squash


### PR DESCRIPTION
## Description

Add `pre-commit-autoupdate` from:
- https://github.com/autowarefoundation/autoware_common/blob/a7e776a47e309fba1b1ab7c14ecd2d51aa2e39f7/.github/workflows/pre-commit-autoupdate.yaml

We can set up the sync-files job later.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
