### PR TITLE
revert(obstacle_cruisse): revert "fix(obstacle_cruise_planner): guarantee the stop margin (#1076)"

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/obstacle_cruise_planner.param.yaml
@@ -26,7 +26,7 @@
         enable_approaching: false
         additional_safe_distance_margin: 3.0 # [m]
         min_safe_distance_margin: 3.0 # [m]
-      suppress_sudden_obstacle_stop: false
+      suppress_sudden_obstacle_stop: true
 
       stop_obstacle_type:
         pointcloud: false


### PR DESCRIPTION
## Description
Now we can achieve a stop with a margin for interrupts, thanks to the stop with predicted_path by @brkay54 https://github.com/autowarefoundation/autoware.universe/pull/8072. Since the need for sudden stops has been reduced, we will revert this parameter.

This reverts the PR https://github.com/autowarefoundation/autoware_launch/pull/1076

<!-- Write a brief description of this PR. -->

## Tests performed
scenario tests

## Effects on system behavior
<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
