### PR TITLE
chore: add taekjin lee to perception launcher and configuration maintainer

### DIFF
--- a/.github/CODEOWNERS-manual
+++ b/.github/CODEOWNERS-manual
@@ -4,7 +4,7 @@ autoware_launch/** yukihiro.saito@tier4.jp ryohsuke.mitsudome@tier4.jp mfc@leodr
 autoware_launch/config/control/** takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp
 autoware_launch/config/localization/** masahiro.sakamoto@tier4.jp yamato.ando@tier4.jp ryu.yamamoto@tier4.jp kento.yabuuchi.2@tier4.jp shintaro.sakoda@tier4.jp taiki.yamada@tier4.jp anh.nguyen.2@tier4.jp
 autoware_launch/config/map/** masahiro.sakamoto@tier4.jp yamato.ando@tier4.jp ryu.yamamoto@tier4.jp kento.yabuuchi.2@tier4.jp shintaro.sakoda@tier4.jp taiki.yamada@tier4.jp anh.nguyen.2@tier4.jp
-autoware_launch/config/perception/** shunsuke.miura@tier4.jp yoshi.ri@tier4.jp koji.minoda@tier4.jp
+autoware_launch/config/perception/** shunsuke.miura@tier4.jp yoshi.ri@tier4.jp koji.minoda@tier4.jp taekjin.lee@tier4.jp
 autoware_launch/config/planning/** takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp
 autoware_launch/config/simulator/** takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp
 autoware_launch/config/system/** fumihito.ito@tier4.jp isamu.takagi@tier4.jp
@@ -13,7 +13,7 @@ autoware_launch/launch/components/tier4_autoware_api_component.launch.xml isamu.
 autoware_launch/launch/components/tier4_control_component.launch.xml takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp
 autoware_launch/launch/components/tier4_localization_component.launch.xml masahiro.sakamoto@tier4.jp yamato.ando@tier4.jp ryu.yamamoto@tier4.jp kento.yabuuchi.2@tier4.jp shintaro.sakoda@tier4.jp taiki.yamada@tier4.jp anh.nguyen.2@tier4.jp
 autoware_launch/launch/components/tier4_map_component.launch.xml masahiro.sakamoto@tier4.jp yamato.ando@tier4.jp ryu.yamamoto@tier4.jp kento.yabuuchi.2@tier4.jp shintaro.sakoda@tier4.jp taiki.yamada@tier4.jp anh.nguyen.2@tier4.jp
-autoware_launch/launch/components/tier4_perception_component.launch.xml shunsuke.miura@tier4.jp yoshi.ri@tier4.jp koji.minoda@tier4.jp
+autoware_launch/launch/components/tier4_perception_component.launch.xml shunsuke.miura@tier4.jp yoshi.ri@tier4.jp koji.minoda@tier4.jp taekjin.lee@tier4.jp
 autoware_launch/launch/components/tier4_planning_component.launch.xml takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp
 autoware_launch/launch/components/tier4_sensing_component.launch.xml shunsuke.miura@tier4.jp yoshi.ri@tier4.jp koji.minoda@tier4.jp
 autoware_launch/launch/components/tier4_simulator_component.launch.xml takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp


### PR DESCRIPTION
## Description
Add Taekjin Lee (myself) to the maintainer of the perception launcher and the perception parameters

## Tests performed

Not applicable.

## Effects on system behavior

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
