### PR TITLE
feat(system_monitor): add on/off config for network traffic monitor

### DIFF
--- a/autoware_launch/config/system/system_monitor/net_monitor.param.yaml
+++ b/autoware_launch/config/system/system_monitor/net_monitor.param.yaml
@@ -2,6 +2,7 @@
   ros__parameters:
       devices: ["*"]
       monitor_program: "greengrass"
+      enable_traffic_monitor: true
       crc_error_check_duration: 1
       crc_error_count_threshold: 1
       reassembles_failed_check_duration: 1


### PR DESCRIPTION
## Description

- This PR adds a new config into `net_monitor.param.yaml` corresponding to https://github.com/autowarefoundation/autoware.universe/pull/9069

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
