### PR TITLE
feat(MRM_handler, MRM_emergency_stop_operator): revert mrm_stop parameter, enable mrm_comfortable_stop

### DIFF
--- a/autoware_launch/config/system/mrm_emergency_stop_operator/mrm_emergency_stop_operator.param.yaml
+++ b/autoware_launch/config/system/mrm_emergency_stop_operator/mrm_emergency_stop_operator.param.yaml
@@ -1,5 +1,5 @@
 /**:
   ros__parameters:
     update_rate: 30
-    target_acceleration: -3.0
-    target_jerk: -3.0
+    target_acceleration: -2.5
+    target_jerk: -1.5

--- a/autoware_launch/config/system/mrm_handler/mrm_handler.param.yaml
+++ b/autoware_launch/config/system/mrm_handler/mrm_handler.param.yaml
@@ -10,7 +10,7 @@
     timeout_emergency_recovery: 5.0
     use_parking_after_stopped: false
     use_pull_over: false
-    use_comfortable_stop: false
+    use_comfortable_stop: true
 
     # setting whether to turn hazard lamp on for each situation
     turning_hazard_on:


### PR DESCRIPTION
## Description
This PR contains the following changes.

1. Revert the mrm_emergency_stop parameter, which was changed by https://github.com/autowarefoundation/autoware_launch/pull/1099 half a year ago. These changes are oriented to AEB; however, these parameters are used for all MRM emergency stops. Therefore, I propose to revert these parameters to maintain any behavior other than AEB.
2. Enabling comfortable_stop. MRM comfortable stop was tested enough by tier4 operations. Now I recommend enabling it as public.

## How was this PR tested?
psim test

## Notes for reviewers
None.

## Effects on system behavior

None.
