### PR TITLE
feat(dummy_infrastructur): auto approval when ego stops at stop line

### DIFF
--- a/autoware_launch/config/planning/preset/default_preset.yaml
+++ b/autoware_launch/config/planning/preset/default_preset.yaml
@@ -64,7 +64,7 @@ launch:
       default: "true"
   - arg:
       name: launch_virtual_traffic_light_module
-      default: "false"
+      default: "true"
   - arg:
       name: launch_no_stopping_area_module
       default: "true"

--- a/autoware_launch/launch/components/tier4_simulator_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_simulator_component.launch.xml
@@ -82,4 +82,7 @@
       value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/tracking/tracking_object_merger/decorative_tracker_merger.param.yaml"
     />
   </include>
+  <group if="$(var scenario_simulation)">
+    <include file="$(find-pkg-share autoware_dummy_infrastructure)/launch/dummy_infrastructure.launch.xml"/>
+  </group>
 </launch>


### PR DESCRIPTION
## Description

launcher update for https://github.com/autowarefoundation/autoware.universe/pull/10223

- enable virtual traffic light by default
- launch dummy_infrastructure when scenario simulator

## How was this PR tested?
same to https://github.com/autowarefoundation/autoware.universe/pull/10223
## Notes for reviewers

None.

## Effects on system behavior

None.
