### PR TITLE
fix(.github): change runs-on value to to ubuntu-22.04

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -17,7 +17,7 @@ jobs:
   build-and-test-differential:
     needs: make-sure-label-is-present
     if: ${{ needs.make-sure-label-is-present.outputs.result == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-and-test:
     if: ${{ github.event_name != 'push' || github.ref_name == github.event.repository.default_branch }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false

--- a/.github/workflows/cancel-previous-workflows.yaml
+++ b/.github/workflows/cancel-previous-workflows.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   cancel-previous-workflows:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/check-build-depends.yaml
+++ b/.github/workflows/check-build-depends.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-build-depends:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/labeler@v4
         with:

--- a/.github/workflows/pre-commit-autoupdate.yaml
+++ b/.github/workflows/pre-commit-autoupdate.yaml
@@ -14,7 +14,7 @@ jobs:
   pre-commit-autoupdate:
     needs: check-secret
     if: ${{ needs.check-secret.outputs.set == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/update-codeowners-from-packages.yaml
+++ b/.github/workflows/update-codeowners-from-packages.yaml
@@ -14,7 +14,7 @@ jobs:
   update-codeowners-from-packages:
     needs: check-secret
     if: ${{ needs.check-secret.outputs.set == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/update-sync-param-files.yaml
+++ b/.github/workflows/update-sync-param-files.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update-sync-param-files:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Generate token
         id: generate-token


### PR DESCRIPTION
## Description
This PR changes the runs-on value to ubuntu-22.04 instead of ubuntu-latest.

Related PR
- https://github.com/autowarefoundation/autoware/pull/5320
- https://github.com/autowarefoundation/autoware_launch/pull/1188

## Tests performed
Not applicable.

## Effects on system behavior
Not applicable.

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
