### PR TITLE
fix(planning): param update for sudden stop

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop.param.yaml
@@ -3,7 +3,7 @@
     obstacle_stop:
       option:
         ignore_crossing_obstacle: true
-        suppress_sudden_stop: true
+        suppress_sudden_stop: false
 
       stop_planning:
         stop_margin : 5.0 # longitudinal margin to obstacle [m]


### PR DESCRIPTION
## Description
Without this PR, the stop position by the obstacle_stop_module moves forward when the ego cannot stop before the stop position due to the control error, etc.
In the simulation test and real experiment, there were some cases where the ego cannot decelerate well, and the ego got very close to the front object. To reduce this risk, this PR disables the flag.
## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
