### PR TITLE
fix: add missing default param for concatenation

### DIFF
--- a/autoware_launch/config/perception/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml
+++ b/autoware_launch/config/perception/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml
@@ -35,3 +35,20 @@
 
         # debug parameters
         publish_processing_time_detail: false
+    # default parameters for concatenation node when addition_lidars or ransac inputs are used
+    concatenation:
+      parameters:
+        debug_mode: false
+        has_static_tf_only: false
+        rosbag_length: 10.0
+        maximum_queue_size: 5
+        timeout_sec: 0.2
+        is_motion_compensated: false
+        publish_synchronized_pointcloud: false
+        keep_input_frame_in_synchronized_pointcloud: true
+        publish_previous_but_late_pointcloud: false
+        synchronized_pointcloud_postfix: pointcloud
+        input_twist_topic_type: twist
+        output_frame: base_link
+        matching_strategy:
+          type: advanced

--- a/autoware_launch/config/perception/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml
+++ b/autoware_launch/config/perception/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml
@@ -51,4 +51,4 @@
         input_twist_topic_type: odom
         output_frame: base_link
         matching_strategy:
-          type: advanced
+          type: naive

--- a/autoware_launch/config/perception/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml
+++ b/autoware_launch/config/perception/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml
@@ -48,7 +48,7 @@
         keep_input_frame_in_synchronized_pointcloud: true
         publish_previous_but_late_pointcloud: false
         synchronized_pointcloud_postfix: pointcloud
-        input_twist_topic_type: twist
+        input_twist_topic_type: odom
         output_frame: base_link
         matching_strategy:
           type: advanced


### PR DESCRIPTION
## Description

- Add default parameter for concatenation nodes in ground_segmentation pipeline updated by https://github.com/autowarefoundation/autoware_universe/pull/10411

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
