### PR TITLE
feat(autoware_launch): use adapi diagnostics

### DIFF
--- a/autoware_launch/config/system/diagnostics/localization.yaml
+++ b/autoware_launch/config/system/diagnostics/localization.yaml
@@ -14,8 +14,8 @@ units:
 
   - path: /autoware/localization/state
     type: diag
-    node: component_state_diagnostics
-    name: localization_state
+    node: /adapi/node/localization
+    name: state
 
   - path: /autoware/localization/topic_rate_check/transform
     type: diag

--- a/autoware_launch/config/system/diagnostics/planning.yaml
+++ b/autoware_launch/config/system/diagnostics/planning.yaml
@@ -27,8 +27,8 @@ units:
 
   - path: /autoware/planning/routing/state
     type: diag
-    node: component_state_diagnostics
-    name: route_state
+    node: /adapi/node/routing
+    name: state
 
   - path: /autoware/planning/topic_rate_check/route
     type: diag


### PR DESCRIPTION
## Description

**This PR should be merged after https://github.com/autowarefoundation/autoware_universe/pull/10539.**
Use diagnostics from adapi node instead of the [component_state_diagnostics](https://github.com/autowarefoundation/autoware_universe/blob/main/system/autoware_system_diagnostic_monitor/script/component_state_diagnostics.py) script.

## How was this PR tested?

Check that the vehicle drives in autonomous mode using simple planning simulator.

## Notes for reviewers

None.

## Effects on system behavior

None.
