### PR TITLE
feat(crosswalk_module): set the velocity of occluded objects to 2.0m/s

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/crosswalk.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/crosswalk.param.yaml
@@ -73,7 +73,7 @@
       # param for occlusions
       occlusion:
         enable: true  # if true, ego will slowdown around crosswalks that are occluded
-        occluded_object_velocity: 1.0 # [m/s] assumed velocity of objects that may come out of the occluded space
+        occluded_object_velocity: 2.0 # [m/s] assumed velocity of objects that may come out of the occluded space
         slow_down_velocity: 1.0  # [m/s]
         time_buffer: 0.5  # [s] consecutive time with/without an occlusion to add/remove the slowdown
         min_size: 1.0  # [m] minimum size of an occlusion (square side size)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Set `occluded_object_velocity` to 2.0 to make the crosswalk module more conservative around occlusions.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
