### PR TITLE
chore(vehicle_cmd_gate): delete deprecated parameters

### DIFF
--- a/autoware_launch/config/control/vehicle_cmd_gate/vehicle_cmd_gate.param.yaml
+++ b/autoware_launch/config/control/vehicle_cmd_gate/vehicle_cmd_gate.param.yaml
@@ -4,7 +4,6 @@
     system_emergency_heartbeat_timeout: 0.5
     use_emergency_handling: true
     check_external_emergency_heartbeat: $(var check_external_emergency_heartbeat)
-    use_start_request: false
     enable_cmd_limit_filter: true
     filter_activated_count_threshold: 5
     filter_activated_velocity_threshold: 1.0
@@ -12,7 +11,6 @@
     stop_hold_acceleration: -1.5
     emergency_acceleration: -2.4
     moderate_stop_service_acceleration: -1.5
-    stopped_state_entry_duration_time: 0.1
     stop_check_duration: 1.0
     nominal:
       vel_lim: 25.0


### PR DESCRIPTION
## Description

Delete deprecated parameters in `vehicle_cmd_gate.param.yaml`

The following parameters have been removed as they are no longer used by `vehicle_cmd_gate` node.

- `use_start_request`
- `stopped_state_entry_duration_time`

PR for autoware.universe: https://github.com/autowarefoundation/autoware.universe/pull/8537

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

PSim test was performed.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->



## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
