### PR TITLE
feat(autoware_probabilistic_occupancy_grid_map): disabled the subsample filters for the ogm

### DIFF
--- a/autoware_launch/config/perception/occupancy_grid_map/pointcloud_based_occupancy_grid_map.param.yaml
+++ b/autoware_launch/config/perception/occupancy_grid_map/pointcloud_based_occupancy_grid_map.param.yaml
@@ -9,7 +9,7 @@
       max_height: 2.0
 
     # downsample input pointcloud
-    downsample_input_pointcloud: true
+    downsample_input_pointcloud: false
     downsample_voxel_size: 0.125 # [m]
 
     enable_single_frame_mode: false


### PR DESCRIPTION

## Description

Since the introduction of 
https://github.com/autowarefoundation/autoware.universe/pull/9542
The OGM creation is faster, making the subsample filters (which were added to reduce the processing time of the OGM) less relevant.

## How was this PR tested?
Run autoware with a few rosbags to evaluate the processing times with and without this PR

The subsample filters presented the following processing times:
 - obstacle: 2-5ms
 - raw: around 10ms

Processing time of the OGM:
 - with subsample filters: 3.7ms
 - without subsample filters: 8ms

Note: of the 8ms, 6.4ms are just to copy the data to the device ! If inputs use the blackboard (soon to be introduced), this copy will not be needed.

## Notes for reviewers

None.

## Effects on system behavior

None.
