### PR TITLE
chore(autoware_multi_object_tracker): fix typo in input_channels

### DIFF
--- a/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
@@ -40,8 +40,8 @@
           name: "apollo"
           short_name: "Lap"
       # LIDAR-CAMERA - DNN
-      # cspell:ignore lidar_pointpainitng pointpainting
-      lidar_pointpainitng:
+      # cspell:ignore lidar_pointpainting pointpainting
+      lidar_pointpainting:
         topic: "/perception/object_recognition/detection/pointpainting/objects"
         can_spawn_new_tracker: true
         optional:


### PR DESCRIPTION
## Description
Fix a typo error of lidar_pointpainting

lidar_pointpainitng -> lidar_pointpainting

This PR need to be merged with https://github.com/autowarefoundation/autoware.universe/pull/8515

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
