### PR TITLE
refactor(lane_change): add missing safety check parameter 

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -57,6 +57,7 @@
           lateral_distance_max_threshold: 2.0
           longitudinal_distance_min_threshold: 3.0
           longitudinal_velocity_delta_time: 0.0
+          extended_polygon_policy: "rectangle"
         parked:
           expected_front_deceleration: -1.0
           expected_rear_deceleration: -2.0
@@ -65,6 +66,7 @@
           lateral_distance_max_threshold: 1.0
           longitudinal_distance_min_threshold: 3.0
           longitudinal_velocity_delta_time: 0.0
+          extended_polygon_policy: "rectangle"
         cancel:
           expected_front_deceleration: -1.0
           expected_rear_deceleration: -2.0
@@ -73,6 +75,7 @@
           lateral_distance_max_threshold: 1.0
           longitudinal_distance_min_threshold: 2.5
           longitudinal_velocity_delta_time: 0.0
+          extended_polygon_policy: "rectangle"
         stuck:
           expected_front_deceleration: -1.0
           expected_rear_deceleration: -1.0
@@ -81,6 +84,7 @@
           lateral_distance_max_threshold: 2.0
           longitudinal_distance_min_threshold: 3.0
           longitudinal_velocity_delta_time: 0.0
+          extended_polygon_policy: "rectangle"
 
         # lane expansion for object filtering
         lane_expansion:

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -111,7 +111,8 @@
           intersection: true
           turns: true
         prediction_time_resolution: 0.5
-        yaw_diff_threshold: 3.1416
+        th_incoming_object_yaw: 2.3562 # [rad]
+        yaw_diff_threshold: 3.1416 # [rad]
         check_current_lanes: false
         check_other_lanes: false
         use_all_predicted_paths: false


### PR DESCRIPTION
## Description

Parameterized incoming object yaw threshold.

[Related PR](https://github.com/autowarefoundation/autoware.universe/pull/9928).

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `collision_check.th_incoming_object_yaw`   | `double` | `2.3562`         | Objects with a heading difference from the ego exceeding this value are excluded from the safety check. |
| Added | `execution.extended_polygon_policy`   | `string` | `rectangle`         | Policy used to determine polygon's shape for safety check. |
| Added | `cancel.extended_polygon_policy`   | `string` | `rectangle`         | Policy used to determine polygon's shape for safety check. |
| Added | `stuck.extended_polygon_policy`   | `string` | `rectangle`         | Policy used to determine polygon's shape for safety check. |
| Added | `parked.extended_polygon_policy`   | `string` | `rectangle`         | Policy used to determine polygon's shape for safety check. |


## How was this PR tested?

1. PSIM
2. [Evaluator/TIER IV internal link](https://evaluation.tier4.jp/evaluation/reports/be08211b-4492-5a46-a953-88ec83e073a2?project_id=prd_jt)

## Notes for reviewers

None.

## Effects on system behavior

None.
