### PR TITLE
feat(path_generator): add parameters

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/path_generator/path_generator.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/path_generator/path_generator.param.yaml
@@ -12,5 +12,5 @@
       search_distance: 30.0
       resampling_interval: 1.0
       angle_threshold_deg: 15.0
-    refine_goal_search_radius_range: 10.0  # [m]
+    refine_goal_search_radius_range: 7.5  # [m]
     search_radius_decrement: 1.0

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/path_generator/path_generator.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/path_generator/path_generator.param.yaml
@@ -12,3 +12,5 @@
       search_distance: 30.0
       resampling_interval: 1.0
       angle_threshold_deg: 15.0
+    refine_goal_search_radius_range: 10.0  # [m]
+    search_radius_decrement: 1.0


### PR DESCRIPTION
## Description

Adds following two parameters for `autoware_path_generator` package on the `autoware.core` side.

```
    refine_goal_search_radius_range: 7.5  # [m]
    search_radius_decrement: 1.0
```

This fix is for this `autoware.core` side PR: https://github.com/autowarefoundation/autoware.core/pull/227. Thus, **THIS PR MUST BE MERGED WITH THE `autoware.core` SIDE PR AT THE SAME TIME TOGETHER**.

## How was this PR tested?

The tests are performed by using the scenario evaluator. Please see the PR description in the following PR:
https://github.com/autowarefoundation/autoware.core/pull/227

## Notes for reviewers

Please do not enable auto merge as we need to be aware of the timing of merge as description above.

## Effects on system behavior

The `autoware.core` side will have a feature that makes the path smooth ([link to PR](https://github.com/autowarefoundation/autoware.core/pull/227))