### PR TITLE
feat(planning_simulator): disable tlr in psim

### DIFF
--- a/autoware_launch/launch/components/tier4_simulator_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_simulator_component.launch.xml
@@ -7,6 +7,7 @@
   <arg name="launch_scenario_simulator_v2_adapter"/>
   <arg name="perception/enable_detection_failure"/>
   <arg name="perception/enable_object_recognition"/>
+  <arg name="perception/enable_traffic_light"/>
   <arg name="perception/use_base_link_z"/>
   <arg name="sensing/visible_range"/>
   <arg name="vehicle_model"/>
@@ -23,6 +24,7 @@
     <arg name="launch_scenario_simulator_v2_adapter" value="$(var launch_scenario_simulator_v2_adapter)"/>
     <arg name="perception/enable_detection_failure" value="$(var perception/enable_detection_failure)"/>
     <arg name="perception/enable_object_recognition" value="$(var perception/enable_object_recognition)"/>
+    <arg name="perception/enable_traffic_light" value="$(var perception/enable_traffic_light)"/>
     <arg name="perception/use_base_link_z" value="$(var perception/use_base_link_z)"/>
     <arg name="sensing/visible_range" value="$(var sensing/visible_range)"/>
     <arg name="vehicle_model" value="$(var vehicle_model)"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -24,6 +24,7 @@
   <arg name="initial_engage_state" default="true" description="/vehicle/engage state after starting Autoware"/>
   <arg name="perception/enable_detection_failure" default="true" description="enable to simulate detection failure when using dummy perception"/>
   <arg name="perception/enable_object_recognition" default="true" description="enable object recognition when using dummy perception"/>
+  <arg name="perception/enable_traffic_light" default="false" description="enable traffic light recognition"/>
   <arg name="perception/use_base_link_z" default="true" description="dummy perception uses base_link z axis coordinate if it is true"/>
   <arg name="sensing/visible_range" default="300.0" description="visible range when using dummy perception"/>
   <arg name="scenario_simulation" default="false" description="use scenario simulation"/>
@@ -100,6 +101,7 @@
       <arg name="launch_scenario_simulator_v2_adapter" value="$(var launch_scenario_simulator_v2_adapter)"/>
       <arg name="perception/enable_detection_failure" value="$(var perception/enable_detection_failure)"/>
       <arg name="perception/enable_object_recognition" value="$(var perception/enable_object_recognition)"/>
+      <arg name="perception/enable_traffic_light" value="$(var perception/enable_traffic_light)"/>
       <arg name="perception/use_base_link_z" value="$(var perception/use_base_link_z)"/>
       <arg name="sensing/visible_range" value="$(var sensing/visible_range)"/>
       <arg name="vehicle_model" value="$(var vehicle_model)"/>


### PR DESCRIPTION
## Description

This PR disable to use TLR in planning_simulator. So it works well if you do not have cuda environment. (TLR often use cuda)

## How was this PR tested?

```
ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
```

## Notes for reviewers

None.

## Effects on system behavior

None.
