### PR TITLE
feat(psim)!: change a setting parameter type from bool to string

### DIFF
--- a/autoware_launch/launch/components/tier4_simulator_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_simulator_component.launch.xml
@@ -2,7 +2,7 @@
 <launch>
   <arg name="launch_dummy_perception"/>
   <arg name="launch_dummy_vehicle"/>
-  <arg name="launch_dummy_localization"/>
+  <arg name="localization_sim_mode"/>
   <arg name="launch_dummy_doors"/>
   <arg name="launch_diagnostic_converter"/>
   <arg name="perception/enable_detection_failure"/>
@@ -18,7 +18,7 @@
   <include file="$(find-pkg-share tier4_simulator_launch)/launch/simulator.launch.xml">
     <arg name="launch_dummy_perception" value="$(var launch_dummy_perception)"/>
     <arg name="launch_dummy_vehicle" value="$(var launch_dummy_vehicle)"/>
-    <arg name="launch_dummy_localization" value="$(var launch_dummy_localization)"/>
+    <arg name="localization_sim_mode" value="$(var localization_sim_mode)"/>
     <arg name="launch_dummy_doors" value="$(var launch_dummy_doors)"/>
     <arg name="launch_diagnostic_converter" value="$(var launch_diagnostic_converter)"/>
     <arg name="perception/enable_detection_failure" value="$(var perception/enable_detection_failure)"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -38,7 +38,11 @@
   <!-- Simulated time -->
   <arg name="use_sim_time" default="$(var scenario_simulation)"/>
   <!-- Localization-->
-  <arg name="localization_sim_mode" default="api" description="select localization mode. none, api"/>
+  <arg
+    name="localization_sim_mode"
+    default="api"
+    description="Select localization mode. Options are 'none' or 'api'. 'api' starts an external API for initial position estimation. 'none' does not start any localization-related process."
+  />
 
   <group scoped="false">
     <!-- Vehicle -->
@@ -83,7 +87,6 @@
     <let name="launch_dummy_perception" value="true" unless="$(var scenario_simulation)"/>
     <let name="launch_dummy_vehicle" value="false" if="$(var scenario_simulation)"/>
     <let name="launch_dummy_vehicle" value="true" unless="$(var scenario_simulation)"/>
-    <let name="localization_sim_mode" value="$(var localization_sim_mode)"/>
     <let name="launch_diagnostic_converter" value="$(var scenario_simulation)"/>
 
     <include file="$(find-pkg-share autoware_launch)/launch/components/tier4_simulator_component.launch.xml">

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -81,7 +81,7 @@
     <let name="launch_dummy_perception" value="true" unless="$(var scenario_simulation)"/>
     <let name="launch_dummy_vehicle" value="false" if="$(var scenario_simulation)"/>
     <let name="launch_dummy_vehicle" value="true" unless="$(var scenario_simulation)"/>
-    <!-- candidate velues of localization_sim_mode: nothing, api -->
+    <!-- The following modes are available as localization_sim_mode: nothing, api -->
     <let name="localization_sim_mode" value="api"/>
     <let name="launch_diagnostic_converter" value="$(var scenario_simulation)"/>
 

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -81,13 +81,14 @@
     <let name="launch_dummy_perception" value="true" unless="$(var scenario_simulation)"/>
     <let name="launch_dummy_vehicle" value="false" if="$(var scenario_simulation)"/>
     <let name="launch_dummy_vehicle" value="true" unless="$(var scenario_simulation)"/>
-    <let name="launch_dummy_localization" value="true"/>
+    <!-- candidate velues of localization_sim_mode: nothing, api -->
+    <let name="localization_sim_mode" value="api"/>
     <let name="launch_diagnostic_converter" value="$(var scenario_simulation)"/>
 
     <include file="$(find-pkg-share autoware_launch)/launch/components/tier4_simulator_component.launch.xml">
       <arg name="launch_dummy_perception" value="$(var launch_dummy_perception)"/>
       <arg name="launch_dummy_vehicle" value="$(var launch_dummy_vehicle)"/>
-      <arg name="launch_dummy_localization" value="$(var launch_dummy_localization)"/>
+      <arg name="localization_sim_mode" value="$(var localization_sim_mode)"/>
       <arg name="launch_dummy_doors" value="$(var launch_dummy_doors)"/>
       <arg name="launch_diagnostic_converter" value="$(var launch_diagnostic_converter)"/>
       <arg name="perception/enable_detection_failure" value="$(var perception/enable_detection_failure)"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -37,6 +37,8 @@
   <arg name="enable_all_modules_auto_mode" default="$(var scenario_simulation)" description="enable all module's auto mode"/>
   <!-- Simulated time -->
   <arg name="use_sim_time" default="$(var scenario_simulation)"/>
+  <!-- Localization-->
+  <arg name="localization_sim_mode" default="api" description="select localization mode. none, api"/>
 
   <group scoped="false">
     <!-- Vehicle -->
@@ -81,8 +83,7 @@
     <let name="launch_dummy_perception" value="true" unless="$(var scenario_simulation)"/>
     <let name="launch_dummy_vehicle" value="false" if="$(var scenario_simulation)"/>
     <let name="launch_dummy_vehicle" value="true" unless="$(var scenario_simulation)"/>
-    <!-- The following modes are available as localization_sim_mode: nothing, api -->
-    <let name="localization_sim_mode" value="api"/>
+    <let name="localization_sim_mode" value="$(var localization_sim_mode)"/>
     <let name="launch_diagnostic_converter" value="$(var scenario_simulation)"/>
 
     <include file="$(find-pkg-share autoware_launch)/launch/components/tier4_simulator_component.launch.xml">


### PR DESCRIPTION
## Description
This PR changes a configuration variable from a bool type to a string type to allow more flexibility in configuring the localization module to be activated in psim.
This PR does not change the behavior.

This PR is a part of the following issue, and a new mode will be added in a few weeks.
https://github.com/autowarefoundation/autoware_launch/issues/1100

universe PR: https://github.com/autowarefoundation/autoware.universe/pull/8331

## Tests performed
In psim, we verified that the activated nodes are properly switched.
There was also no problem in executing scenario_sim. 
internal link: https://evaluation.tier4.jp/evaluation/reports/bc29eeab-daa3-55e1-8446-400bdb049517?project_id=prd_jt

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
