### PR TITLE
feat(dynamic_obstacle_avoidance): shorter predicted path for pedestrians

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/dynamic_obstacle_avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/dynamic_obstacle_avoidance.param.yaml
@@ -58,7 +58,7 @@
         lat_offset_from_obstacle: 1.0 # [m]
         margin_distance_around_pedestrian: 2.0 # [m]
         predicted_path:
-          end_time_to_consider: 3.0 # [s]
+          end_time_to_consider: 2.0 # [s]
           threshold_confidence: 0.0 # [] not probability
         max_lat_offset_to_avoid: 0.5 # [m]
         max_time_for_object_lat_shift: 0.0 # [s]


### PR DESCRIPTION
## Description

Tuned the following parameter in the experiment.
- The horizon time of the pedestrians/bicycles' predicted path to cut the drivable area by the dynamic obstacle avoidance module.
![image](https://github.com/user-attachments/assets/75399fe9-52df-4a3c-aba6-a37c0b6f4d09)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

scenario test: https://evaluation.tier4.jp/evaluation/reports/9be5175a-311e-58b9-8f23-7d5a35e99aa3?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
