### PR TITLE
chore: update labeler.yaml for v5

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,33 +1,55 @@
-"type:ci":
-  - .github/**/*
-  - "*.json"
-  - "*.yaml"
-  - "*.cfg"
-  - .clang-format
-  - .gitignore
-  - .prettierignore
-"type:documentation":
-  - "**/*.md"
-  - "**/*.rst"
-  - "**/*.jpg"
-  - "**/*.png"
-  - "**/*.svg"
-"component:control":
-  - "**/*control*"
-"component:localization":
-  - "**/*localization*"
-"component:map":
-  - "**/*map*"
-"component:perception":
-  - "**/*perception*"
-"component:planning":
-  - "**/*planning*"
-"component:sensing":
-  - "**/*sensing*"
-"component:simulation":
-  - "**/*simulator*"
-"component:system":
-  - "**/*system*"
-"component:ui":
-  - "**/*.rviz"
-  - "**/rviz"
+type:ci:
+  - changed_files:
+      - any-glob-to-any-file:
+          - .github/**/*
+          - "*.json"
+          - "*.yaml"
+          - "*.cfg"
+          - .clang-format
+          - .gitignore
+          - .prettierignore
+type:documentation:
+  - changed_files:
+      - any-glob-to-any-file:
+          - "*.md"
+          - "*.rst"
+          - "*.jpg"
+          - "*.png"
+          - "*.svg"
+component:control:
+  - changed_files:
+      - any-glob-to-any-file:
+          - "**/*control*"
+component:localization:
+  - changed_files:
+      - any-glob-to-any-file:
+          - "**/*localization*"
+component:map:
+  - changed_files:
+      - any-glob-to-any-file:
+          - "**/*map*"
+component:perception:
+  - changed_files:
+      - any-glob-to-any-file:
+          - "**/*perception*"
+component:planning:
+  - changed_files:
+      - any-glob-to-any-file:
+          - "**/*planning*"
+component:sensing:
+  - changed_files:
+      - any-glob-to-any-file:
+          - "**/*sensing*"
+component:simulation:
+  - changed_files:
+      - any-glob-to-any-file:
+          - "**/*simulation*"
+component:system:
+  - changed_files:
+      - any-glob-to-any-file:
+          - "**/*system*"
+component:ui:
+  - changed_files:
+      - any-glob-to-any-file:
+          - "**/*.rviz"
+          - "**/rviz"

--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,5 +1,5 @@
 type:ci:
-  - changed_files:
+  - changed-files:
       - any-glob-to-any-file:
           - .github/**/*
           - "*.json"
@@ -9,7 +9,7 @@ type:ci:
           - .gitignore
           - .prettierignore
 type:documentation:
-  - changed_files:
+  - changed-files:
       - any-glob-to-any-file:
           - "*.md"
           - "*.rst"
@@ -17,39 +17,39 @@ type:documentation:
           - "*.png"
           - "*.svg"
 component:control:
-  - changed_files:
+  - changed-files:
       - any-glob-to-any-file:
           - "**/*control*"
 component:localization:
-  - changed_files:
+  - changed-files:
       - any-glob-to-any-file:
           - "**/*localization*"
 component:map:
-  - changed_files:
+  - changed-files:
       - any-glob-to-any-file:
           - "**/*map*"
 component:perception:
-  - changed_files:
+  - changed-files:
       - any-glob-to-any-file:
           - "**/*perception*"
 component:planning:
-  - changed_files:
+  - changed-files:
       - any-glob-to-any-file:
           - "**/*planning*"
 component:sensing:
-  - changed_files:
+  - changed-files:
       - any-glob-to-any-file:
           - "**/*sensing*"
 component:simulation:
-  - changed_files:
+  - changed-files:
       - any-glob-to-any-file:
           - "**/*simulation*"
 component:system:
-  - changed_files:
+  - changed-files:
       - any-glob-to-any-file:
           - "**/*system*"
 component:ui:
-  - changed_files:
+  - changed-files:
       - any-glob-to-any-file:
           - "**/*.rviz"
           - "**/rviz"


### PR DESCRIPTION
## Description

Fix labeler CI failures that have been occurring since https://github.com/autowarefoundation/autoware_launch/pull/1058 .
labeler.yaml must be updated as the labeler is updated to v5.

ref: https://github.com/actions/labeler/tree/main#pull-request-labeler

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
