### PR TITLE
perf(freespace_planning_algorithms): tune freespace planner parameters

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/parking/freespace_planner/freespace_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/parking/freespace_planner/freespace_planner.param.yaml
@@ -24,8 +24,8 @@
     lateral_goal_range: 0.5
     longitudinal_goal_range: 1.0
     curve_weight: 0.5
-    reverse_weight: 1.0
-    direction_change_weight: 1.5
+    reverse_weight: 0.7
+    direction_change_weight: 2.0
     # costmap configs
     obstacle_threshold: 100
 

--- a/autoware_launch/config/planning/scenario_planning/parking/freespace_planner/freespace_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/parking/freespace_planner/freespace_planner.param.yaml
@@ -22,7 +22,7 @@
     theta_size: 120
     angle_goal_range: 6.0
     lateral_goal_range: 0.5
-    longitudinal_goal_range: 2.0
+    longitudinal_goal_range: 1.0
     curve_weight: 0.5
     reverse_weight: 1.0
     direction_change_weight: 1.5


### PR DESCRIPTION
## Description

Tune freespace planner parameters to improve quality of generated path

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

see https://github.com/autowarefoundation/autoware.universe/pull/8091

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
