### PR TITLE
chore(e2e_launch): add launch_sensing_driver arg

### DIFF
--- a/autoware_launch/launch/e2e_simulator.launch.xml
+++ b/autoware_launch/launch/e2e_simulator.launch.xml
@@ -37,6 +37,8 @@
     default="$(find-pkg-share autoware_launch)/config/system/system_error_monitor/system_error_monitor.awsim.param.yaml"
     description="system error monitor param path"
   />
+  <!-- Sensing -->
+  <arg name="launch_sensing_driver" default="false"/>
   <!-- Tools -->
   <arg name="rviz" default="true" description="launch rviz"/>
   <arg name="rviz_config" default="$(find-pkg-share autoware_launch)/rviz/autoware.rviz" description="rviz config"/>
@@ -74,7 +76,7 @@
       <arg name="system_error_monitor_param_path" value="$(var system_error_monitor_param_path)"/>
       <arg name="diagnostic_graph_aggregator_graph_path" value="$(find-pkg-share autoware_launch)/config/system/diagnostic_graph_aggregator/autoware-awsim.yaml"/>
       <!-- Sensing -->
-      <arg name="launch_sensing_driver" value="false"/>
+      <arg name="launch_sensing_driver" value="$(var launch_sensing_driver)"/>
       <!-- Perception-->
       <arg name="traffic_light_recognition/enable_fine_detection" value="false"/>
       <arg name="namespace1" value="$(var traffic_light_namespace)"/>


### PR DESCRIPTION
## Description

To launch a sensing driver (e.g. Nebula) via argument control, I added `launch_sensing_driver` arg in the launch file.

## Tests performed

Added a log message in the autoware.launch.xml, and confirmed the argument control works fine.
![image](https://github.com/user-attachments/assets/0f59740a-d0ee-42c2-b1f0-f250f5ee1607)

I also tested with AWSIM to ensure the sensor driver launched correctly. Since the test was conducted locally, I will omit the details here.

## Effects on system behavior

None since the default parameter is not changed.

## Interface changes

`launch_sensing_driver` variable can be controlled via CLI like below:

```
ros2 launch autoware_launch e2e_simulator.launch.xml launch_sensing_driver:=true 
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
