### PR TITLE
feat(crosswalk_module): add param to consider objects on crosswalk when pedestrian traffic light is red

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/crosswalk.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/crosswalk.param.yaml
@@ -46,6 +46,8 @@
         ego_pass_later_additional_margin: 0.5 # [s] additional time margin for object pass first situation to suppress chattering
         ego_min_assumed_speed: 2.0 # [m/s] assumed speed to calculate the time to collision point
 
+        consider_obj_on_crosswalk_on_red_light: false # consider and do not ignore objects if they are on the crosswalk when the crosswalk pedestrian traffic light is red
+
         no_stop_decision: # parameters to determine stop cancel. {-$overrun_threshold_length + f($min_acc, $min_jerk)} is compared against distance to stop pose.
           min_acc: -1.5 # min acceleration [m/ss]
           min_jerk: -1.5 # min jerk [m/sss]


### PR DESCRIPTION
## Description

This PR created to add `consider_obj_on_crosswalk_on_red_light` parameter to consider and do not ignore objects if they are on the crosswalk when the crosswalk pedestrian traffic light is red.

:bookmark_tabs:  It is left as `consider_obj_on_crosswalk_on_red_light`: `false` not to change the current system behavior. 

[Related universe PR link](https://github.com/autowarefoundation/autoware_universe/pull/10332)

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
