### PR TITLE
chore(autoware_launch): increase default speed limit 

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/common/common.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/common/common.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    max_vel: 4.17           # max velocity limit [m/s]
+    max_vel: 20.00           # max velocity limit [m/s]
 
     # constraints param for normal driving
     normal:


### PR DESCRIPTION
## Description

Currently the max speed that test vehicle can reach has been limited to 30 km/h. It is impossible for developer to test autoware under higher speed.

we increase default speed limit to 72km/h thus developer can test higher speed scenario both in planning simulator or AWSIM, 

## How was this PR tested?

1. planning simulator
2. AWSIM

![Screenshot from 2025-03-12 14-12-42](https://github.com/user-attachments/assets/ff6e012f-d78f-4574-b507-35374c39254b)


## Notes for reviewers

None.

## Effects on system behavior

None.
