### PR TITLE
feat(goal_planner): set lane departure check margin 0.20

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
@@ -59,7 +59,7 @@
         maximum_jerk: 1.0
         path_priority: "efficient_path" # "efficient_path" or "close_goal"
         efficient_path_order: ["SHIFT", "ARC_FORWARD", "ARC_BACKWARD"] # only lane based pull over(exclude freespace parking)
-        lane_departure_check_expansion_margin: 0.3
+        lane_departure_check_expansion_margin: 0.2
 
         # shift parking
         shift_parking:


### PR DESCRIPTION
## Description

the margin 0.3 is same to avoidance module and the judge is dirrent.
so sometimes avoidance allow the pass but goal planner dones not. this causes stuck.
In this PR, decrease margin in goal planner side.

https://github.com/autowarefoundation/autoware_launch/blob/fb963dec89b73ae78f6e91eaa2556cefd2580c14/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/static_obstacle_avoidance.param.yaml#L223-L224

![image](https://github.com/user-attachments/assets/83a52802-749b-4918-a316-8e2e8e11f532)



<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

https://evaluation.tier4.jp/evaluation/reports/b831b1b8-3369-5628-a394-da4da8a04836?project_id=prd_jt
4048/4048

https://star4.slack.com/archives/C07F96ZTVGC/p1730885499632059?thread_ts=1730882551.439009&cid=C07F96ZTVGC


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
