### PR TITLE
fix(obstacle_cruise_planner): ignore invalid stopping objects

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_cruise.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_cruise.param.yaml
@@ -95,6 +95,17 @@
             bicycle: false
             pedestrian: false
 
+          # If an object does not have this label, the ego vehicle does not assume that the yielded obstacle will cut in due to the object.
+          ahead_stopped:
+            unknown: false
+            car: true
+            truck: true
+            bus: true
+            trailer: true
+            motorcycle: true
+            bicycle: false
+            pedestrian: false
+
         max_lat_margin: 1.0 # lateral margin between obstacle and trajectory band with ego's width
 
         # if crossing vehicle is determined as target obstacles or not

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_cruise.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_cruise.param.yaml
@@ -96,7 +96,7 @@
             pedestrian: false
 
           # If an object does not have this label, the ego vehicle does not assume that the yielded obstacle will cut in due to the object.
-          ahead_stopped:
+          side_stopped:
             unknown: false
             car: true
             truck: true


### PR DESCRIPTION
## Description

* Please see https://github.com/autowarefoundation/autoware.universe/pull/10227

## How was this PR tested?

* Please see https://github.com/autowarefoundation/autoware.universe/pull/10227

## Notes for reviewers

None.

## Effects on system behavior

None.

