### PR TITLE
feat(tier4_perception_launch): enable to use multi camera on traffic light recognition

### DIFF
--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -46,7 +46,7 @@
     <arg name="use_traffic_light_recognition" value="$(var use_traffic_light_recognition)"/>
     <arg name="traffic_light_recognition/enable_fine_detection" value="$(var traffic_light_recognition/enable_fine_detection)"/>
     <arg name="traffic_light_recognition/fusion_only" value="false"/>
-    <arg name="traffic_light_image_number" value="2"/>
+    <arg name="all_traffic_light_camera" value="[camera6, camera7]"/>
 
     <!-- object recognition parameters -->
     <arg


### PR DESCRIPTION
## Description
This PR enable to use multi camera(more than 3 cameras) on traffic light recognition
We need to merge[universe PR](https://github.com/autowarefoundation/autoware.universe/pull/8676) at same time.

## Tests performed
I have tested this on local DLR and [Evaluator](https://evaluation.ci.tier4.jp/evaluation/reports/de03c639-c8c1-562c-b5d8-6a6d1237a378?project_id=prd_jt) when I use 1 or 2 traffic light cameras. And I checked node is started correctly when I choose 3 or 4 cameras.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
