### PR TITLE
feat(aeb): set global param to override autoware state check

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -29,7 +29,7 @@
   <arg name="launch_vehicle_interface" default="true" description="launch vehicle interface"/>
   <!-- Control -->
   <arg name="check_external_emergency_heartbeat" default="false"/>
-  <arg name="use_aeb_autoware_state_check" default="true"/>
+  <arg name="using_logging_simulator" default="true"/>
   <!-- Map -->
   <arg name="lanelet2_map_file" default="lanelet2_map.osm" description="lanelet2 map file name"/>
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>

--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -29,6 +29,7 @@
   <arg name="launch_vehicle_interface" default="true" description="launch vehicle interface"/>
   <!-- Control -->
   <arg name="check_external_emergency_heartbeat" default="false"/>
+  <arg name="use_aeb_autoware_state_check" default="true"/>
   <!-- Map -->
   <arg name="lanelet2_map_file" default="lanelet2_map.osm" description="lanelet2 map file name"/>
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>

--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -29,7 +29,7 @@
   <arg name="launch_vehicle_interface" default="true" description="launch vehicle interface"/>
   <!-- Control -->
   <arg name="check_external_emergency_heartbeat" default="false"/>
-  <arg name="using_logging_simulator" default="true"/>
+  <arg name="using_logging_simulator" default="false"/>
   <!-- Map -->
   <arg name="lanelet2_map_file" default="lanelet2_map.osm" description="lanelet2 map file name"/>
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>

--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -29,7 +29,6 @@
   <arg name="launch_vehicle_interface" default="true" description="launch vehicle interface"/>
   <!-- Control -->
   <arg name="check_external_emergency_heartbeat" default="false"/>
-  <arg name="using_logging_simulator" default="false"/>
   <!-- Map -->
   <arg name="lanelet2_map_file" default="lanelet2_map.osm" description="lanelet2 map file name"/>
   <arg name="pointcloud_map_file" default="pointcloud_map.pcd" description="pointcloud map file name"/>

--- a/autoware_launch/launch/components/tier4_control_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_control_component.launch.xml
@@ -4,8 +4,8 @@
   <arg name="lateral_controller_mode" default="mpc"/>
   <arg name="longitudinal_controller_mode" default="pid"/>
   <arg name="use_individual_control_param" default="false"/>
+  <arg name="use_aeb_autoware_state_check" default="true"/>
   <arg name="enable_autonomous_emergency_braking" default="true"/>
-  <arg name="using_logging_simulator" default="false"/>
   <arg name="enable_predicted_path_checker" default="false"/>
   <arg name="enable_collision_detector" default="false"/>
 
@@ -44,7 +44,7 @@
     <arg name="aeb_param_path" value="$(find-pkg-share autoware_launch)/config/control/autoware_autonomous_emergency_braking/autonomous_emergency_braking.param.yaml"/>
     <arg name="collision_detector_param_path" value="$(find-pkg-share autoware_launch)/config/control/autoware_collision_detector/collision_detector.param.yaml"/>
     <arg name="enable_autonomous_emergency_braking" value="$(var enable_autonomous_emergency_braking)"/>
-    <arg name="using_logging_simulator" value="$(var using_logging_simulator)"/>
+    <arg name="use_aeb_autoware_state_check" value="$(var use_aeb_autoware_state_check)"/>
     <arg name="enable_predicted_path_checker" value="$(var enable_predicted_path_checker)"/>
     <arg name="enable_collision_detector" value="$(var enable_collision_detector)"/>
     <arg name="predicted_path_checker_param_path" value="$(find-pkg-share autoware_launch)/config/control/predicted_path_checker/predicted_path_checker.param.yaml"/>

--- a/autoware_launch/launch/components/tier4_control_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_control_component.launch.xml
@@ -5,6 +5,7 @@
   <arg name="longitudinal_controller_mode" default="pid"/>
   <arg name="use_individual_control_param" default="false"/>
   <arg name="enable_autonomous_emergency_braking" default="true"/>
+  <arg name="using_logging_simulator" default="false"/>
   <arg name="enable_predicted_path_checker" default="false"/>
   <arg name="enable_collision_detector" default="false"/>
 
@@ -43,6 +44,7 @@
     <arg name="aeb_param_path" value="$(find-pkg-share autoware_launch)/config/control/autoware_autonomous_emergency_braking/autonomous_emergency_braking.param.yaml"/>
     <arg name="collision_detector_param_path" value="$(find-pkg-share autoware_launch)/config/control/autoware_collision_detector/collision_detector.param.yaml"/>
     <arg name="enable_autonomous_emergency_braking" value="$(var enable_autonomous_emergency_braking)"/>
+    <arg name="using_logging_simulator" value="$(var using_logging_simulator)"/>
     <arg name="enable_predicted_path_checker" value="$(var enable_predicted_path_checker)"/>
     <arg name="enable_collision_detector" value="$(var enable_collision_detector)"/>
     <arg name="predicted_path_checker_param_path" value="$(find-pkg-share autoware_launch)/config/control/predicted_path_checker/predicted_path_checker.param.yaml"/>


### PR DESCRIPTION
## Description
This PR adds a parameter to set AEB's state check to true or false in the launch file, this changes is aimed at facilitating ci/cd evaluation where turning this parameter on and off is sometimes necessary depending on the evaluation tool (DLR, planning simulation, etc).

Example usage: 
`ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware_map/lane_change_map  vehicle_model:=lexus sensor_model:=aip_xx1  use_aeb_autoware_state_check:=false
`

Note, requires universe changes:  https://github.com/autowarefoundation/autoware.universe/pull/9263
<!-- Write a brief description of this PR. -->

## Tests performed
PSim
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
