### PR TITLE
feat(lane_change): using frenet planner to generate lane change path when ego near terminal

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -40,6 +40,7 @@
       # trajectory generation near terminal using frenet planner
       frenet:
         enable: true
+        th_yaw_diff: 10.0  # [deg]
 
       # safety check
       safety_check:

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -37,6 +37,10 @@
         min_road_shoulder_width: 0.5  # [m]
         th_parked_vehicle_shift_ratio: 0.6
 
+      # trajectory generation near terminal using frenet planner
+      frenet:
+        enable: true
+
       # safety check
       safety_check:
         allow_loose_check_for_cancel: true

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -42,6 +42,7 @@
       frenet:
         enable: true
         th_yaw_diff: 10.0  # [deg]
+        th_curvature_smoothing: 0.1 # [/]
 
       # safety check
       safety_check:

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -29,6 +29,7 @@
         lon_acc_sampling_num: 5
         lat_acc_sampling_num: 3
         lane_changing_decel_factor: 0.5
+        th_prepare_curvature: 0.03 # [/]
 
       # delay lane change
       delay_lane_change:


### PR DESCRIPTION
## Description

Parameter for enabling frenet planner as path generation near terminal lane change.

https://github.com/autowarefoundation/autoware.universe/pull/9767

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
