### PR TITLE
feat(vehicle_cmd_gate): change param to relax pedal rate limit when the vehicle velocity is slow enough

### DIFF
--- a/autoware_launch/config/control/vehicle_cmd_gate/vehicle_cmd_gate.param.yaml
+++ b/autoware_launch/config/control/vehicle_cmd_gate/vehicle_cmd_gate.param.yaml
@@ -16,14 +16,14 @@
     stop_check_duration: 1.0
     nominal:
       vel_lim: 25.0
-      reference_speed_points: [20.0, 30.0]
-      steer_lim: [1.0, 0.8]
-      steer_rate_lim: [1.0, 0.8]
-      lon_acc_lim: [5.0, 4.0]
-      lon_jerk_lim: [5.0, 4.0]
-      lat_acc_lim: [5.0, 4.0]
-      lat_jerk_lim: [7.0, 6.0]
-      actual_steer_diff_lim: [1.0, 0.8]
+      reference_speed_points: [0.1, 0.3, 20.0, 30.0]
+      steer_lim: [1.0, 1.0, 1.0, 0.8]
+      steer_rate_lim: [1.0, 1.0, 1.0, 0.8]
+      lon_acc_lim: [5.0, 5.0, 5.0, 4.0]
+      lon_jerk_lim: [80.0, 5.0, 5.0, 4.0]
+      lat_acc_lim: [5.0, 5.0, 5.0, 4.0]
+      lat_jerk_lim: [7.0, 7.0, 7.0, 6.0]
+      actual_steer_diff_lim: [1.0, 1.0, 1.0, 0.8]
     on_transition:
       vel_lim: 50.0
       reference_speed_points: [20.0, 30.0]

--- a/autoware_launch/config/control/vehicle_cmd_gate/vehicle_cmd_gate.param.yaml
+++ b/autoware_launch/config/control/vehicle_cmd_gate/vehicle_cmd_gate.param.yaml
@@ -20,7 +20,7 @@
       steer_lim: [1.0, 1.0, 1.0, 0.8]
       steer_rate_lim: [1.0, 1.0, 1.0, 0.8]
       lon_acc_lim: [5.0, 5.0, 5.0, 4.0]
-      lon_jerk_lim: [80.0, 5.0, 5.0, 4.0] # The first element is required for quick pedal changes when stopping and starting on a slope.
+      lon_jerk_lim: [80.0, 5.0, 5.0, 4.0] # The first element is required for quick pedal changes when stopping and starting.
       lat_acc_lim: [5.0, 5.0, 5.0, 4.0]
       lat_jerk_lim: [7.0, 7.0, 7.0, 6.0]
       actual_steer_diff_lim: [1.0, 1.0, 1.0, 0.8]

--- a/autoware_launch/config/control/vehicle_cmd_gate/vehicle_cmd_gate.param.yaml
+++ b/autoware_launch/config/control/vehicle_cmd_gate/vehicle_cmd_gate.param.yaml
@@ -20,7 +20,7 @@
       steer_lim: [1.0, 1.0, 1.0, 0.8]
       steer_rate_lim: [1.0, 1.0, 1.0, 0.8]
       lon_acc_lim: [5.0, 5.0, 5.0, 4.0]
-      lon_jerk_lim: [80.0, 5.0, 5.0, 4.0]
+      lon_jerk_lim: [80.0, 5.0, 5.0, 4.0] # The first element is required for quick pedal changes when stopping and starting on a slope.
       lat_acc_lim: [5.0, 5.0, 5.0, 4.0]
       lat_jerk_lim: [7.0, 7.0, 7.0, 6.0]
       actual_steer_diff_lim: [1.0, 1.0, 1.0, 0.8]


### PR DESCRIPTION
## Description
This PR relax the pedal rate limit value when the vehicle velocity is slow enough to achieve stop/go on the slopes.

universe PR: https://github.com/autowarefoundation/autoware.universe/pull/7720

## Tests performed
I have tested this change by two type of real vehicles.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
