### PR TITLE
feat(costmap_generator): change lidar height thresholds to vehicle frame

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/common/costmap_generator.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/common/costmap_generator.param.yaml
@@ -12,8 +12,8 @@
     grid_length_y: 70.0
     grid_position_x: 0.0
     grid_position_y: 0.0
-    maximum_lidar_height_thres: 0.3
-    minimum_lidar_height_thres: -2.2
+    maximum_lidar_height_thres: 2.5  # [m] when use_points is true, ignore points with a z value above this (in the vehicle_frame)
+    minimum_lidar_height_thres: 0.0  # [m] when use_points is true, ignore points with a z value bellow this (in the vehicle_frame)
     use_wayarea: true
     use_parkinglot: true
     use_objects: true


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Change parameters used to filter the pointcloud to represent height in the vehicle frame instead of in the lidar frame.
See https://github.com/autowarefoundation/autoware.universe/pull/9311

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
