### PR TITLE
feat(processing_time_checker): add five module.

### DIFF
--- a/autoware_launch/config/system/processing_time_checker/processing_time_checker.param.yaml
+++ b/autoware_launch/config/system/processing_time_checker/processing_time_checker.param.yaml
@@ -2,9 +2,11 @@
   ros__parameters:
     update_rate: 10.0
     processing_time_topic_name_list:
+      - /control/control_validator/debug/processing_time_ms
       - /control/trajectory_follower/controller_node_exe/lateral/debug/processing_time_ms
       - /control/trajectory_follower/controller_node_exe/longitudinal/debug/processing_time_ms
       - /control/trajectory_follower/lane_departure_checker_node/debug/processing_time_ms
+      - /control/vehicle_cmd_gate/debug/processing_time_ms
       - /perception/object_recognition/prediction/map_based_prediction/debug/processing_time_ms
       - /perception/object_recognition/tracking/multi_object_tracker/debug/processing_time_ms
       - /planning/planning_validator/debug/processing_time_ms
@@ -33,5 +35,8 @@
       - /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/debug/processing_time_ms
       - /planning/scenario_planning/lane_driving/motion_planning/obstacle_cruise_planner/debug/processing_time_ms
       - /planning/scenario_planning/lane_driving/motion_planning/path_optimizer/debug/processing_time_ms
+      - /planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/debug/processing_time_ms
+      - /planning/scenario_planning/parking/costmap_generator/debug/processing_time_ms
+      - /planning/scenario_planning/scenario_selector/debug/processing_time_ms
       - /planning/scenario_planning/velocity_smoother/debug/processing_time_ms
       - /simulation/shape_estimation/debug/processing_time_ms


### PR DESCRIPTION
## Description

### Purpose

To be able to check the values of the modules added in the relationship PR in the scenario.

### Merit

To be able to measure module processing time periodically by scenario.And leads to the following
-> Prevention of cycle failures.
-> Suggestion to improve module processing speed.

### Updated

Added 5 module paths to processing_time_checker.yml to read processing_time_pub from the scenario.

## Related links

[discussion slack link](https://star4.slack.com/archives/C03QW0GU6P7/p1727926601208209?thread_ts=1727851666.022839&cid=C03QW0GU6P7)
(I have not discussed this on github.)

## Tests performed

From the red circle in the image, you can see that the value of the module you have just added is retrieved when the scenario is turned on locally. (Sorry for the small text 🙇‍♂)

![image](https://github.com/user-attachments/assets/1d1bbc4e-2c5b-4259-a4ee-ee8846248868)

## Notes for reviewers

[Changes on the universe side (already merged)](https://github.com/autowarefoundation/autoware.universe/pull/9065)

## Interface changes

### This PR
- processing_time_checker

### [Related PR (universe)](https://github.com/autowarefoundation/autoware.universe/pull/9065)
- /control/control_validator/debug/processing_time_ms
- /control/vehicle_cmd_gate/debug/processing_time_ms
- /planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker/debug/processing_time_ms
- /planning/scenario_planning/parking/costmap_generator/debug/processing_time_ms
- /planning/scenario_planning/scenario_selector/debug/processing_time_ms

### ROS Topic Changes

<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes

<!-- | Parameter Name       | Default Value | Update Description                                  | -->
<!-- | -------------------- | ------------- | --------------------------------------------------- | -->
<!-- | `example_parameters` | `1.0`         | Describe the parameter and also explain the updates | -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/