### PR TITLE
chore: fix typo in drivable_are_expansion.param.yaml

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/drivable_area_expansion.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/drivable_area_expansion.param.yaml
@@ -9,7 +9,7 @@
     dynamic_expansion:
       enabled: true
       print_runtime: false
-      max_expansion_distance: 0.0 # [m] maximum distance by which the drivable area can be expended (0.0 means no limit)
+      max_expansion_distance: 0.0 # [m] maximum distance by which the drivable area can be expanded (0.0 means no limit)
       min_bound_interval: 1.0  # [m] minimum interval between two consecutive bound points (before expansion)
       smoothing:
         curvature_average_window: 3  # window size used for smoothing the curvatures using a moving window average


### PR DESCRIPTION
## Description

Fix typo in param file.

`expended` -> `expanded`

## How was this PR tested?

None.

## Notes for reviewers

None.

## Effects on system behavior

None.
