### PR TITLE
feat(autoware_processing_time_checker): add a parameter to choice whether to output metrics to log folder

### DIFF
--- a/autoware_launch/config/system/processing_time_checker/processing_time_checker.param.yaml
+++ b/autoware_launch/config/system/processing_time_checker/processing_time_checker.param.yaml
@@ -1,5 +1,6 @@
 /**:
   ros__parameters:
+    output_metrics: false
     update_rate: 10.0
     processing_time_topic_name_list:
       - /control/control_evaluator/debug/processing_time_ms


### PR DESCRIPTION
## Description

Add a parameter `output_metrics`, if it's true, the autoware_processing_time_checker node writes the statics of the processing_time measured during its lifetime to <ros2_logging_directory>/autoware_metrics/<node_name>-<time_stamp>.json when shut down.
This is a necessary change for the https://github.com/autowarefoundation/autoware.universe/pull/9479.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
