### PR TITLE
fix(obstacle_cruise_planner): adjust parameters for handling overtaking then slowing down NPC

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
@@ -12,7 +12,7 @@
       idling_time: 2.0 # idling time to detect front vehicle starting deceleration [s]
       min_ego_accel_for_rss: -1.0 # ego's acceleration to calculate RSS distance [m/ss]
       min_object_accel_for_rss: -1.0 # front obstacle's acceleration to calculate RSS distance [m/ss]
-      safe_distance_margin : 6.0 # This is also used as a stop margin [m]
+      safe_distance_margin : 5.0 # This is also used as a stop margin [m]
       terminal_safe_distance_margin : 3.0 # Stop margin at the goal. This value cannot exceed safe distance margin. [m]
       hold_stop_velocity_threshold: 0.01 # The maximum ego velocity to hold stopping [m/s]
       hold_stop_distance_threshold: 0.3 # The ego keeps stopping if the distance to stop changes within the threshold [m]
@@ -88,7 +88,7 @@
       stop_obstacle_hold_time_threshold : 1.0 # maximum time for holding closest stop obstacle
 
       # hysteresis for cruise and stop
-      obstacle_velocity_threshold_from_cruise_to_stop : 3.0 # stop planning is executed to the obstacle whose velocity is less than this value [m/s]
+      obstacle_velocity_threshold_from_cruise_to_stop : 2.5 # stop planning is executed to the obstacle whose velocity is less than this value [m/s]
       obstacle_velocity_threshold_from_stop_to_cruise : 3.5 # stop planning is executed to the obstacle whose velocity is less than this value [m/s]
 
       # if crossing vehicle is determined as target obstacles or not


### PR DESCRIPTION
## Description
Fixes : 
- https://github.com/autowarefoundation/autoware.universe/issues/7877
<!-- Write a brief description of this PR. -->

## Related links
Parent Issue : 
- https://github.com/autowarefoundation/autoware.universe/issues/7485

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
### Using scenario simulation 

- [scenario](https://github.com/user-attachments/files/16450289/UC-NTR-001-0008.zip)
- [map](https://evaluation.ci.tier4.jp/evaluation/maps/980?project_id=awf)

### Before this PR 

#### NPC slowing down from 20 to 15 km/h "**PASSED** :heavy_check_mark: "
https://github.com/user-attachments/assets/917cda44-981e-42f1-9347-f7e694c41fd6


#### NPC slowing down from 20 to 12.5 km/h "**FAILED** :x:"
https://github.com/user-attachments/assets/53c59784-d77e-4438-b367-d6689d1e2109


#### NPC slowing down from 20 to 10 km/h "**FAILED** :x:"
https://github.com/user-attachments/assets/7fc53112-fbc0-48a5-aab8-57528b8b6f7e



### After this PR
#### NPC slowing down from 20 to 15 km/h "**PASSED** :heavy_check_mark: "
https://github.com/user-attachments/assets/7a2b9096-70a7-4a50-af20-17a4070b37db


#### NPC slowing down from 20 to 12.5 km/h "**PASSED** :heavy_check_mark: "
https://github.com/user-attachments/assets/51b0f4d3-9f73-4886-9df4-3a2333fbc54d


#### NPC slowing down from 20 to 10 km/h "**PASSED** :heavy_check_mark: "
https://github.com/user-attachments/assets/e377b3fe-93c6-4b64-8108-60164c2767c5


<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

### ROS Topic Changes

<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes

<!-- | Parameter Name       | Default Value | Update Description                                  | -->
<!-- | -------------------- | ------------- | --------------------------------------------------- | -->
<!-- | `example_parameters` | `1.0`         | Describe the parameter and also explain the updates | -->

| Parameter Name       | Default Value | Update Description                                  | 
| -------------------- | ------------- | --------------------------------------------------- | 
| `safe_distance_margin ` | `5.0 m`         | Lowering the safe distance margin enabling less -ve acceleration and hence and less drop of ego vehicle velocity while slowing down for cruising a front overtaking NPC |
| `obstacle_velocity_threshold_from_cruise_to_stop` | `2.5 m/s`         | Lowering the velocity threshod from cruise to stop for obostacles to be 2.5 m/s (9 km/h) for better handling some situations in dense urban ODD |

## Effects on system behavior
Improving `obstacle_cruise_planner` so that it is handing overtaking then slowing down NPC in dense urban ODD scenarios will better -ve acceleration and velocity drop while slowing down.
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
