### PR TITLE
feat(behavior_velocity_planner)!: remove unused function parameter for extendLine

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
@@ -3,4 +3,3 @@
     forward_path_length: 1000.0
     backward_path_length: 5.0
     behavior_output_path_interval: 1.0
-    stop_line_extend_length: 5.0


### PR DESCRIPTION
## Description

This PR removes the unused parameter for `behavior_velocity_planner`. The PR and https://github.com/autowarefoundation/autoware_core/pull/457 must be merged at the same time.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
