### PR TITLE
feat(autoware_behavior_velocity_traffic_light_module): adjust velocity threshold for ensure stop at yellow light

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/traffic_light.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/traffic_light.param.yaml
@@ -5,5 +5,6 @@
       tl_state_timeout: 1.0
       stop_time_hysteresis: 0.1
       yellow_lamp_period: 2.75
+      yellow_light_stop_velocity: 1.0 # Velocity threshold (m/s) below which the vehicle will always stop before the traffic light when the signal turns yellow, regardless of the pass_judge decision.
       enable_pass_judge: true
       enable_rtc: false # If set to true, the scene modules require approval from the rtc (request to cooperate) function. If set to false, the modules can be executed without requiring rtc approval


### PR DESCRIPTION
## Description
To address the issue in the traffic_light module where the vehicle abruptly stops the moment the light changes from amber to green without performing a pass judge when the speed is below 2.0 m/s, we will adjust the speed threshold.

At the same time, the threshold for performing pass judge has been parameterized, considering potential requests to adjust it.

## Related links

Pull Request for autoware.universe: https://github.com/autowarefoundation/autoware.universe/pull/10064

[TIERIV internal link] https://tier4.atlassian.net/browse/RT0-33895


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
We confirmed an improvement in the sudden deceleration behavior using the rosbag-based logging_simulator, where sudden deceleration had previously been occurring.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

Improvements:

Enables pass judge to be applied even at low speeds (1.0 ~ 2.0 m/s), preventing unnecessary stops when the light changes from amber to green.
Ensures smoother driving and reduces unnecessary braking.
Considerations:

The modified pass judge logic may allow the vehicle to enter the intersection at low speeds.
Changes in stop-and-go behavior could result in different driving patterns compared to the previous implementation.