### PR TITLE
fix(start_planner): set  ignore_distance_from_lane_end param to 0.0 since it is not needed

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -50,7 +50,7 @@
       max_back_distance: 20.0
       backward_search_resolution: 2.0
       backward_path_update_duration: 3.0
-      ignore_distance_from_lane_end: 15.0
+      ignore_distance_from_lane_end: 0.0
       # turns signal
       prepare_time_before_start: 0.0
       # freespace planner


### PR DESCRIPTION
## Description

Based on https://github.com/autowarefoundation/autoware.universe/pull/4889, this parameter can be set back to 0.0, bringing back some functionality to the start planner.

## Tests performed

In the video its shown how with the parameter ignore_distance_from_lane_end: 0.0, the start planner can create a shift pull out path without having to move backwards in an awkward way. 
PSim 


https://github.com/user-attachments/assets/e9df6faf-fb60-41bd-b78a-1c7aeb303d35


Degradation check: [TIER IV PRIVATE LINK](https://evaluation.ci.tier4.jp/evaluation/reports/3c084938-32db-5daf-8e9e-38cbfbc13128?project_id=prd_jt)


<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
