### PR TITLE
fix(rviz): fix a bug about visualizing ego model

### DIFF
--- a/autoware_launch/rviz/planning_bev.rviz
+++ b/autoware_launch/rviz/planning_bev.rviz
@@ -118,7 +118,7 @@ Visualization Manager:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
-                Reliability Policy: Best Effort
+                Reliability Policy: Reliable
                 Value: /robot_description
               Enabled: true
               Links:


### PR DESCRIPTION
## Description

Fix a bug that `autoware_launch/rviz/planning_bev.rviz` can't properly visualize the ego vehicle model.

It seems that there is another bug, which Wakabayashi san may fix in the future.


## Tests performed
QuickTestPro: 
![image](https://github.com/user-attachments/assets/934f12c2-f68d-4d31-817e-fe9f3db20eb9)



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
