### PR TITLE
feat(system_diagnostic_monitor): add collision detector to control yaml file

### DIFF
--- a/autoware_launch/config/system/system_diagnostic_monitor/autoware-main.yaml
+++ b/autoware_launch/config/system/system_diagnostic_monitor/autoware-main.yaml
@@ -68,3 +68,6 @@ units:
     type: and
     list:
       - { type: link, link: /autoware/system/service_log_checker }
+
+edits:
+  - { type: remove, path: /autoware/control/collision_detector }

--- a/autoware_launch/config/system/system_diagnostic_monitor/control.yaml
+++ b/autoware_launch/config/system/system_diagnostic_monitor/control.yaml
@@ -9,6 +9,7 @@ units:
       - { type: link, link: /autoware/control/performance_monitoring/lane_departure }
       - { type: link, link: /autoware/control/performance_monitoring/trajectory_deviation }
       - { type: link, link: /autoware/control/performance_monitoring/control_state }
+      - { type: link, link: /autoware/control/collision_detector }
 
   - path: /autoware/control/local
     type: and
@@ -66,3 +67,8 @@ units:
     type: diag
     node: external_cmd_converter
     name: remote_control_topic_status
+
+  - path: /autoware/control/collision_detector
+    type: diag
+    node: collision_detector
+    name: collision_detect


### PR DESCRIPTION
## Description
This PR adds the collision_detector node information to the system diagnostic monitor.
As, the collision_detector is off by default, the diagnostic monitor would be removed in the `autoware_main.yaml`.
For further information, please check  [this github issue](https://github.com/autowarefoundation/autoware.universe/issues/9145) .

## Tests performed
Could engage in PSim, and checked that the collision_detector diagnostic is disabled with `ros2 run diagnostic_graph_utils dump_node`.

## Effects on system behavior
Not applicable.

## Interface changes
None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
