### PR TITLE
chore(traffic_light): rename enable_fine_detection

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -45,7 +45,7 @@
   <arg name="rviz_respawn" default="true"/>
   <!-- Perception -->
   <arg name="perception_mode" default="lidar" description="select perception mode. camera_lidar_radar_fusion, camera_lidar_fusion, lidar_radar_fusion, lidar, radar"/>
-  <arg name="traffic_light_recognition/enable_fine_detection" default="true" description="enable traffic light fine detection"/>
+  <arg name="traffic_light_recognition/use_ml_detector" default="true" description="enable traffic light fine detection"/>
   <!-- Auto mode setting-->
   <arg name="enable_all_modules_auto_mode" default="false" description="enable all module's auto mode"/>
   <arg name="is_simulation" default="false" description="Autoware's behavior will change depending on whether this is a simulation or not."/>

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -23,11 +23,7 @@
   <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
   <arg name="lidar_detection_model" default="centerpoint" description="If the model name is not declared, the default model in perception.launch.xml will be used"/>
   <arg name="all_traffic_light_camera" default="[camera6, camera7]" description="choose camera which use for traffic light recognition"/>
-  <arg
-    name="traffic_light_recognition/ml_detection_model_type"
-    default="fine_detection_model"
-    description="select ml model for TL detection: fine_detection_model or whole_image_detection_model"
-  />
+  <arg name="traffic_light_recognition/ml_detection_model_type" default="fine_detection_model" description="select ml model for TL detection: fine_detection_model or whole_image_detection_model"/>
 
   <include file="$(find-pkg-share tier4_perception_launch)/launch/perception.launch.xml">
     <!-- Options to Switch Launch Function/Module -->

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -21,7 +21,11 @@
   <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
   <arg name="lidar_detection_model" default="centerpoint" description="If the model name is not declared, the default model in perception.launch.xml will be used"/>
   <arg name="all_traffic_light_camera" default="[camera6, camera7]" description="choose camera which use for traffic light recognition"/>
-  <arg name="traffic_light_recognition/ml_detection_model_type" default="whole_image_detection_model" description="select ml model for TL detection: fine_detection_model or whole_image_detection_model"/>
+  <arg
+    name="traffic_light_recognition/ml_detection_model_type"
+    default="whole_image_detection_model"
+    description="select ml model for TL detection: fine_detection_model or whole_image_detection_model"
+  />
 
   <include file="$(find-pkg-share tier4_perception_launch)/launch/perception.launch.xml">
     <!-- Options to Switch Launch Function/Module -->

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -25,7 +25,7 @@
   <arg name="all_traffic_light_camera" default="[camera6, camera7]" description="choose camera which use for traffic light recognition"/>
   <arg
     name="traffic_light_recognition/ml_detection_model_type"
-    default="whole_image_detection_model"
+    default="fine_detection_model"
     description="select ml model for TL detection: fine_detection_model or whole_image_detection_model"
   />
 

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -48,7 +48,7 @@
     <arg name="data_path" value="$(var data_path)"/>
 
     <arg name="use_traffic_light_recognition" value="$(var use_traffic_light_recognition)"/>
-    <arg name="traffic_light_recognition/enable_fine_detection" value="$(var traffic_light_recognition/enable_fine_detection)"/>
+    <arg name="traffic_light_recognition/use_ml_detector" value="$(var traffic_light_recognition/use_ml_detector)"/>
     <arg name="traffic_light_recognition/fusion_only" value="false"/>
     <arg name="all_traffic_light_camera" value="$(var all_traffic_light_camera)"/>
 

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -21,8 +21,7 @@
   <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
   <arg name="lidar_detection_model" default="centerpoint" description="If the model name is not declared, the default model in perception.launch.xml will be used"/>
   <arg name="all_traffic_light_camera" default="[camera6, camera7]" description="choose camera which use for traffic light recognition"/>
-  <arg name="traffic_light_recognition/ml_detection_model_type" default="fine_detection_model" description="select ml model for TL detection: fine_detection_model or whole_image_detection_model"/>
-  <arg name="traffic_light_recognition/whole_image_detector_model_path" default="$(var data_path)"/>
+  <arg name="traffic_light_recognition/ml_detection_model_type" default="whole_image_detection_model" description="select ml model for TL detection: fine_detection_model or whole_image_detection_model"/>
 
   <include file="$(find-pkg-share tier4_perception_launch)/launch/perception.launch.xml">
     <!-- Options to Switch Launch Function/Module -->
@@ -52,7 +51,6 @@
     <arg name="use_traffic_light_recognition" value="$(var use_traffic_light_recognition)"/>
     <arg name="traffic_light_recognition/use_ml_detector" value="$(var traffic_light_recognition/use_ml_detector)"/>
     <arg name="traffic_light_recognition/ml_detection_model_type" value="$(var traffic_light_recognition/ml_detection_model_type)"/>
-    <arg name="traffic_light_recognition/whole_image_detector_model_path" value="$(var traffic_light_recognition/whole_image_detector_model_path)"/>
     <arg name="traffic_light_recognition/fusion_only" value="false"/>
     <arg name="all_traffic_light_camera" value="$(var all_traffic_light_camera)"/>
 
@@ -192,6 +190,8 @@
 
     <!-- traffic light recognition parameters -->
     <arg name="traffic_light_arbiter_param_path" value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_arbiter/traffic_light_arbiter.param.yaml"/>
+    <arg name="traffic_light_recognition/whole_image_detector_model_path" value="$(var data_path)/tensorrt_yolox"/>
+    <arg name="traffic_light_recognition/whole_image_detector_model_name" value="yolox_s_car_ped_tl_detector_960_960_batch_1.onnx"/>
     <arg name="traffic_light_fine_detector_model_path" value="$(var data_path)/traffic_light_fine_detector"/>
     <arg name="traffic_light_fine_detector_model_name" value="tlr_car_ped_yolox_s_batch_6"/>
     <arg name="traffic_light_classifier_model_path" value="$(var data_path)/traffic_light_classifier"/>

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -21,11 +21,7 @@
   <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
   <arg name="lidar_detection_model" default="centerpoint" description="If the model name is not declared, the default model in perception.launch.xml will be used"/>
   <arg name="all_traffic_light_camera" default="[camera6, camera7]" description="choose camera which use for traffic light recognition"/>
-  <arg
-    name="traffic_light_recognition/ml_detection_model_type"
-    default="whole_image_detection_model"
-    description="select ml model for TL detection: fine_detection_model or whole_image_detection_model"
-  />
+  <arg name="traffic_light_recognition/ml_detection_model_type" default="fine_detection_model" description="select ml model for TL detection: fine_detection_model or whole_image_detection_model"/>
   <arg name="traffic_light_recognition/whole_image_detector_model_path" value="$(var data_path)"/>
 
   <include file="$(find-pkg-share tier4_perception_launch)/launch/perception.launch.xml">

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -22,7 +22,7 @@
   <arg name="lidar_detection_model" default="centerpoint" description="If the model name is not declared, the default model in perception.launch.xml will be used"/>
   <arg name="all_traffic_light_camera" default="[camera6, camera7]" description="choose camera which use for traffic light recognition"/>
   <arg name="traffic_light_recognition/ml_detection_model_type" default="fine_detection_model" description="select ml model for TL detection: fine_detection_model or whole_image_detection_model"/>
-  <arg name="traffic_light_recognition/whole_image_detector_model_path" value="$(var data_path)"/>
+  <arg name="traffic_light_recognition/whole_image_detector_model_path" default="$(var data_path)"/>
 
   <include file="$(find-pkg-share tier4_perception_launch)/launch/perception.launch.xml">
     <!-- Options to Switch Launch Function/Module -->

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -21,6 +21,12 @@
   <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
   <arg name="lidar_detection_model" default="centerpoint" description="If the model name is not declared, the default model in perception.launch.xml will be used"/>
   <arg name="all_traffic_light_camera" default="[camera6, camera7]" description="choose camera which use for traffic light recognition"/>
+  <arg
+    name="traffic_light_recognition/ml_detection_model_type"
+    default="whole_image_detection_model"
+    description="select ml model for TL detection: fine_detection_model or whole_image_detection_model"
+  />
+  <arg name="traffic_light_recognition/whole_image_detector_model_path" value="$(var data_path)"/>
 
   <include file="$(find-pkg-share tier4_perception_launch)/launch/perception.launch.xml">
     <!-- Options to Switch Launch Function/Module -->
@@ -49,6 +55,8 @@
 
     <arg name="use_traffic_light_recognition" value="$(var use_traffic_light_recognition)"/>
     <arg name="traffic_light_recognition/use_ml_detector" value="$(var traffic_light_recognition/use_ml_detector)"/>
+    <arg name="traffic_light_recognition/ml_detection_model_type" value="$(var traffic_light_recognition/ml_detection_model_type)"/>
+    <arg name="traffic_light_recognition/whole_image_detector_model_path" value="$(var traffic_light_recognition/whole_image_detector_model_path)"/>
     <arg name="traffic_light_recognition/fusion_only" value="false"/>
     <arg name="all_traffic_light_camera" value="$(var all_traffic_light_camera)"/>
 

--- a/autoware_launch/launch/e2e_simulator.launch.xml
+++ b/autoware_launch/launch/e2e_simulator.launch.xml
@@ -75,7 +75,7 @@
       <!-- Sensing -->
       <arg name="launch_sensing_driver" value="$(var launch_sensing_driver)"/>
       <!-- Perception-->
-      <arg name="traffic_light_recognition/enable_fine_detection" value="false"/>
+      <arg name="traffic_light_recognition/use_ml_detector" value="false"/>
       <arg name="all_traffic_light_camera" value="$(var traffic_light_namespace)"/>
       <!-- Tools -->
       <arg name="rviz" value="$(var rviz)"/>


### PR DESCRIPTION
## Description

- To unify the renaming of `enable_fine_detection` parameter at https://github.com/autowarefoundation/autoware.universe/pull/9731
- Note that this PR should mereger together with above PR. 

## How was this PR tested?

I checked new tlr and existing perception pipeline on Evaluator.
https://evaluation.ci.tier4.jp/evaluation/reports/e545bfca-9777-5031-9e92-818bd694e2df?project_id=prd_jt

And I checked AWSIM works on my local pc under below conditions.
- `traffic_light_recognition/use_ml_detector` : false
- `traffic_light_recognition/use_ml_detector` : true
  - w/ `traffic_light_recognition/ml_detection_model_type` : fine_detector_model
- `traffic_light_recognition/use_ml_detector` : true
  - w/ `traffic_light_recognition/ml_detection_model_type` : whole_image_detection_model

![image](https://github.com/user-attachments/assets/b0a50cc1-2cbc-4787-b656-db59e8942576)

[Screencast from 02-18-2025 05:24:59 PM.webm](https://github.com/user-attachments/assets/ea8964e4-8d93-45ce-b5ed-600d53f2e3b2)


## Notes for reviewers

None.

## Effects on system behavior

None.
