### PR TITLE
feat(planning_validator): add diag to check planning component latency

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/common/planning_validator/planning_validator.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/common/planning_validator/planning_validator.param.yaml
@@ -27,6 +27,7 @@
       velocity_deviation: 100.0
       distance_deviation: 100.0
       longitudinal_distance_deviation: 1.0
+      nominal_latency: 1.0
 
     parameters:
       # The required trajectory length is calculated as the distance needed


### PR DESCRIPTION
## Description

- https://github.com/autowarefoundation/autoware.universe/pull/10241

Add new nominal latency threshold.

```patch
diff --git a/autoware_launch/config/planning/scenario_planning/common/planning_validator/planning_validator.param.yaml b/autoware_launch/config/planning/scenario_planning/common/planning_validator/planning_validator.param.yaml
index da337d70..19fd7fec 100644
--- a/autoware_launch/config/planning/scenario_planning/common/planning_validator/planning_validator.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/common/planning_validator/planning_validator.param.yaml
@@ -27,6 +27,7 @@
       velocity_deviation: 100.0
       distance_deviation: 100.0
       longitudinal_distance_deviation: 1.0
+      nominal_latency: 0.1
 
     parameters:
       # The required trajectory length is calculated as the distance needed
```

## How was this PR tested?

Psim&Evaluator

## Notes for reviewers

None.

## Effects on system behavior

None.
