### PR TITLE
feat(autonomous_emergency_braking): add parameter to limit IMU path length and rename longitudinal offset

### DIFF
--- a/autoware_launch/config/control/autoware_autonomous_emergency_braking/autonomous_emergency_braking.param.yaml
+++ b/autoware_launch/config/control/autoware_autonomous_emergency_braking/autonomous_emergency_braking.param.yaml
@@ -4,6 +4,7 @@
     use_predicted_trajectory: true
     use_imu_path: true
     limit_imu_path_lat_dev: false
+    limit_imu_path_length: true
     use_pointcloud_data: true
     use_predicted_object_data: false
     use_object_velocity_calculation: true
@@ -39,7 +40,7 @@
     maximum_cluster_size: 10000
 
     # RSS distance collision check
-    longitudinal_offset: 1.0
+    longitudinal_offset_margin: 1.0
     t_response: 1.0
     a_ego_min: -3.0
     a_obj_min: -1.0


### PR DESCRIPTION
## Description

add parameter to limit IMU path length and rename longitudinal offset
necessary change for the [PR](https://github.com/autowarefoundation/autoware.universe/pull/9463).

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
