### PR TITLE
feat(autoware_behavior_path_planner_common): add continuous curvature pullover path generation

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
@@ -58,7 +58,7 @@
         maximum_deceleration: 1.0
         maximum_jerk: 1.0
         path_priority: "efficient_path" # "efficient_path" or "close_goal"
-        efficient_path_order: ["SHIFT", "ARC_FORWARD", "ARC_BACKWARD"] # only lane based pull over(exclude freespace parking)
+        efficient_path_order: ["SHIFT", "ARC_FORWARD", "CLOTHOID_FORWARD", "ARC_BACKWARD", "CLOTHOID_BACKWARD"] # only lane based pull over(exclude freespace parking)
         lane_departure_check_expansion_margin: 0.2
 
         # shift parking
@@ -76,6 +76,7 @@
           max_steer_angle: 0.4 #22.9deg
           forward:
             enable_arc_forward_parking: true
+            enable_clothoid_forward_parking: true
             after_forward_parking_straight_distance: 2.0
             forward_parking_velocity: 1.38
             forward_parking_lane_departure_margin: 0.0
@@ -83,16 +84,15 @@
             forward_parking_max_steer_angle: 0.4  # 22.9deg
             forward_parking_max_steer_angle: 0.35  # 20deg
             forward_parking_steer_rate_lim: 0.35
-            forward_parking_use_clothoid: true
           backward:
             enable_arc_backward_parking: true
+            enable_clothoid_backward_parking: false # Not supported yet
             after_backward_parking_straight_distance: 2.0
             backward_parking_velocity: -1.38
             backward_parking_lane_departure_margin: 0.0
             backward_parking_path_interval: 1.0
             backward_parking_max_steer_angle: 0.4  # 22.9deg
             backward_parking_steer_rate_lim: 0.35
-            backward_parking_use_clothoid: true
 
         # freespace parking
         freespace_parking:

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
@@ -81,6 +81,8 @@
             forward_parking_lane_departure_margin: 0.0
             forward_parking_path_interval: 1.0
             forward_parking_max_steer_angle: 0.4  # 22.9deg
+            forward_parking_max_steer_angle: 0.35  # 20deg
+            forward_parking_use_clothoid: true
           backward:
             enable_arc_backward_parking: true
             after_backward_parking_straight_distance: 2.0
@@ -88,6 +90,7 @@
             backward_parking_lane_departure_margin: 0.0
             backward_parking_path_interval: 1.0
             backward_parking_max_steer_angle: 0.4  # 22.9deg
+            backward_parking_use_clothoid: true
 
         # freespace parking
         freespace_parking:

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
@@ -82,6 +82,7 @@
             forward_parking_path_interval: 1.0
             forward_parking_max_steer_angle: 0.4  # 22.9deg
             forward_parking_max_steer_angle: 0.35  # 20deg
+            forward_parking_steer_rate_lim: 0.35
             forward_parking_use_clothoid: true
           backward:
             enable_arc_backward_parking: true
@@ -90,6 +91,7 @@
             backward_parking_lane_departure_margin: 0.0
             backward_parking_path_interval: 1.0
             backward_parking_max_steer_angle: 0.4  # 22.9deg
+            backward_parking_steer_rate_lim: 0.35
             backward_parking_use_clothoid: true
 
         # freespace parking

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -44,6 +44,7 @@
       lane_departure_check_expansion_margin: 0.0
       backward_velocity: -1.0
       pull_out_max_steer_angle: 0.4  # 22.9deg
+      pull_out_use_clothoid: true
       # search start pose backward
       enable_back: true
       search_priority: "efficient_path"  # "efficient_path" or "short_back_distance"

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -36,6 +36,7 @@
       end_pose_curvature_threshold: 0.1
       # geometric pull out
       enable_geometric_pull_out: true
+      enable_clothoid_pull_out: true
       geometric_collision_check_distance_from_end: 0.0
       arc_path_interval: 1.0
       divide_pull_out_path: true
@@ -45,7 +46,6 @@
       backward_velocity: -1.0
       pull_out_max_steer_angle: 0.4  # 22.9deg
       pull_out_steer_rate_lim: 0.35
-      pull_out_use_clothoid: true
       # search start pose backward
       enable_back: true
       search_priority: "efficient_path"  # "efficient_path" or "short_back_distance"

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -44,6 +44,7 @@
       lane_departure_check_expansion_margin: 0.0
       backward_velocity: -1.0
       pull_out_max_steer_angle: 0.4  # 22.9deg
+      pull_out_steer_rate_lim: 0.35
       pull_out_use_clothoid: true
       # search start pose backward
       enable_back: true


### PR DESCRIPTION
## Description

Append continuous curvature pullover path generation feature using clothoid curve.
Supporting only the forward pullover for now.

## Related links
universe [PR#10045](https://github.com/autowarefoundation/autoware.universe/pull/10045)


## How was this PR tested?

evaluator
https://evaluation.tier4.jp/evaluation/reports/c9a0571a-c807-5888-8e76-c757cf1948a3?project_id=prd_jt

## Notes for reviewers

None.

## Effects on system behavior

None.
