### PR TITLE
feat(occupancy_grid_map): add option for time keeper

### DIFF
--- a/autoware_launch/config/perception/occupancy_grid_map/laserscan_based_occupancy_grid_map.param.yaml
+++ b/autoware_launch/config/perception/occupancy_grid_map/laserscan_based_occupancy_grid_map.param.yaml
@@ -18,4 +18,4 @@
     map_resolution: 0.5
 
     # debug parameters
-    publish_processing_time_detail: true
+    publish_processing_time_detail: false

--- a/autoware_launch/config/perception/occupancy_grid_map/laserscan_based_occupancy_grid_map.param.yaml
+++ b/autoware_launch/config/perception/occupancy_grid_map/laserscan_based_occupancy_grid_map.param.yaml
@@ -16,3 +16,6 @@
     map_length: 150.0
     map_width: 150.0
     map_resolution: 0.5
+
+    # debug parameters
+    publish_processing_time_detail: true

--- a/autoware_launch/config/perception/occupancy_grid_map/multi_lidar_pointcloud_based_occupancy_grid_map.param.yaml
+++ b/autoware_launch/config/perception/occupancy_grid_map/multi_lidar_pointcloud_based_occupancy_grid_map.param.yaml
@@ -13,7 +13,7 @@
         map_length_y: 150.0 # [m]
 
         # debug parameters
-        publish_processing_time_detail: true
+        publish_processing_time_detail: false
 
       # downsample input pointcloud
       downsample_input_pointcloud: true

--- a/autoware_launch/config/perception/occupancy_grid_map/multi_lidar_pointcloud_based_occupancy_grid_map.param.yaml
+++ b/autoware_launch/config/perception/occupancy_grid_map/multi_lidar_pointcloud_based_occupancy_grid_map.param.yaml
@@ -12,6 +12,9 @@
         map_length_x: 150.0 # [m]
         map_length_y: 150.0 # [m]
 
+        # debug parameters
+        publish_processing_time_detail: true
+
       # downsample input pointcloud
       downsample_input_pointcloud: true
       downsample_voxel_size: 0.25 # [m]

--- a/autoware_launch/config/perception/occupancy_grid_map/pointcloud_based_occupancy_grid_map.param.yaml
+++ b/autoware_launch/config/perception/occupancy_grid_map/pointcloud_based_occupancy_grid_map.param.yaml
@@ -34,4 +34,4 @@
       pub_debug_grid: false
 
     # debug parameters
-    publish_processing_time_detail: true
+    publish_processing_time_detail: false

--- a/autoware_launch/config/perception/occupancy_grid_map/pointcloud_based_occupancy_grid_map.param.yaml
+++ b/autoware_launch/config/perception/occupancy_grid_map/pointcloud_based_occupancy_grid_map.param.yaml
@@ -32,3 +32,6 @@
       projection_dz_threshold: 0.01 # [m] for avoiding null division
       obstacle_separation_threshold: 1.0 # [m] fill the interval between obstacles with unknown for this length
       pub_debug_grid: false
+
+    # debug parameters
+    publish_processing_time_detail: true

--- a/autoware_launch/config/perception/occupancy_grid_map/synchronized_grid_map_fusion_node.param.yaml
+++ b/autoware_launch/config/perception/occupancy_grid_map/synchronized_grid_map_fusion_node.param.yaml
@@ -18,3 +18,6 @@
     fusion_map_length_x: 100.0
     fusion_map_length_y: 100.0
     fusion_map_resolution: 0.5
+
+    # debug parameters
+    publish_processing_time_detail: true

--- a/autoware_launch/config/perception/occupancy_grid_map/synchronized_grid_map_fusion_node.param.yaml
+++ b/autoware_launch/config/perception/occupancy_grid_map/synchronized_grid_map_fusion_node.param.yaml
@@ -20,4 +20,4 @@
     fusion_map_resolution: 0.5
 
     # debug parameters
-    publish_processing_time_detail: true
+    publish_processing_time_detail: false


### PR DESCRIPTION
## Description
This PR will add parameter `publish_processing_time_detail` for time keeper feature to `occupancy_grid_map`.
Related to https://github.com/autowarefoundation/autoware.universe/pull/8601

When `publish_processing_time_detail` is
- `true`: enable the [TimeKeeper](https://github.com/autowarefoundation/autoware.universe/tree/d75f87520e6af854ee3cf2a05738afe88254c2f3/common/autoware_universe_utils) for tracking processing time in detail
- `false`: disable the feature, no topic will be sent

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
