### PR TITLE
feat(pose_initializer): add new parameter for check error between initial pose and GNSS pose

### DIFF
--- a/autoware_launch/config/localization/pose_initializer.param.yaml
+++ b/autoware_launch/config/localization/pose_initializer.param.yaml
@@ -7,7 +7,7 @@
     gnss_pose_timeout: 3.0 # [sec]
     stop_check_duration: 3.0 # [sec]
     pose_error_threshold: 5.0 # [m]
-    pose_error_check_enabled: true
+    pose_error_check_enabled: false
     ekf_enabled: $(var ekf_enabled)
     gnss_enabled: $(var gnss_enabled)
     yabloc_enabled: $(var yabloc_enabled)

--- a/autoware_launch/config/localization/pose_initializer.param.yaml
+++ b/autoware_launch/config/localization/pose_initializer.param.yaml
@@ -6,6 +6,8 @@
 
     gnss_pose_timeout: 3.0 # [sec]
     stop_check_duration: 3.0 # [sec]
+    pose_error_threshold: 5.0 # [m]
+    pose_error_check_enabled: true
     ekf_enabled: $(var ekf_enabled)
     gnss_enabled: $(var gnss_enabled)
     yabloc_enabled: $(var yabloc_enabled)


### PR DESCRIPTION
## Description
- Add new parameter for check initial pose error with gnss(https://github.com/autowarefoundation/autoware.universe/pull/8947).
- Check 2D(x-y) Error between Initial Pose result and GNSS Pose, if pose error is large, output an message in the /diagnostics topic.
- This feature is off by default, but can be enabled by setting pose_error_check_enabled to true when the GNSS is reliable, such as RTK-GNSS.

<!-- Write a brief description of this PR. -->

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/8947

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
- checkout autoware.universe to [feat/initial_pose_check_with_gnss](https://github.com/autowarefoundation/autoware.universe/pull/8947)
- Check that localization works correctly in logging_simulator.
- Set pose_error_check_enabled to True and check that diagnostics (gnss_pose_error_2d, is_gnss_pose_error) are output. If set to False, gnss_pose_error_2d and is_gnss_pose_error are not output.

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

### ROS Topic Changes

<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes

Add new parameters.
| Parameter Name       | Default Value | Update Description                                  |
| -------------------- | ------------- | --------------------------------------------------- |
| `pose_error_threshold` | `5.0`         | The error threshold between GNSS and initial pose | 
| `pose_error_check_enabled` | `false`         | If true, check error between initial pose result and GNSS pose |

<!-- | Parameter Name       | Default Value | Update Description                                  | -->
<!-- | -------------------- | ------------- | --------------------------------------------------- | -->
<!-- | `example_parameters` | `1.0`         | Describe the parameter and also explain the updates | -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
