### PR TITLE
fix(static_obstacle_avoidance): improve avoidance for parked NPCs

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/static_obstacle_avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/static_obstacle_avoidance.param.yaml
@@ -23,7 +23,7 @@
           th_moving_time: 2.0                           # [s]
           longitudinal_margin: 0.0                      # [m]
           lateral_margin:
-            soft_margin: 0.7                            # [m]
+            soft_margin: 0.5                            # [m]
             hard_margin: 0.2                            # [m]
             hard_margin_for_parked_vehicle: 0.2         # [m]
           max_expand_ratio: 0.0                         # [-] FOR DEVELOPER
@@ -34,7 +34,7 @@
           th_moving_time: 2.0
           longitudinal_margin: 0.0
           lateral_margin:
-            soft_margin: 0.7
+            soft_margin: 0.5
             hard_margin: 0.2
             hard_margin_for_parked_vehicle: 0.2
           max_expand_ratio: 0.0
@@ -45,7 +45,7 @@
           th_moving_time: 2.0
           longitudinal_margin: 0.0
           lateral_margin:
-            soft_margin: 0.7
+            soft_margin: 0.5
             hard_margin: 0.2
             hard_margin_for_parked_vehicle: 0.2
           max_expand_ratio: 0.0
@@ -56,7 +56,7 @@
           th_moving_time: 2.0
           longitudinal_margin: 0.0
           lateral_margin:
-            soft_margin: 0.7
+            soft_margin: 0.5
             hard_margin: 0.2
             hard_margin_for_parked_vehicle: 0.2
           max_expand_ratio: 0.0
@@ -67,7 +67,7 @@
           th_moving_time: 1.0
           longitudinal_margin: 0.0
           lateral_margin:
-            soft_margin: 0.7
+            soft_margin: 0.5
             hard_margin: -0.2
             hard_margin_for_parked_vehicle: -0.2
           max_expand_ratio: 0.0
@@ -89,7 +89,7 @@
           th_moving_time: 1.0
           longitudinal_margin: 1.0
           lateral_margin:
-            soft_margin: 0.7
+            soft_margin: 0.5
             hard_margin: 0.3
             hard_margin_for_parked_vehicle: 0.2
           max_expand_ratio: 0.0

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/static_obstacle_avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/static_obstacle_avoidance.param.yaml
@@ -25,7 +25,7 @@
           lateral_margin:
             soft_margin: 0.7                            # [m]
             hard_margin: 0.2                            # [m]
-            hard_margin_for_parked_vehicle: 0.5         # [m]
+            hard_margin_for_parked_vehicle: 0.2         # [m]
           max_expand_ratio: 0.0                         # [-] FOR DEVELOPER
           envelope_buffer_margin: 0.1                   # [m] FOR DEVELOPER
           th_error_eclipse_long_radius : 0.6            # [m]
@@ -36,7 +36,7 @@
           lateral_margin:
             soft_margin: 0.7
             hard_margin: 0.2
-            hard_margin_for_parked_vehicle: 0.5
+            hard_margin_for_parked_vehicle: 0.2
           max_expand_ratio: 0.0
           envelope_buffer_margin: 0.1
           th_error_eclipse_long_radius : 0.6
@@ -47,7 +47,7 @@
           lateral_margin:
             soft_margin: 0.7
             hard_margin: 0.2
-            hard_margin_for_parked_vehicle: 0.5
+            hard_margin_for_parked_vehicle: 0.2
           max_expand_ratio: 0.0
           envelope_buffer_margin: 0.1
           th_error_eclipse_long_radius : 0.6
@@ -58,7 +58,7 @@
           lateral_margin:
             soft_margin: 0.7
             hard_margin: 0.2
-            hard_margin_for_parked_vehicle: 0.5
+            hard_margin_for_parked_vehicle: 0.2
           max_expand_ratio: 0.0
           envelope_buffer_margin: 0.1
           th_error_eclipse_long_radius : 0.6
@@ -80,7 +80,7 @@
           lateral_margin:
             soft_margin: 0.7
             hard_margin: 0.5
-            hard_margin_for_parked_vehicle: 0.5
+            hard_margin_for_parked_vehicle: 0.2
           max_expand_ratio: 0.0
           envelope_buffer_margin: 0.5
           th_error_eclipse_long_radius : 0.6
@@ -91,7 +91,7 @@
           lateral_margin:
             soft_margin: 0.7
             hard_margin: 0.3
-            hard_margin_for_parked_vehicle: 0.3
+            hard_margin_for_parked_vehicle: 0.2
           max_expand_ratio: 0.0
           envelope_buffer_margin: 0.5
           th_error_eclipse_long_radius : 0.6
@@ -102,7 +102,7 @@
           lateral_margin:
             soft_margin: 0.7
             hard_margin: 0.5
-            hard_margin_for_parked_vehicle: 0.5
+            hard_margin_for_parked_vehicle: 0.2
           max_expand_ratio: 0.0
           envelope_buffer_margin: 0.5
           th_error_eclipse_long_radius : 0.6

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/static_obstacle_avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/static_obstacle_avoidance.param.yaml
@@ -25,7 +25,7 @@
           lateral_margin:
             soft_margin: 0.7                            # [m]
             hard_margin: 0.2                            # [m]
-            hard_margin_for_parked_vehicle: 0.2         # [m]
+            hard_margin_for_parked_vehicle: 0.5         # [m]
           max_expand_ratio: 0.0                         # [-] FOR DEVELOPER
           envelope_buffer_margin: 0.1                   # [m] FOR DEVELOPER
           th_error_eclipse_long_radius : 0.6            # [m]
@@ -36,7 +36,7 @@
           lateral_margin:
             soft_margin: 0.7
             hard_margin: 0.2
-            hard_margin_for_parked_vehicle: 0.7
+            hard_margin_for_parked_vehicle: 0.5
           max_expand_ratio: 0.0
           envelope_buffer_margin: 0.1
           th_error_eclipse_long_radius : 0.6
@@ -47,7 +47,7 @@
           lateral_margin:
             soft_margin: 0.7
             hard_margin: 0.2
-            hard_margin_for_parked_vehicle: 0.7
+            hard_margin_for_parked_vehicle: 0.5
           max_expand_ratio: 0.0
           envelope_buffer_margin: 0.1
           th_error_eclipse_long_radius : 0.6
@@ -58,7 +58,7 @@
           lateral_margin:
             soft_margin: 0.7
             hard_margin: 0.2
-            hard_margin_for_parked_vehicle: 0.7
+            hard_margin_for_parked_vehicle: 0.5
           max_expand_ratio: 0.0
           envelope_buffer_margin: 0.1
           th_error_eclipse_long_radius : 0.6

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/static_obstacle_avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/static_obstacle_avoidance.param.yaml
@@ -232,7 +232,7 @@
         # avoidance distance parameters
         longitudinal:
           min_prepare_time: 1.0                         # [s]
-          max_prepare_time: 3.0                         # [s]
+          max_prepare_time: 2.0                         # [s]
           min_prepare_distance: 1.0                     # [m]
           min_slow_down_speed: 1.38                     # [m/s]
           buf_slow_down_speed: 0.56                     # [m/s] FOR DEVELOPER

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/static_obstacle_avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/static_obstacle_avoidance.param.yaml
@@ -294,7 +294,7 @@
           velocity: [1.39, 4.17, 11.1]                  # [m/s]
           max_accel_values: [0.5, 0.5, 0.5]             # [m/ss]
           min_jerk_values: [0.2, 0.2, 0.2]              # [m/sss]
-          max_jerk_values: [1.0, 1.0, 1.0]              # [m/sss]
+          max_jerk_values: [3.0, 3.0, 3.0]              # [m/sss]
 
         # longitudinal constraints
         longitudinal:

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/static_obstacle_avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/static_obstacle_avoidance.param.yaml
@@ -25,7 +25,7 @@
           lateral_margin:
             soft_margin: 0.7                            # [m]
             hard_margin: 0.2                            # [m]
-            hard_margin_for_parked_vehicle: 0.7         # [m]
+            hard_margin_for_parked_vehicle: 0.2         # [m]
           max_expand_ratio: 0.0                         # [-] FOR DEVELOPER
           envelope_buffer_margin: 0.1                   # [m] FOR DEVELOPER
           th_error_eclipse_long_radius : 0.6            # [m]

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/static_obstacle_avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/static_obstacle_avoidance.param.yaml
@@ -76,7 +76,7 @@
         bicycle:
           th_moving_speed: 0.28
           th_moving_time: 1.0
-          longitudinal_margin: 1.0
+          longitudinal_margin: 0.6
           lateral_margin:
             soft_margin: 0.7
             hard_margin: 0.5
@@ -87,7 +87,7 @@
         motorcycle:
           th_moving_speed: 1.0
           th_moving_time: 1.0
-          longitudinal_margin: 1.0
+          longitudinal_margin: 0.6
           lateral_margin:
             soft_margin: 0.5
             hard_margin: 0.3
@@ -98,7 +98,7 @@
         pedestrian:
           th_moving_speed: 0.28
           th_moving_time: 1.0
-          longitudinal_margin: 1.0
+          longitudinal_margin: 0.6
           lateral_margin:
             soft_margin: 0.7
             hard_margin: 0.5


### PR DESCRIPTION
## Description
Fixes :
- https://github.com/autowarefoundation/autoware.universe/issues/8539
<!-- Write a brief description of this PR. -->

## Related links
Parent Issue :
- https://github.com/autowarefoundation/autoware.universe/issues/7485

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
### Before this PR
#### UC-NTR-002-0002_case1 (second iteration when D = 20 m)
https://github.com/user-attachments/assets/e48399da-0f3b-464f-9493-6da9f7486cd9

#### UC-NTR-002-0002_case1 (third iteration when D = 15 m)
https://github.com/user-attachments/assets/a942f56f-b88c-4eac-92c4-411840a170fb

#### UC-NTR-002-0002_case2 (second iteration when D = 20 m)
https://github.com/user-attachments/assets/70d617ae-0c4e-4628-b1fa-2a5e60f0019c

#### UC-NTR-002-0002_case2 (third iteration when D = 15 m)
https://github.com/user-attachments/assets/6bee694d-37ec-459c-abda-465d46df1c35

### After this PR
#### UC-NTR-002-0002_case1 (second iteration when D = 20 m)
https://github.com/user-attachments/assets/0c4ab26a-009a-4c30-baa4-da069bd4d4c9

#### UC-NTR-002-0002_case1 (third iteration when D = 15 m)
https://github.com/user-attachments/assets/92127640-4812-497a-a239-f282cb97edb3

#### UC-NTR-002-0002_case2 (second iteration when D = 20 m)
https://github.com/user-attachments/assets/f45ea742-b029-45ca-9063-f7e141a8cafb

#### UC-NTR-002-0002_case2 (third iteration when D = 15 m)
https://github.com/user-attachments/assets/761f3710-0f9d-495d-b9c0-13b00d064a7c

### when dynamic_obstacle_avoidance is enable

https://github.com/user-attachments/assets/9a586851-287f-4523-b4c3-61658f9ca1b5

https://github.com/user-attachments/assets/3880209c-1532-4a5f-ae54-163a9cfa6fe1


https://github.com/user-attachments/assets/4ec1a7c8-40d5-42dd-bb03-c08e1a98f4a3


https://github.com/user-attachments/assets/5d983ef7-7626-482b-9adf-314467d01808

## Notes for reviewers
- 1st iteration of UC-NTR-002-0001_case1 & UC-NTR-002-0001_case2 is passing with current Autoware.
- 1st iteration of UC-NTR-002-0002_case1 & UC-NTR-002-0002_case2 is passing with current Autoware.
- 2nd and 3rd iterations of UC-NTR-002-0001_case1 & UC-NTR-002-0001_case2 will be covered in this [issue](https://github.com/autowarefoundation/autoware.universe/issues/8739) "dynamic obstacle avoidance"

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

### ROS Topic Changes
N.A
<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes
| Parameter Name       | Updated Value | Update Description                                  | 
| -------------------- | ------------- | --------------------------------------------------- | 
|soft_margin      | 0.5 | lower lateral soft margin for triggering avoidance when second NPC is close to first NPC                                 | 
|hard_margin_for_parked_vehicle      | 0.2 | lowering `hard_margin_for_parked_vehicle`  to trigger avoidance for parked NPCs in side of the road                      |  
|max_prepare_time      | 0.2 | lower max prepare time for triggering avoidance when second NPC is close to first NPC                                 | 
|lateral.max_jerk_values      |[3.0, 3.0, 3.0] | raising `max_jerk_values`  to avoiding objects that are close to each other| 
|pedestrian.longitudinal_margin      |0.6| lowering `longitudinal_margin` for pedestrian to trigger avoidance for parked NPCs in side of the road| 
|bicycle.longitudinal_margin      |0.6 | lowering `longitudinal_margin` for bicycle to trigger avoidance for parked NPCs in side of the road|   
|motorcycle.longitudinal_margin      |0.6| lowering `longitudinal_margin` for motorcycle to trigger avoidance for parked NPCs in side of the road|     

## Effects on system behavior
The `autoware_behavior_path_static_obstacle_avoidance_module` is capable of handling improperly parked NPCs in dense urban situations.
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
