### PR TITLE
feat(collision detector): add collision detector to launch/config

### DIFF
--- a/autoware_launch/config/control/autoware_collision_detector/collision_detector.param.yaml
+++ b/autoware_launch/config/control/autoware_collision_detector/collision_detector.param.yaml
@@ -1,0 +1,16 @@
+/**:
+  ros__parameters:
+    use_pointcloud: false # use pointcloud as obstacle check
+    use_dynamic_object: true # use dynamic object as obstacle check
+    collision_distance: 0.1 # Distance at which an object is determined to have collided with ego [m]
+    nearby_filter_radius: 5.0 # Radius to filter nearby objects [m]
+    keep_ignoring_time: 10.0 # Time to keep filtering objects that first appeared in the vicinity
+    nearby_object_type_filters: # Classes subject to filtering for objects first appearing in the vicinity
+      filter_car: false
+      filter_truck: false
+      filter_bus: false
+      filter_trailer: false
+      filter_bicycle: false
+      filter_motorcycle: false
+      filter_pedestrian: false
+      filter_unknown: true

--- a/autoware_launch/launch/components/tier4_control_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_control_component.launch.xml
@@ -6,7 +6,7 @@
   <arg name="use_individual_control_param" default="false"/>
   <arg name="enable_autonomous_emergency_braking" default="true"/>
   <arg name="enable_predicted_path_checker" default="false"/>
-  <arg name="enable_collision_detector" default="true"/>
+  <arg name="enable_collision_detector" default="false"/>
 
   <let name="latlon_controller_param_path_dir" value="$(var vehicle_id)" if="$(var use_individual_control_param)"/>
   <let name="latlon_controller_param_path_dir" value="" unless="$(var use_individual_control_param)"/>

--- a/autoware_launch/launch/components/tier4_control_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_control_component.launch.xml
@@ -6,6 +6,7 @@
   <arg name="use_individual_control_param" default="false"/>
   <arg name="enable_autonomous_emergency_braking" default="true"/>
   <arg name="enable_predicted_path_checker" default="false"/>
+  <arg name="enable_collision_detector" default="true"/>
 
   <let name="latlon_controller_param_path_dir" value="$(var vehicle_id)" if="$(var use_individual_control_param)"/>
   <let name="latlon_controller_param_path_dir" value="" unless="$(var use_individual_control_param)"/>
@@ -40,8 +41,10 @@
     <arg name="obstacle_collision_checker_param_path" value="$(find-pkg-share autoware_launch)/config/control/obstacle_collision_checker/obstacle_collision_checker.param.yaml"/>
     <arg name="external_cmd_selector_param_path" value="$(find-pkg-share autoware_launch)/config/control/external_cmd_selector/external_cmd_selector.param.yaml"/>
     <arg name="aeb_param_path" value="$(find-pkg-share autoware_launch)/config/control/autoware_autonomous_emergency_braking/autonomous_emergency_braking.param.yaml"/>
+    <arg name="collision_detector_param_path" value="$(find-pkg-share autoware_launch)/config/control/autoware_collision_detector/collision_detector.param.yaml"/>
     <arg name="enable_autonomous_emergency_braking" value="$(var enable_autonomous_emergency_braking)"/>
     <arg name="enable_predicted_path_checker" value="$(var enable_predicted_path_checker)"/>
+    <arg name="enable_collision_detector" value="$(var enable_collision_detector)"/>
     <arg name="predicted_path_checker_param_path" value="$(find-pkg-share autoware_launch)/config/control/predicted_path_checker/predicted_path_checker.param.yaml"/>
   </include>
 </launch>


### PR DESCRIPTION
## Description
This PR adds the collision detector package in the control component launch.
The default value is set to false. (collision detector node would not start in default)
Look at [Github issue](https://github.com/autowarefoundation/autoware.universe/issues/9145) for detailed information.

## Tests performed
PSim
[Screencast from 2024年11月01日 14時27分07秒.webm](https://github.com/user-attachments/assets/3e6a9bea-2a59-4e45-8f7e-c41343e9d52c)


## Effects on system behavior
Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
