### PR TITLE
chore(traffic_light_multi_camera_fusion): read parameters from yaml file

### DIFF
--- a/autoware_launch/config/perception/traffic_light_multi_camera_fusion/traffic_light_multi_camera_fusion.param.yaml
+++ b/autoware_launch/config/perception/traffic_light_multi_camera_fusion/traffic_light_multi_camera_fusion.param.yaml
@@ -1,5 +1,4 @@
 /**:
   ros__parameters:
-    camera_namespaces: $(var all_traffic_light_camera)
     message_lifespan: 0.09
     approximate_sync: false

--- a/autoware_launch/config/perception/traffic_light_multi_camera_fusion/traffic_light_multi_camera_fusion.param.yaml
+++ b/autoware_launch/config/perception/traffic_light_multi_camera_fusion/traffic_light_multi_camera_fusion.param.yaml
@@ -1,0 +1,5 @@
+/**:
+  ros__parameters:
+    camera_namespaces: $(var all_traffic_light_camera)
+    message_lifespan: 0.09
+    approximate_sync: false

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -193,6 +193,7 @@
 
     <!-- traffic light recognition parameters -->
     <arg name="traffic_light_arbiter_param_path" value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_arbiter/traffic_light_arbiter.param.yaml"/>
+    <arg name="traffic_light_multi_camera_fusion_param_path" value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_multi_camera_fusion/traffic_light_multi_camera_fusion.param.yaml"/>
     <arg name="traffic_light_fine_detector_model_path" value="$(var data_path)/traffic_light_fine_detector"/>
     <arg name="traffic_light_fine_detector_model_name" value="tlr_car_ped_yolox_s_batch_6"/>
     <arg name="traffic_light_classifier_model_path" value="$(var data_path)/traffic_light_classifier"/>

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -193,7 +193,10 @@
 
     <!-- traffic light recognition parameters -->
     <arg name="traffic_light_arbiter_param_path" value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_arbiter/traffic_light_arbiter.param.yaml"/>
-    <arg name="traffic_light_multi_camera_fusion_param_path" value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_multi_camera_fusion/traffic_light_multi_camera_fusion.param.yaml"/>
+    <arg
+      name="traffic_light_multi_camera_fusion_param_path"
+      value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_multi_camera_fusion/traffic_light_multi_camera_fusion.param.yaml"
+    />
     <arg name="traffic_light_fine_detector_model_path" value="$(var data_path)/traffic_light_fine_detector"/>
     <arg name="traffic_light_fine_detector_model_name" value="tlr_car_ped_yolox_s_batch_6"/>
     <arg name="traffic_light_classifier_model_path" value="$(var data_path)/traffic_light_classifier"/>


### PR DESCRIPTION
## Description
PR for universe: https://github.com/autowarefoundation/autoware.universe/pull/10144

Currently, the parameters for `traffic_light_multi_camera_fusion` are [hardcoded in the launch file](https://github.com/autowarefoundation/autoware.universe/blob/b4d9155fbe78aaf35f976af808b2ca62d1727d1f/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml#L61-L62), preventing modifications from the launch file.
To resolve this issue, I modified it to read parameters from a YAML file in `autoware_launch`.

## How was this PR tested?
Please see https://github.com/autowarefoundation/autoware.universe/pull/10144

## Notes for reviewers
The default values in the parameter file is the same as the one in `autoware.universe`.
https://github.com/TomohitoAndo/autoware.universe/blob/614ac8e762e644aec1b1d2b74b87755c27f1a453/perception/autoware_traffic_light_multi_camera_fusion/config/traffic_light_multi_camera_fusion.param.yaml

## Effects on system behavior

None.
