### PR TITLE
fix(mpc_lateral_controller): publish predicted trajectory in Frenet coordinate and visualize it on Rviz

### DIFF
--- a/autoware_launch/config/control/trajectory_follower/lateral/mpc.param.yaml
+++ b/autoware_launch/config/control/trajectory_follower/lateral/mpc.param.yaml
@@ -75,4 +75,4 @@
       average_num: 1000
       steering_offset_limit: 0.02
 
-    debug_publish_predicted_trajectory: false  # publish debug predicted trajectory in Frenet coordinate
+    debug_publish_predicted_trajectory: true  # publish debug predicted trajectory in Frenet coordinate

--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -2396,7 +2396,7 @@ Visualization Manager:
             Durability Policy: Volatile
             History Policy: Keep Last
             Reliability Policy: Reliable
-            Value: /control/trajectory_follower/lateral/predicted_trajectory
+            Value: /control/trajectory_follower/controller_node_exe/debug/predicted_trajectory_in_frenet_coordinate
           Value: true
           View Path:
             Alpha: 1


### PR DESCRIPTION
## Description

Regarding the visualization of the predicted trajectory by MPC, previously the trajectory in the frenet frame was used, but the one in the world coordinate is currently used by the following PR.
https://github.com/autowarefoundation/autoware.universe/pull/5576

However, the predicted trajectory in the world coordinate has a bug as shown in the following video.
- white: predicted trajectory in the world coordinate
- pink: predicted trajectory in the frenet frame
[Screencast from 2024年08月09日 01時15分36秒.webm](https://github.com/user-attachments/assets/423b0c8e-1484-49d9-819e-379a10aed736)

Therefore, as a temporal solution, this PR started to visualize the predicted trajectory in the frenet frame on Rviz again.


<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
