### PR TITLE
refactor(goal_planner): remove use_object_recognition because it is default

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
@@ -39,7 +39,6 @@
 
       # object recognition
       object_recognition:
-        use_object_recognition: true
         collision_check_soft_margins: [5.0, 4.5, 4.0, 3.5, 3.0, 2.5, 2.0, 1.5, 1.0]  # the maximum margin when ego and objects are oriented.
         collision_check_hard_margins: [0.6]  # this should be larger than `surround_check_distance` of surround_obstacle_checker
         object_recognition_collision_check_max_extra_stopping_margin: 1.0


### PR DESCRIPTION
## Description

see https://github.com/autowarefoundation/autoware.universe/pull/10050

## How was this PR tested?

see https://github.com/autowarefoundation/autoware.universe/pull/10050

## Notes for reviewers

None.

## Effects on system behavior

None.
