### PR TITLE
fix(obstacle_cruise_planner): tune obstacle_cruise_planner for cruising front NPCs in dense urban ODD scenarios

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
@@ -12,7 +12,7 @@
       idling_time: 2.0 # idling time to detect front vehicle starting deceleration [s]
       min_ego_accel_for_rss: -1.0 # ego's acceleration to calculate RSS distance [m/ss]
       min_object_accel_for_rss: -1.0 # front obstacle's acceleration to calculate RSS distance [m/ss]
-      safe_distance_margin : 6.0 # This is also used as a stop margin [m]
+      safe_distance_margin : 4.0 # This is also used as a stop margin [m]
       terminal_safe_distance_margin : 3.0 # Stop margin at the goal. This value cannot exceed safe distance margin. [m]
       hold_stop_velocity_threshold: 0.01 # The maximum ego velocity to hold stopping [m/s]
       hold_stop_distance_threshold: 0.3 # The ego keeps stopping if the distance to stop changes within the threshold [m]
@@ -88,8 +88,8 @@
       stop_obstacle_hold_time_threshold : 1.0 # maximum time for holding closest stop obstacle
 
       # hysteresis for cruise and stop
-      obstacle_velocity_threshold_from_cruise_to_stop : 3.0 # stop planning is executed to the obstacle whose velocity is less than this value [m/s]
-      obstacle_velocity_threshold_from_stop_to_cruise : 3.5 # stop planning is executed to the obstacle whose velocity is less than this value [m/s]
+      obstacle_velocity_threshold_from_cruise_to_stop : 1.0 # stop planning is executed to the obstacle whose velocity is less than this value [m/s]
+      obstacle_velocity_threshold_from_stop_to_cruise : 1.5 # stop planning is executed to the obstacle whose velocity is less than this value [m/s]
 
       # if crossing vehicle is determined as target obstacles or not
       crossing_obstacle:


### PR DESCRIPTION
## Description
Fixes :
- https://github.com/autowarefoundation/autoware.universe/issues/7922
- https://github.com/autowarefoundation/autoware.universe/issues/7877
- https://github.com/autowarefoundation/autoware.universe/issues/8311

## Related links
Parent Issue :
- https://github.com/autowarefoundation/autoware.universe/issues/7485

## Tests performed
### Before this PR
#### UC-NTR-005-0001
https://github.com/user-attachments/assets/9d9f7398-7448-4a2c-a51c-e7591450b416

#### UC-NTR-001-0008
https://github.com/user-attachments/assets/3b214e68-c53b-4167-910c-fd48fb12c3ef

#### UC-VRU-002-0002_case1
https://github.com/user-attachments/assets/b7c98cce-caa9-4f1a-9225-06309c248302

#### UC-VRU-002-0002_case2
https://github.com/user-attachments/assets/32040fb6-512b-4d2c-9dc1-b5ebd47f264d

---


### After this PR
#### UC-NTR-005-0001
https://github.com/user-attachments/assets/8b8e2c3b-810c-4084-8075-9520944a1f11

#### UC-NTR-001-0008
https://github.com/user-attachments/assets/640cf170-be59-49ce-8e72-30a5a00fd57e

#### UC-VRU-002-0002_case1
https://github.com/user-attachments/assets/00075ff3-2d85-4d3b-b5d7-acac4357c3ca

#### UC-VRU-002-0002_case2
https://github.com/user-attachments/assets/5b8f4bde-2032-42f3-964b-e2e79a7a033f

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

### ROS Topic Changes
N.A

<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes
| Parameter Name       | Default Value | Update Description                                  | 
| -------------------- | ------------- | --------------------------------------------------- | 
| `safe_distance_margin ` | `4.0 m`         | - Lowering the safe distance margin enabling less -ve acceleration and hence and less drop of ego vehicle velocity while slowing down for cruising a front overtaking NPC |
| `obstacle_velocity_threshold_from_cruise_to_stop` | `1.0 m/s`         | - Lowering the velocity threshod from cruise to stop for better handling some situations in dense urban ODD <br>- Lowering the this threshold below `obstacle_velocity_threshold_from_stop_to_cruise` to prevent chattering between cruise and stop |
| `obstacle_velocity_threshold_from_stop_to_cruise` | `1.5 m/s`         | - Lowering the the velocity threshold hysteresis from cruise to obstacle stop so that `obstacle_cruise_planner` is not performing high -ve acceleration once the VRU is overlapping with ego trajectory and allowing the ego vehicle to cruise the front VRU not always triggering obstacle stop for it|

## Effects on system behavior
- Improving `obstacle_cruise_planner` so that it is handing overtaking then slowing down NPC in dense urban ODD scenarios will better -ve acceleration and velocity drop while slowing down.
- Improving `obstacle_cruise_planner` behavior in cruising scenarios, mitigating any mitigate any unnecessary long safe distance ego and npc and satisfying and following RSS distance.
- Enhancing the `obstacle_cruise_planner` to effectively handle scenarios where vulnerable road users (VRUs) suddenly maneuver and overlap with the ego vehicle's trajectory in dense urban operational design domains (ODDs) will improve deceleration and velocity adjustments, resulting in more human-like driving behavior.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
