### PR TITLE
feat(duplicated_node_checker): ignore duplicate get parameter

### DIFF
--- a/autoware_launch/config/system/duplicated_node_checker/duplicated_node_checker.param.yaml
+++ b/autoware_launch/config/system/duplicated_node_checker/duplicated_node_checker.param.yaml
@@ -4,3 +4,4 @@
     add_duplicated_node_names_to_msg: true # if true, duplicated node names are added to msg
     nodes_to_ignore:  # List of nodes to ignore when checking for duplicates
       - /rviz2
+      - /simulation/getParameter


### PR DESCRIPTION
## Description
This adds `/simulation/getParameter` to the ignore list for duplicate node checker. 
Otherwise, Autoware won't start for scenario simulation.

## How was this PR tested?
Test with these PRs:
 - https://github.com/autowarefoundation/autoware/pull/6064
 - https://github.com/autowarefoundation/autoware/pull/6063

## Notes for reviewers

None.

## Effects on system behavior

None.
