### PR TITLE
chore(diagnostic_graph_aggregator, system_diagnostic_monitor)!: change the config file directories from universe to autoware_launch

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 *.param.yaml
 *.rviz
+**/diagnostic_graph_aggregator/

--- a/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-awsim.yaml
+++ b/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-awsim.yaml
@@ -1,5 +1,5 @@
 files:
-  - { path: $(find-pkg-share system_diagnostic_monitor)/config/autoware-main.yaml }
+  - { path: $(find-pkg-share autoware_launch)/config/system/system_diagnostic_monitor/autoware-main.yaml }
 
 edits:
   - { type: remove, path: /autoware/system/duplicated_node_checker }

--- a/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-main.yaml
+++ b/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-main.yaml
@@ -1,2 +1,2 @@
 files:
-  - { path: $(find-pkg-share system_diagnostic_monitor)/config/autoware-main.yaml }
+  - { path: $(find-pkg-share autoware_launch)/config/system/system_diagnostic_monitor/autoware-main.yaml }

--- a/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-psim.yaml
+++ b/autoware_launch/config/system/diagnostic_graph_aggregator/autoware-psim.yaml
@@ -1,2 +1,2 @@
 files:
-  - { path: $(find-pkg-share system_diagnostic_monitor)/config/autoware-psim.yaml }
+  - { path: $(find-pkg-share autoware_launch)/config/system/system_diagnostic_monitor/autoware-psim.yaml }

--- a/autoware_launch/config/system/system_diagnostic_monitor/autoware-main.yaml
+++ b/autoware_launch/config/system/system_diagnostic_monitor/autoware-main.yaml
@@ -1,0 +1,70 @@
+files:
+  - { path: $(dirname)/map.yaml }
+  - { path: $(dirname)/localization.yaml }
+  - { path: $(dirname)/planning.yaml }
+  - { path: $(dirname)/perception.yaml }
+  - { path: $(dirname)/control.yaml }
+  - { path: $(dirname)/vehicle.yaml }
+  - { path: $(dirname)/system.yaml }
+
+units:
+  - path: /autoware/modes/stop
+    type: ok
+
+  - path: /autoware/modes/autonomous
+    type: and
+    list:
+      - { type: link, link: /autoware/map }
+      - { type: link, link: /autoware/localization }
+      - { type: link, link: /autoware/planning }
+      - { type: link, link: /autoware/perception }
+      - { type: link, link: /autoware/control }
+      - { type: link, link: /autoware/vehicle }
+      - { type: link, link: /autoware/system }
+
+  - path: /autoware/modes/local
+    type: and
+    list:
+      - { type: link, link: /autoware/vehicle }
+      - { type: link, link: /autoware/system }
+      - { type: link, link: /autoware/control/local }
+
+  - path: /autoware/modes/remote
+    type: and
+    list:
+      - { type: link, link: /autoware/vehicle }
+      - { type: link, link: /autoware/system }
+      - { type: link, link: /autoware/control/remote }
+
+  - path: /autoware/modes/emergency_stop
+    type: and
+    list:
+      - { type: link, link: /autoware/vehicle }
+      - { type: link, link: /autoware/system }
+
+  - path: /autoware/modes/comfortable_stop
+    type: and
+    list:
+      - { type: link, link: /autoware/map }
+      - { type: link, link: /autoware/localization }
+      - { type: link, link: /autoware/planning }
+      - { type: link, link: /autoware/perception }
+      - { type: link, link: /autoware/control }
+      - { type: link, link: /autoware/vehicle }
+      - { type: link, link: /autoware/system }
+
+  - path: /autoware/modes/pull_over
+    type: and
+    list:
+      - { type: link, link: /autoware/map }
+      - { type: link, link: /autoware/localization }
+      - { type: link, link: /autoware/planning }
+      - { type: link, link: /autoware/perception }
+      - { type: link, link: /autoware/control }
+      - { type: link, link: /autoware/vehicle }
+      - { type: link, link: /autoware/system }
+
+  - path: /autoware/debug/tools
+    type: and
+    list:
+      - { type: link, link: /autoware/system/service_log_checker }

--- a/autoware_launch/config/system/system_diagnostic_monitor/autoware-psim.yaml
+++ b/autoware_launch/config/system/system_diagnostic_monitor/autoware-psim.yaml
@@ -1,0 +1,10 @@
+files:
+  - { path: $(dirname)/autoware-main.yaml }
+
+edits:
+  - { type: remove, path: /autoware/map/topic_rate_check/pointcloud_map }
+  - { type: remove, path: /autoware/localization/scan_matching_status }
+  - { type: remove, path: /autoware/localization/accuracy }
+  - { type: remove, path: /autoware/localization/sensor_fusion_status }
+  - { type: remove, path: /autoware/localization/topic_rate_check/pose_twist_fusion }
+  - { type: remove, path: /autoware/perception/topic_rate_check/pointcloud }

--- a/autoware_launch/config/system/system_diagnostic_monitor/control.yaml
+++ b/autoware_launch/config/system/system_diagnostic_monitor/control.yaml
@@ -1,0 +1,68 @@
+units:
+  - path: /autoware/control
+    type: and
+    list:
+      - { type: link, link: /autoware/control/topic_rate_check/trajectory_follower }
+      - { type: link, link: /autoware/control/topic_rate_check/control_command }
+      - { type: link, link: /autoware/control/node_alive_monitoring/vehicle_cmd_gate }
+      - { type: link, link: /autoware/control/emergency_braking }
+      - { type: link, link: /autoware/control/performance_monitoring/lane_departure }
+      - { type: link, link: /autoware/control/performance_monitoring/trajectory_deviation }
+      - { type: link, link: /autoware/control/performance_monitoring/control_state }
+
+  - path: /autoware/control/local
+    type: and
+    list:
+      - { type: link, link: /autoware/control/topic_rate_check/external_cmd_selector }
+      - { type: link, link: /autoware/control/topic_rate_check/external_cmd_converter }
+
+  - path: /autoware/control/remote
+    type: and
+    list:
+      - { type: link, link: /autoware/control/topic_rate_check/external_cmd_selector }
+      - { type: link, link: /autoware/control/topic_rate_check/external_cmd_converter }
+
+  - path: /autoware/control/topic_rate_check/trajectory_follower
+    type: diag
+    node: topic_state_monitor_trajectory_follower_control_cmd
+    name: control_topic_status
+
+  - path: /autoware/control/topic_rate_check/control_command
+    type: diag
+    node: topic_state_monitor_control_command_control_cmd
+    name: control_topic_status
+
+  - path: /autoware/control/node_alive_monitoring/vehicle_cmd_gate
+    type: diag
+    node: vehicle_cmd_gate
+    name: heartbeat
+
+  - path: /autoware/control/emergency_braking
+    type: diag
+    node: autonomous_emergency_braking
+    name: aeb_emergency_stop
+
+  - path: /autoware/control/performance_monitoring/lane_departure
+    type: diag
+    node: lane_departure_checker_node
+    name: lane_departure
+
+  - path: /autoware/control/performance_monitoring/trajectory_deviation
+    type: diag
+    node: lane_departure_checker_node
+    name: trajectory_deviation
+
+  - path: /autoware/control/performance_monitoring/control_state
+    type: diag
+    node: controller_node_exe
+    name: control_state
+
+  - path: /autoware/control/topic_rate_check/external_cmd_selector
+    type: diag
+    node: external_cmd_selector
+    name: heartbeat
+
+  - path: /autoware/control/topic_rate_check/external_cmd_converter
+    type: diag
+    node: external_cmd_converter
+    name: remote_control_topic_status

--- a/autoware_launch/config/system/system_diagnostic_monitor/hardware.yaml
+++ b/autoware_launch/config/system/system_diagnostic_monitor/hardware.yaml
@@ -1,0 +1,121 @@
+# TODO(Takagi, Isamu): This file is under construction.
+units:
+  - path: /autoware/system/resources/clock/offset
+    diag: ": NTP Offset"
+    timeout: 10.0
+
+  - path: /autoware/system/resources/cpu/offset
+    diag: ": CPU Temperature"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/cpu/usage
+    diag: ": CPU Usage"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/cpu/thermal_throttling
+    diag: ": CPU Thermal Throttling"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/cpu/frequency
+    diag: ": CPU Frequency"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/cpu/load_average
+    diag: ": CPU Load Average"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/gpu/temperature
+    diag: ": GPU Temperature"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/gpu/usage
+    diag: ": GPU Usage"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/gpu/memory_usage
+    diag: ": GPU Memory Usage"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/gpu/thermal_throttling
+    diag: ": GPU Thermal Throttling"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/gpu/frequency
+    diag: ": GPU Frequency"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/memory/usage
+    diag: ": Memory Usage"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/network/usage
+    diag: ": Network Usage"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/network/traffic
+    diag: ": Network Traffic"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/network/crc
+    diag: ": Network CRC Error"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/network/packet_reassembles
+    diag: ": IP Packet Reassembles Failed"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/storage/temperature
+    diag: ": HDD Temperature"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/storage/recovered_error
+    diag: ": HDD RecoveredError"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/storage/read_data_rate
+    diag: ": HDD ReadDataRate"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/storage/write_data_rate
+    diag: ": HDD WriteDataRate"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/storage/read_iops
+    diag: ": HDD ReadIOPS"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/storage/write_iops
+    diag: ": HDD WriteIOPS"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/storage/usage
+    diag: ": HDD Usage"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/storage/power_on_hours
+    diag: ": HDD PowerOnHours"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/storage/total_data_written
+    diag: ": HDD TotalDataWritten"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/storage/connection
+    diag: ": HDD Connection"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/process/high_load
+    diag: ": High-load"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/process/high_mem
+    diag: ": High-mem"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/process/tasks_summary
+    diag: ": Tasks Summary"
+    timeout: 3.0
+
+  - path: /autoware/system/resources/voltage/battery
+    diag: ": CMOS Battery Status"
+    timeout: 3.0

--- a/autoware_launch/config/system/system_diagnostic_monitor/localization.yaml
+++ b/autoware_launch/config/system/system_diagnostic_monitor/localization.yaml
@@ -1,0 +1,43 @@
+units:
+  - path: /autoware/localization
+    type: short-circuit-and
+    list:
+      - type: link
+        link: /autoware/localization/state
+      - type: and
+        list:
+          - { type: link, link: /autoware/localization/topic_rate_check/transform }
+          - { type: link, link: /autoware/localization/topic_rate_check/pose_twist_fusion }
+          - { type: link, link: /autoware/localization/scan_matching_status }
+          - { type: link, link: /autoware/localization/accuracy }
+          - { type: link, link: /autoware/localization/sensor_fusion_status }
+
+  - path: /autoware/localization/state
+    type: diag
+    node: component_state_diagnostics
+    name: localization_state
+
+  - path: /autoware/localization/topic_rate_check/transform
+    type: diag
+    node: topic_state_monitor_transform_map_to_base_link
+    name: localization_topic_status
+
+  - path: /autoware/localization/topic_rate_check/pose_twist_fusion
+    type: diag
+    node: topic_state_monitor_pose_twist_fusion_filter_pose
+    name: localization_topic_status
+
+  - path: /autoware/localization/scan_matching_status
+    type: diag
+    node: ndt_scan_matcher
+    name: scan_matching_status
+
+  - path: /autoware/localization/accuracy
+    type: diag
+    node: localization_error_monitor
+    name: ellipse_error_status
+
+  - path: /autoware/localization/sensor_fusion_status
+    type: diag
+    node: localization
+    name: ekf_localizer

--- a/autoware_launch/config/system/system_diagnostic_monitor/map.yaml
+++ b/autoware_launch/config/system/system_diagnostic_monitor/map.yaml
@@ -1,0 +1,16 @@
+units:
+  - path: /autoware/map
+    type: and
+    list:
+      - { type: link, link: /autoware/map/topic_rate_check/vector_map }
+      - { type: link, link: /autoware/map/topic_rate_check/pointcloud_map }
+
+  - path: /autoware/map/topic_rate_check/vector_map
+    type: diag
+    node: topic_state_monitor_vector_map
+    name: map_topic_status
+
+  - path: /autoware/map/topic_rate_check/pointcloud_map
+    type: diag
+    node: topic_state_monitor_pointcloud_map
+    name: map_topic_status

--- a/autoware_launch/config/system/system_diagnostic_monitor/perception.yaml
+++ b/autoware_launch/config/system/system_diagnostic_monitor/perception.yaml
@@ -1,0 +1,16 @@
+units:
+  - path: /autoware/perception
+    type: and
+    list:
+      - { type: link, link: /autoware/perception/topic_rate_check/objects }
+      - { type: link, link: /autoware/perception/topic_rate_check/pointcloud }
+
+  - path: /autoware/perception/topic_rate_check/objects
+    type: diag
+    node: topic_state_monitor_object_recognition_objects
+    name: perception_topic_status
+
+  - path: /autoware/perception/topic_rate_check/pointcloud
+    type: diag
+    node: topic_state_monitor_obstacle_segmentation_pointcloud
+    name: perception_topic_status

--- a/autoware_launch/config/system/system_diagnostic_monitor/planning.yaml
+++ b/autoware_launch/config/system/system_diagnostic_monitor/planning.yaml
@@ -1,0 +1,90 @@
+units:
+  - path: /autoware/planning
+    type: short-circuit-and
+    list:
+      - type: link
+        link: /autoware/planning/routing/state
+      - type: and
+        list:
+          - { type: link, link: /autoware/planning/topic_rate_check/route }
+          - { type: link, link: /autoware/planning/topic_rate_check/trajectory }
+          - { type: link, link: /autoware/planning/trajectory_validation }
+
+  - path: /autoware/planning/trajectory_validation
+    type: and
+    list:
+      - { type: link, link: /autoware/planning/trajectory_validation/finite }
+      - { type: link, link: /autoware/planning/trajectory_validation/interval }
+      - { type: link, link: /autoware/planning/trajectory_validation/curvature }
+      - { type: link, link: /autoware/planning/trajectory_validation/angle }
+      - { type: link, link: /autoware/planning/trajectory_validation/lateral_acceleration }
+      - { type: link, link: /autoware/planning/trajectory_validation/acceleration }
+      - { type: link, link: /autoware/planning/trajectory_validation/deceleration }
+      - { type: link, link: /autoware/planning/trajectory_validation/steering }
+      - { type: link, link: /autoware/planning/trajectory_validation/steering_rate }
+      - { type: link, link: /autoware/planning/trajectory_validation/velocity_deviation }
+
+  - path: /autoware/planning/routing/state
+    type: diag
+    node: component_state_diagnostics
+    name: route_state
+
+  - path: /autoware/planning/topic_rate_check/route
+    type: diag
+    node: topic_state_monitor_mission_planning_route
+    name: planning_topic_status
+
+  - path: /autoware/planning/topic_rate_check/trajectory
+    type: diag
+    node: topic_state_monitor_scenario_planning_trajectory
+    name: planning_topic_status
+
+  - path: /autoware/planning/trajectory_validation/finite
+    type: diag
+    node: planning_validator
+    name: trajectory_validation_finite
+
+  - path: /autoware/planning/trajectory_validation/interval
+    type: diag
+    node: planning_validator
+    name: trajectory_validation_interval
+
+  - path: /autoware/planning/trajectory_validation/curvature
+    type: diag
+    node: planning_validator
+    name: trajectory_validation_curvature
+
+  - path: /autoware/planning/trajectory_validation/angle
+    type: diag
+    node: planning_validator
+    name: trajectory_validation_relative_angle
+
+  - path: /autoware/planning/trajectory_validation/lateral_acceleration
+    type: diag
+    node: planning_validator
+    name: trajectory_validation_lateral_acceleration
+
+  - path: /autoware/planning/trajectory_validation/acceleration
+    type: diag
+    node: planning_validator
+    name: trajectory_validation_acceleration
+
+  - path: /autoware/planning/trajectory_validation/deceleration
+    type: diag
+    node: planning_validator
+    name: trajectory_validation_deceleration
+
+  - path: /autoware/planning/trajectory_validation/steering
+    type: diag
+    node: planning_validator
+    name: trajectory_validation_steering
+
+  - path: /autoware/planning/trajectory_validation/steering_rate
+    type: diag
+    node: planning_validator
+    name: trajectory_validation_steering_rate
+
+  - path: /autoware/planning/trajectory_validation/velocity_deviation
+    type: diag
+    node: planning_validator
+    name: trajectory_validation_velocity_deviation

--- a/autoware_launch/config/system/system_diagnostic_monitor/system.yaml
+++ b/autoware_launch/config/system/system_diagnostic_monitor/system.yaml
@@ -1,0 +1,27 @@
+units:
+  - path: /autoware/system
+    type: and
+    list:
+      - { type: link, link: /autoware/system/duplicated_node_checker }
+      - { type: link, link: /autoware/system/topic_rate_check/emergency_control_command }
+      - { type: link, link: /autoware/system/emergency_stop_operation }
+
+  - path: /autoware/system/duplicated_node_checker
+    type: diag
+    node: duplicated_node_checker
+    name: duplicated_node_checker
+
+  - path: /autoware/system/service_log_checker
+    type: diag
+    node: service_log_checker
+    name: response_status
+
+  - path: /autoware/system/topic_rate_check/emergency_control_command
+    type: diag
+    node: topic_state_monitor_system_emergency_control_cmd
+    name: system_topic_status
+
+  - path: /autoware/system/emergency_stop_operation
+    type: diag
+    node: vehicle_cmd_gate
+    name: emergency_stop_operation

--- a/autoware_launch/config/system/system_diagnostic_monitor/vehicle.yaml
+++ b/autoware_launch/config/system/system_diagnostic_monitor/vehicle.yaml
@@ -1,0 +1,16 @@
+units:
+  - path: /autoware/vehicle
+    type: and
+    list:
+      - { type: link, link: /autoware/vehicle/topic_rate_check/velocity }
+      - { type: link, link: /autoware/vehicle/topic_rate_check/steering }
+
+  - path: /autoware/vehicle/topic_rate_check/velocity
+    type: diag
+    node: topic_state_monitor_vehicle_status_velocity_status
+    name: vehicle_topic_status
+
+  - path: /autoware/vehicle/topic_rate_check/steering
+    type: diag
+    node: topic_state_monitor_vehicle_status_steering_status
+    name: vehicle_topic_status


### PR DESCRIPTION
## Description
To follow our standard manner, This PR change the config file directories from the universe to the autoware_launch.

## Related links

## Tests performed
psim and tier4 internal tests

## Notes for reviewers

## Interface changes

### ROS Topic Changes

### ROS Parameter Changes


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
