### PR TITLE
feat(pid_long): disable overshoot_emergency

### DIFF
--- a/autoware_launch/config/control/trajectory_follower/longitudinal/pid.param.yaml
+++ b/autoware_launch/config/control/trajectory_follower/longitudinal/pid.param.yaml
@@ -3,7 +3,7 @@
     delay_compensation_time: 0.1
 
     enable_smooth_stop: true
-    enable_overshoot_emergency: true
+    enable_overshoot_emergency: false
     enable_large_tracking_error_emergency: true
     enable_slope_compensation: true
     enable_keep_stopped_until_steer_convergence: true


### PR DESCRIPTION
## Description
The behavior when crossing the stop line is handled by the control_validator as a reference. For this reason, similar functions on the pid_long side are disabled as default.

## How was this PR tested?
psim

## Notes for reviewers

None.

## Effects on system behavior

None.
