### PR TITLE
feat: change the old diagnostic_convertor to scenario_simulator_v2_adapter

### DIFF
--- a/autoware_launch/launch/components/tier4_simulator_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_simulator_component.launch.xml
@@ -4,7 +4,7 @@
   <arg name="launch_dummy_vehicle"/>
   <arg name="localization_sim_mode"/>
   <arg name="launch_dummy_doors"/>
-  <arg name="launch_diagnostic_converter"/>
+  <arg name="launch_scenario_simulator_v2_adapter"/>
   <arg name="perception/enable_detection_failure"/>
   <arg name="perception/enable_object_recognition"/>
   <arg name="perception/use_base_link_z"/>
@@ -20,7 +20,7 @@
     <arg name="launch_dummy_vehicle" value="$(var launch_dummy_vehicle)"/>
     <arg name="localization_sim_mode" value="$(var localization_sim_mode)"/>
     <arg name="launch_dummy_doors" value="$(var launch_dummy_doors)"/>
-    <arg name="launch_diagnostic_converter" value="$(var launch_diagnostic_converter)"/>
+    <arg name="launch_scenario_simulator_v2_adapter" value="$(var launch_scenario_simulator_v2_adapter)"/>
     <arg name="perception/enable_detection_failure" value="$(var perception/enable_detection_failure)"/>
     <arg name="perception/enable_object_recognition" value="$(var perception/enable_object_recognition)"/>
     <arg name="perception/use_base_link_z" value="$(var perception/use_base_link_z)"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -88,14 +88,14 @@
     <let name="launch_dummy_perception" value="true" unless="$(var scenario_simulation)"/>
     <let name="launch_dummy_vehicle" value="false" if="$(var scenario_simulation)"/>
     <let name="launch_dummy_vehicle" value="true" unless="$(var scenario_simulation)"/>
-    <let name="launch_diagnostic_converter" value="$(var scenario_simulation)"/>
+    <let name="launch_scenario_simulator_v2_adapter" value="$(var scenario_simulation)"/>
 
     <include file="$(find-pkg-share autoware_launch)/launch/components/tier4_simulator_component.launch.xml">
       <arg name="launch_dummy_perception" value="$(var launch_dummy_perception)"/>
       <arg name="launch_dummy_vehicle" value="$(var launch_dummy_vehicle)"/>
       <arg name="localization_sim_mode" value="$(var localization_sim_mode)"/>
       <arg name="launch_dummy_doors" value="$(var launch_dummy_doors)"/>
-      <arg name="launch_diagnostic_converter" value="$(var launch_diagnostic_converter)"/>
+      <arg name="launch_scenario_simulator_v2_adapter" value="$(var launch_scenario_simulator_v2_adapter)"/>
       <arg name="perception/enable_detection_failure" value="$(var perception/enable_detection_failure)"/>
       <arg name="perception/enable_object_recognition" value="$(var perception/enable_object_recognition)"/>
       <arg name="perception/use_base_link_z" value="$(var perception/use_base_link_z)"/>


### PR DESCRIPTION
## Description

Autoware Launch in the main branch currently fails to launch due to lack of argument to `launch_scenario_simulator_v2_adapter`. This is caused by the change of argument name in Autoware.Universe in [this PR](https://github.com/autowarefoundation/autoware.universe/pull/9180).

This resolved this issue by updating the argument name appropriately.


## Tests performed
I have tested in my local machine that it works after updating the argument name.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
