### PR TITLE
fix(pid_longitudinal_controller): revive hysteresis of state transition

### DIFF
--- a/autoware_launch/config/control/trajectory_follower/longitudinal/pid.param.yaml
+++ b/autoware_launch/config/control/trajectory_follower/longitudinal/pid.param.yaml
@@ -11,7 +11,7 @@
     # state transition
     drive_state_stop_dist: 0.5
     drive_state_offset_stop_dist: 1.0
-    stopping_state_stop_dist: 0.5
+    stopping_state_stop_dist: 0.49
     stopped_state_entry_duration_time: 0.1
     stopped_state_entry_vel: 0.01
     stopped_state_entry_acc: 0.1


### PR DESCRIPTION
## Description

Previously, there was a hysteresis between `drive_state_stop_dist` and `stopping_state_stop_dist` so that the state transition of DRIVE <--> STOPPED will not chatter.

However, the following commit removed the hysteresis by mistake, so this PR revived it.
https://github.com/autowarefoundation/autoware_launch/commit/c6a3df8be00302a72f6fd2c447db7faf0d80475f#diff-a311c12a65b491b5b4c0e9e5ee83bc1488a360826fe46e4204355c9fe009127eL14

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

unit test

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

No chattering of the DRIVE/STOPPED state transition in pid_longitudinal_controller

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
