### PR TITLE
feat: update acceleration limit

### DIFF
--- a/autoware_launch/config/control/trajectory_follower/longitudinal/pid.param.yaml
+++ b/autoware_launch/config/control/trajectory_follower/longitudinal/pid.param.yaml
@@ -53,7 +53,7 @@
 
     # stopped state
     stopped_vel: 0.0
-    stopped_acc: -3.4 # denotes pedal position
+    stopped_acc: -2.49 # denotes pedal position
 
     # emergency state
     emergency_vel: 0.0
@@ -65,8 +65,8 @@
     acc_feedback_gain: 0.0
 
     # acceleration limit
-    max_acc: 3.0
-    min_acc: -5.0
+    max_acc: 1.5
+    min_acc: -2.49
 
     # jerk limit
     max_jerk: 2.0

--- a/autoware_launch/config/planning/scenario_planning/common/common.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/common/common.param.yaml
@@ -11,7 +11,7 @@
 
     # constraints to be observed
     limit:
-      min_acc: -2.5         # min deceleration limit [m/ss]
+      min_acc: -2.49         # min deceleration limit [m/ss]
       max_acc: 1.0          # max acceleration limit [m/ss]
       min_jerk: -1.5        # min jerk limit [m/sss]
       max_jerk: 1.5         # max jerk limit [m/sss]


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->


Following the recent discussions in the ODD Working Group, we've agreed to set the deceleration limit to 0.255G (~2.499 m/s²) for Dense Urban ODD. To implement this change, we need to update the acceleration limit parameters on both the planning and control sides.

For more details, refer to the ODD WG Discussion page: [ODD WG Discussion #5290](https://github.com/orgs/autowarefoundation/discussions/5290)

![image](https://github.com/user-attachments/assets/4c3d73f1-b433-4fa8-8dfe-3aed0ed2953f)

## Tests performed
I tested Dense Urban ODD scenarios in the local.

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
