### PR TITLE
feat(occupancy_grid_map_outlier_filter): add option for time keeper

### DIFF
--- a/autoware_launch/config/perception/obstacle_segmentation/occupancy_grid_based_outlier_filter/occupancy_grid_map_outlier_filter.param.yaml
+++ b/autoware_launch/config/perception/obstacle_segmentation/occupancy_grid_based_outlier_filter/occupancy_grid_map_outlier_filter.param.yaml
@@ -10,3 +10,6 @@
     cost_threshold: 45
     use_radius_search_2d_filter: true
     enable_debugger: false
+
+    # debug parameters
+    publish_processing_time_detail: False


### PR DESCRIPTION
## Description
This PR will add parameter `publish_processing_time_detail` for time keeper feature to `occupancy_grid_map_outlier_filter`.
Related to https://github.com/autowarefoundation/autoware.universe/pull/8597/

When `publish_processing_time_detail` is
- `true`: enable the [TimeKeeper](https://github.com/autowarefoundation/autoware.universe/tree/d75f87520e6af854ee3cf2a05738afe88254c2f3/common/autoware_universe_utils) for tracking processing time in detail
- `false`: disable the feature, no topic will be sent



## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
