### PR TITLE
fix(pointcloud_container.launch.py): autoware_glog_component

### DIFF
--- a/autoware_launch/launch/pointcloud_container.launch.py
+++ b/autoware_launch/launch/pointcloud_container.launch.py
@@ -40,7 +40,7 @@ def generate_launch_description():
 
     glog_component = ComposableNode(
         package="autoware_glog_component",
-        plugin="GlogComponent",
+        plugin="autoware::glog_component::GlogComponent",
         name="glog_component",
         namespace="pointcloud_container",
     )


### PR DESCRIPTION
## Description

This pull request fixes an issue where the following error occurs in `~/.ros/log`:

```
1733476966.5042253 [ERROR] [launch_ros.actions.load_composable_nodes]: Failed to load node 'glog_component' of type 'GlogComponent' in container '/pointcloud_container': Failed to find class with the requested plugin name.
```

## Related link

- https://github.com/autowarefoundation/autoware.universe/pull/9302

## Tests performed

- [x] logging_simulator

## Effects on system behavior

Fix an error

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
