### PR TITLE
feat(lane_change): enable cancel when ego in turn direction lane main (RT0-33893)

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -6,6 +6,7 @@
 
       backward_length_buffer_for_end_of_lane: 3.0 # [m]
       backward_length_buffer_for_blocking_object: 3.0 # [m]
+      backward_length_from_intersection: 5.0 # [m]
 
       lane_changing_lateral_jerk: 0.5              # [m/s3]
 


### PR DESCRIPTION
## Description

When performing a lane change after an intersection, nearby vehicle might attempt to overtake the ego vehicle. Although simulations may suggest the maneuver is safe, real world testing shows it can feel unsafe. This is particularly true in intersections, where surrounding vehicle often exhibits significant speed variations and unpredictable behavior.

The image below illustrates  such a scenario.

![image](https://github.com/user-attachments/assets/6be24de7-04d8-467c-a643-e6f26d2e2ef6)

In this situation, rear vehicle may either stop abruptly or accelerate suddenly, making it challenging for the safety check to produce reliable result.

This PR addresses the issue by making the lane change module adopt a more conservative approach near intersection.


If the ego vehicle is within an intersection and currently in a turn lane, the lane change module will output an invalid path.

![lane_change_redesign-Test_ computing distance to lane change](https://github.com/user-attachments/assets/62084096-1adf-473a-97fe-cd3735144b5e)

Additionally, if the ego vehicle has just exited the turn lane of an intersection and its distance from the intersection is within the backward_length_from_intersection, the lane change will also be marked as invalid.

![lane_change_redesign-Test_ computing distance to lane change (1)](https://github.com/user-attachments/assets/e04dea58-3ac4-471d-9db5-58ff3379bb7f)

The module also monitors objects behind the ego vehicle. If their highest-confidence predicted path overlaps with the target lanes, the lane change path will be cancelled.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
