### PR TITLE
feat: remove individual_params references

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -71,7 +71,7 @@
       <arg name="sensor_model" value="$(var sensor_model)"/>
       <arg name="vehicle_id" value="$(var vehicle_id)"/>
       <arg name="launch_vehicle_interface" value="$(var launch_vehicle_interface)"/>
-      <arg name="config_dir" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/$(var sensor_model)"/>
+      <arg name="config_dir" value="$(find-pkg-share $(var sensor_model)_description)/config"/>
       <arg name="raw_vehicle_cmd_converter_param_path" value="$(find-pkg-share autoware_launch)/config/vehicle/raw_vehicle_cmd_converter/raw_vehicle_cmd_converter.param.yaml"/>
     </include>
   </group>

--- a/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_description/config/sensor_kit_calibration.yaml
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_description/config/sensor_kit_calibration.yaml
@@ -64,18 +64,18 @@ sensor_kit_base_link:
     yaw: 1.575
   velodyne_left_base_link:
     x: 0.0
-    y: 0.56362
+    y: 0.59
     z: -0.30555
     roll: -0.02
     pitch: 0.71
     yaw: 1.575
   velodyne_right_base_link:
     x: 0.0
-    y: -0.56362
+    y: -0.59
     z: -0.30555
-    roll: -0.01
+    roll: -0.02
     pitch: 0.71
-    yaw: -1.580
+    yaw: -1.575
   gnss_link:
     x: -0.1
     y: 0.0

--- a/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/launch/imu.launch.xml
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/launch/imu.launch.xml
@@ -5,14 +5,12 @@
       <arg name="input_topic" value="tamagawa/imu_raw"/>
       <arg name="output_topic" value="imu_data"/>
       <!-- We are using default node values -->
-      <!-- <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/awsim_sensor_kit/imu_corrector.param.yaml"/> -->
     </include>
 
     <include file="$(find-pkg-share autoware_imu_corrector)/launch/gyro_bias_estimator.launch.xml">
       <arg name="input_imu_raw" value="tamagawa/imu_raw"/>
       <arg name="input_odom" value="/localization/kinematic_state"/>
       <!-- We are using default node values -->
-      <!-- <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/awsim_sensor_kit/imu_corrector.param.yaml"/> -->
     </include>
   </group>
 </launch>

--- a/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_launch/launch/imu.launch.xml
+++ b/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_launch/launch/imu.launch.xml
@@ -5,14 +5,12 @@
       <arg name="input_topic" value="tamagawa/imu_raw"/>
       <arg name="output_topic" value="imu_data"/>
       <!-- We are using default node values -->
-      <!-- <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/awsim_sensor_kit/imu_corrector.param.yaml"/> -->
     </include>
 
     <include file="$(find-pkg-share autoware_imu_corrector)/launch/gyro_bias_estimator.launch.xml">
       <arg name="input_imu_raw" value="tamagawa/imu_raw"/>
       <arg name="input_odom" value="/localization/kinematic_state"/>
       <!-- We are using default node values -->
-      <!-- <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/awsim_sensor_kit/imu_corrector.param.yaml"/> -->
     </include>
   </group>
 </launch>

--- a/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_description/config/imu_corrector.param.yaml
+++ b/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_description/config/imu_corrector.param.yaml
@@ -1,0 +1,8 @@
+/**:
+  ros__parameters:
+    angular_velocity_stddev_xx: 0.00339
+    angular_velocity_stddev_yy: 0.00339
+    angular_velocity_stddev_zz: 0.00339
+    angular_velocity_offset_x: -0.005799
+    angular_velocity_offset_y: -0.007148
+    angular_velocity_offset_z: -0.001499

--- a/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/launch/imu.launch.xml
+++ b/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/launch/imu.launch.xml
@@ -14,7 +14,7 @@
     </group> -->
 
     <arg name="imu_raw_name" default="tamagawa/imu_raw"/>
-    <arg name="imu_corrector_param_file" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)/sample_sensor_kit/imu_corrector.param.yaml"/>
+    <arg name="imu_corrector_param_file" default="$(find-pkg-share sample_sensor_kit_description)/config/imu_corrector.param.yaml"/>
     <include file="$(find-pkg-share autoware_imu_corrector)/launch/imu_corrector.launch.xml">
       <arg name="input_topic" value="$(var imu_raw_name)"/>
       <arg name="output_topic" value="imu_data"/>


### PR DESCRIPTION
## Description

**Parent Issue:**
- https://github.com/autowarefoundation/autoware/issues/5975

### Changes

**Old location:**
https://github.com/autowarefoundation/autoware_individual_params/tree/main/individual_params/config/default/sample_sensor_kit

**New Location:**
https://github.com/autowarefoundation/autoware_launch/tree/main/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_description/config

- This has been repeated for all 4 managed `sensor_kit`s.
- The reference in `autoware.launch.xml` is updated.
- `sample_sensor_kit_launch/launch/imu.launch.xml`'s reference is updated.

## How was this PR tested?

- Tested with:
  - [AWSIM Labs Demo](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/digital-twin-simulation/awsim-tutorial/) (AWSIM should work the same way, changes are identical)
  - [Planning Simulator Demo](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/)
  - [Rosbag Replay Sim Demo](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/)

## Effects on system behavior

None.
