### PR TITLE
fix(lane_departure_checker): replace curbstone to road_border (RT1-9845)

### DIFF
--- a/autoware_launch/config/control/lane_departure_checker/lane_departure_checker.param.yaml
+++ b/autoware_launch/config/control/lane_departure_checker/lane_departure_checker.param.yaml
@@ -12,7 +12,7 @@
     include_left_lanes: false
     include_opposite_lanes: false
     include_conflicting_lanes: false
-    boundary_types_to_detect: [curbstone]
+    boundary_types_to_detect: [road_border]
 
     # Core
     footprint_margin_scale: 1.0


### PR DESCRIPTION
## Description

The official supported road boundary tags is `road_border` and not `curbstone`. 
However, `road_border` is not the default setting for the `boundary_type_to_detect` in the lane departure checker. In this PR, we replace the default setting to `road_border`, and removed `curbstone` to prevent misleading tags.

## How was this PR tested?

Place ego vehicle on top of linestrings with road_border tags. Ensure that tier4_diagnostic is triggered.


## Notes for reviewers

None.

## Effects on system behavior

None.
