### PR TITLE
feat(lane_change): add feature flag param

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -5,6 +5,7 @@
       backward_length_buffer_for_end_of_lane: 3.0 # [m]
       backward_length_buffer_for_blocking_object: 3.0 # [m]
       backward_length_from_intersection: 5.0 # [m]
+      enable_stopped_vehicle_buffer: true
 
       # turn signal
       min_length_for_turn_signal_activation: 10.0 # [m]


### PR DESCRIPTION
## Description

Add flag parameter `enable_stopped_vehicle_buffer` to enable/disable keeping distance from front stopped object for lane change. [related PR](https://github.com/autowarefoundation/autoware.universe/pull/9785)

## How was this PR tested?

- PSIM

## Notes for reviewers

None.

## Effects on system behavior

None.
