### PR TITLE
fix: changed `loc_config_path` declaration from let to arg

### DIFF
--- a/autoware_launch/launch/components/tier4_localization_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_localization_component.launch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <launch>
-  <let name="loc_config_path" value="$(find-pkg-share autoware_launch)/config/localization"/>
+  <arg name="loc_config_path" default="$(find-pkg-share autoware_launch)/config/localization"/>
   <arg name="pose_source" default="ndt" description="select pose_estimator: ndt, yabloc, eagleye"/>
   <arg name="twist_source" default="gyro_odom" description="select twist_estimator. gyro_odom, eagleye"/>
   <arg name="input_pointcloud" default="/sensing/lidar/concatenated/pointcloud" description="The topic will be used in the localization util module"/>


### PR DESCRIPTION
## Description

### Context

Currently, Autoware cannot accept the argument `ndt_scan_matcher/ndt_scan_matcher_param_path`.

NG)

```bash
ros2 launch autoware_launch logging_simulator.launch.xml \
    map_path:=$MAP \
    ndt_scan_matcher/ndt_scan_matcher_param_path:=/your/path
```

This is because the argument is overwritten in `tier4_localization_component.launch.xml`.
https://github.com/autowarefoundation/autoware_launch/blob/642eb3e5a9dbb128e114135d681c2098abdecd9f/autoware_launch/launch/components/tier4_localization_component.launch.xml#L27

The `loc_config_path` is not an argument, as it is declared using `let`.

https://github.com/autowarefoundation/autoware_launch/blob/642eb3e5a9dbb128e114135d681c2098abdecd9f/autoware_launch/launch/components/tier4_localization_component.launch.xml#L3

Also NG)
```bash
ros2 launch autoware_launch logging_simulator.launch.xml \
    map_path:=$MAP \
    loc_config_path:=/your/path
```

### Changes

In this pull request, I have changed the `loc_config_path` declaration from `let` to `arg`.

OK!)

```bash
ros2 launch autoware_launch logging_simulator.launch.xml \
    map_path:=$MAP \
    loc_config_path:=/your/path
```

## Tests performed

- [x] `planning_simulator` with [sample_map](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/)
- [x] `logging_simulator` with [sample_rosbag](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/)
- [x] `logging_simulator` with [awsim_gt_data(TIER IV INTERNAL)](https://drive.google.com/file/d/1BtH3Ry5lu-h85GHM-sYq_jNJLw-s0re6/view?usp=drive_link)
- [x] `e2e_simulator` with [AWSIM v1.3.0](https://github.com/tier4/AWSIM/releases/tag/v1.3.0)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
