### PR TITLE
fix(detection-lidar-model): remove unused iou_nms_target_class_names parameter

### DIFF
--- a/autoware_launch/config/perception/object_recognition/detection/lidar_model/centerpoint.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/lidar_model/centerpoint.param.yaml
@@ -11,7 +11,6 @@
     post_process_params:
       # post-process params
       circle_nms_dist_threshold: 0.5
-      iou_nms_target_class_names: ["CAR"]
       iou_nms_search_distance_2d: 10.0
       iou_nms_threshold: 0.1
       yaw_norm_thresholds: [0.3, 0.3, 0.3, 0.3, 0.0]

--- a/autoware_launch/config/perception/object_recognition/detection/lidar_model/centerpoint_sigma.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/lidar_model/centerpoint_sigma.param.yaml
@@ -11,7 +11,6 @@
     post_process_params:
       # post-process params
       circle_nms_dist_threshold: 0.5
-      iou_nms_target_class_names: ["CAR"]
       iou_nms_search_distance_2d: 10.0
       iou_nms_threshold: 0.1
       yaw_norm_thresholds: [0.3, 0.3, 0.3, 0.3, 0.0]

--- a/autoware_launch/config/perception/object_recognition/detection/lidar_model/centerpoint_tiny.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/lidar_model/centerpoint_tiny.param.yaml
@@ -11,7 +11,6 @@
     post_process_params:
       # post-process params
       circle_nms_dist_threshold: 0.5
-      iou_nms_target_class_names: ["CAR"]
       iou_nms_search_distance_2d: 10.0
       iou_nms_threshold: 0.1
       yaw_norm_thresholds: [0.3, 0.3, 0.3, 0.3, 0.0]

--- a/autoware_launch/config/perception/object_recognition/detection/lidar_model/pointpainting.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/lidar_model/pointpainting.param.yaml
@@ -9,7 +9,6 @@
     post_process_params:
       # post-process params
       circle_nms_dist_threshold: 0.3
-      iou_nms_target_class_names: ["CAR"]
       iou_nms_search_distance_2d: 10.0
       iou_nms_threshold: 0.1
       score_threshold: 0.45

--- a/autoware_launch/config/perception/object_recognition/detection/lidar_model/transfusion.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/lidar_model/transfusion.param.yaml
@@ -10,7 +10,6 @@
     densification_world_frame_id: map
     # post-process params
     circle_nms_dist_threshold: 0.5
-    iou_nms_target_class_names: ["CAR"]
     iou_nms_search_distance_2d: 10.0
     iou_nms_threshold: 0.1
     yaw_norm_thresholds: [0.3, 0.3, 0.3, 0.3, 0.0]  # refers to the class_names


### PR DESCRIPTION
## Description
parameter `iou_nms_target_class_names` to be removed by PR https://github.com/autowarefoundation/autoware.universe/pull/9595 and https://github.com/autowarefoundation/autoware.universe/pull/9612

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
