### PR TITLE
chore: bump up version to 0.44.0

### DIFF
--- a/.github/CODEOWNERS-manual
+++ b/.github/CODEOWNERS-manual
@@ -4,7 +4,7 @@ autoware_launch/** yukihiro.saito@tier4.jp ryohsuke.mitsudome@tier4.jp mfc@leodr
 autoware_launch/config/control/** takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp kosuke.takeuchi@tier4.jp yuki.takagi@tier4.jp alqudah.mohammad@tier4.jp kyoichi.sugahara@tier4.jp zulfaqar.azmi@tier4.jp maxime.clement@tier4.jp mamoru.sobue@tier4.jp yukinari.hisaki.2@tier4.jp
 autoware_launch/config/localization/** masahiro.sakamoto@tier4.jp yamato.ando@tier4.jp ryu.yamamoto@tier4.jp kento.yabuuchi.2@tier4.jp shintaro.sakoda@tier4.jp taiki.yamada@tier4.jp anh.nguyen.2@tier4.jp
 autoware_launch/config/map/** masahiro.sakamoto@tier4.jp yamato.ando@tier4.jp ryu.yamamoto@tier4.jp kento.yabuuchi.2@tier4.jp shintaro.sakoda@tier4.jp taiki.yamada@tier4.jp anh.nguyen.2@tier4.jp
-autoware_launch/config/perception/** yoshi.ri@tier4.jp koji.minoda@tier4.jp taekjin.lee@tier4.jp
+autoware_launch/config/perception/** yoshi.ri@tier4.jp taekjin.lee@tier4.jp masato.saeki@tier4.jp lei.gu@tier4.jp
 autoware_launch/config/planning/** takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp kosuke.takeuchi@tier4.jp yuki.takagi@tier4.jp alqudah.mohammad@tier4.jp kyoichi.sugahara@tier4.jp zulfaqar.azmi@tier4.jp maxime.clement@tier4.jp mamoru.sobue@tier4.jp yukinari.hisaki.2@tier4.jp
 autoware_launch/config/simulator/** takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp
 autoware_launch/config/system/** fumihito.ito@tier4.jp isamu.takagi@tier4.jp
@@ -13,9 +13,9 @@ autoware_launch/launch/components/tier4_autoware_api_component.launch.xml isamu.
 autoware_launch/launch/components/tier4_control_component.launch.xml takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp kosuke.takeuchi@tier4.jp yuki.takagi@tier4.jp alqudah.mohammad@tier4.jp kyoichi.sugahara@tier4.jp zulfaqar.azmi@tier4.jp maxime.clement@tier4.jp mamoru.sobue@tier4.jp yukinari.hisaki.2@tier4.jp
 autoware_launch/launch/components/tier4_localization_component.launch.xml masahiro.sakamoto@tier4.jp yamato.ando@tier4.jp ryu.yamamoto@tier4.jp kento.yabuuchi.2@tier4.jp shintaro.sakoda@tier4.jp taiki.yamada@tier4.jp anh.nguyen.2@tier4.jp
 autoware_launch/launch/components/tier4_map_component.launch.xml masahiro.sakamoto@tier4.jp yamato.ando@tier4.jp ryu.yamamoto@tier4.jp kento.yabuuchi.2@tier4.jp shintaro.sakoda@tier4.jp taiki.yamada@tier4.jp anh.nguyen.2@tier4.jp
-autoware_launch/launch/components/tier4_perception_component.launch.xml yoshi.ri@tier4.jp koji.minoda@tier4.jp taekjin.lee@tier4.jp
+autoware_launch/launch/components/tier4_perception_component.launch.xml yoshi.ri@tier4.jp taekjin.lee@tier4.jp masato.saeki@tier4.jp lei.gu@tier4.jp
 autoware_launch/launch/components/tier4_planning_component.launch.xml takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp kosuke.takeuchi@tier4.jp yuki.takagi@tier4.jp alqudah.mohammad@tier4.jp kyoichi.sugahara@tier4.jp zulfaqar.azmi@tier4.jp maxime.clement@tier4.jp mamoru.sobue@tier4.jp yukinari.hisaki.2@tier4.jp
-autoware_launch/launch/components/tier4_sensing_component.launch.xml yoshi.ri@tier4.jp koji.minoda@tier4.jp
+autoware_launch/launch/components/tier4_sensing_component.launch.xml yoshi.ri@tier4.jp taekjin.lee@tier4.jp kenzo.lobos@tier4.jp
 autoware_launch/launch/components/tier4_simulator_component.launch.xml takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp
 autoware_launch/launch/components/tier4_system_component.launch.xml fumihito.ito@tier4.jp isamu.takagi@tier4.jp shumpei.wakabayashi@tier4.jp tomoya.kimura@tier4.jp
 autoware_launch/rviz/**  # no codeowners

--- a/autoware_launch/CHANGELOG.rst
+++ b/autoware_launch/CHANGELOG.rst
@@ -2,6 +2,97 @@
 Changelog for package autoware_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* feat(out_of_lane): improve out of lane stability (`#1404 <https://github.com/autowarefoundation/autoware_launch/issues/1404>`_)
+  * update out_of_lane parameters
+  * change parameter value
+  * remove unused parameter
+  * fix spelling
+  ---------
+* feat(control_validator): add over run estimation feature (`#1394 <https://github.com/autowarefoundation/autoware_launch/issues/1394>`_)
+* feat(autoware_launch): add ColoredPoseWithCovarianceHistory to Localization NDT (`#1382 <https://github.com/autowarefoundation/autoware_launch/issues/1382>`_)
+  * feat: update autoware.rviz
+  - add Localization/NDT ColoredPoseWithCovarianceHistory
+  * add: /localization/pose_estimator/nearest_voxel_transformation_likelihood
+  * change color and alpha
+  * fix: buffer size (15 seconds)
+  * fix: typo
+  * fix: add space
+  ---------
+* feat(traffic_light): add traffic light restart suppression parameters (`#1405 <https://github.com/autowarefoundation/autoware_launch/issues/1405>`_)
+  * feat: add traffic light restart_suppression param
+  * style(pre-commit): autofix
+  ---------
+  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
+* feat: remove individual_params references (`#1403 <https://github.com/autowarefoundation/autoware_launch/issues/1403>`_)
+* refactor(planning_validator): separate validation check for steering and steering rate (`#1402 <https://github.com/autowarefoundation/autoware_launch/issues/1402>`_)
+  feat(planning_validator): separate steering rate parameter for improved configuration
+* feat(lidar_transfusion): add transfusion common param file (`#1400 <https://github.com/autowarefoundation/autoware_launch/issues/1400>`_)
+  add transfusion_common param
+* feat(multi_object_tracker): add detailed processing time publishing option (`#1398 <https://github.com/autowarefoundation/autoware_launch/issues/1398>`_)
+  * feat(multi_object_tracker): add detailed processing time publishing option
+  * fix(multi_object_tracker): disable detailed processing time publishing option
+  ---------
+* feat(radar_object_tracker): add diagnostics param (`#1399 <https://github.com/autowarefoundation/autoware_launch/issues/1399>`_)
+  * add diagnostics param
+  * fix param name
+  * change callback param name
+  ---------
+* feat(multi_object_tracker): vehicle's ego frame as a parameter (`#1397 <https://github.com/autowarefoundation/autoware_launch/issues/1397>`_)
+* revert(lane_departure_checker): "fix(lane_departure_checker): replace curbstone to road_border… (`#1395 <https://github.com/autowarefoundation/autoware_launch/issues/1395>`_)
+  Revert "fix(lane_departure_checker): replace curbstone to road_border (RT1-9845) (`#1391 <https://github.com/autowarefoundation/autoware_launch/issues/1391>`_)"
+  This reverts commit b26f3375d419f5e2e2621d8b36b7d6e8a0ded209.
+* feat(probabilistic_occupancy_grid_map): add diagnostics warning when … (`#1387 <https://github.com/autowarefoundation/autoware_launch/issues/1387>`_)
+  * feat(probabilistic_occupancy_grid_map): add diagnostics warning when latency is too long
+  * style(pre-commit): autofix
+  * feat(probabilistic_occupancy_grid_map):add tolerance duration
+  * feat(probabilistic_occupancy_grid_map):  fix variable names to processing time
+  ---------
+  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
+* fix(lane_departure_checker): replace curbstone to road_border (RT1-9845) (`#1391 <https://github.com/autowarefoundation/autoware_launch/issues/1391>`_)
+  fix(lane_departure_checker): replace curbstone to road_border
+* feat(lidar_centerpoint): add common param file (`#1377 <https://github.com/autowarefoundation/autoware_launch/issues/1377>`_)
+  * add common param
+  * fix comment and change value to float
+  ---------
+* feat(autoware_launch): remove exec_depend on autoware_launch from tier4_simulator_launch (`#1392 <https://github.com/autowarefoundation/autoware_launch/issues/1392>`_)
+* refactor(planning_validator): restructure planning validator configuration (`#1389 <https://github.com/autowarefoundation/autoware_launch/issues/1389>`_)
+  update planning validator config
+* feat: add parameter for irregular object pipeline (`#1381 <https://github.com/autowarefoundation/autoware_launch/issues/1381>`_)
+  * feat: add parameter for small unknown object pipeline
+  * chore: rename param
+  * refactor
+  * chore: spelling
+  * refactor: file renaming
+  * fix: param rename
+  * refactor: param path update
+  ---------
+* feat(multi_object_tracker): add diagnostics warning when extrapolation time exceeds limit with latency guarantee enabled (`#1378 <https://github.com/autowarefoundation/autoware_launch/issues/1378>`_)
+  * feat(multi_object_tracker): add diagnostics warning when extrapolation time exceeds limit with latency guarantee enabled
+  * style(pre-commit): autofix
+  ---------
+  Co-authored-by: lei.gu <lei.gu@tier4.jp>
+  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
+* fix(detection_area): integrate RTC feature (`#1383 <https://github.com/autowarefoundation/autoware_launch/issues/1383>`_)
+* feat(start/goal_planner): update max steer angle parameters to use margin scale (`#1368 <https://github.com/autowarefoundation/autoware_launch/issues/1368>`_)
+* feat: add parameter for diagnostics (`#1362 <https://github.com/autowarefoundation/autoware_launch/issues/1362>`_)
+* feat(perception): add parameter for diag (`#1357 <https://github.com/autowarefoundation/autoware_launch/issues/1357>`_)
+  * add parameter for diag
+  * change param name
+  * add unit
+  ---------
+* fix(roi_pointcloud_fusion): add roi scale factor param (`#1376 <https://github.com/autowarefoundation/autoware_launch/issues/1376>`_)
+* feat(control_validator)!: add acceleration check (`#1375 <https://github.com/autowarefoundation/autoware_launch/issues/1375>`_)
+* feat(crosswalk_module): add param to consider objects on crosswalk when pedestrian traffic light is red (`#1374 <https://github.com/autowarefoundation/autoware_launch/issues/1374>`_)
+* feat(crosswalk): fix stop position calclaton params (`#1370 <https://github.com/autowarefoundation/autoware_launch/issues/1370>`_)
+* feat(multi_object_tracker): add input channel flags for selective update per channel (`#1364 <https://github.com/autowarefoundation/autoware_launch/issues/1364>`_)
+  feat(multi_object_tracker): update input channel flags for improved tracking parameters
+* feat(goal_planner): expand outer collision check margin (`#1365 <https://github.com/autowarefoundation/autoware_launch/issues/1365>`_)
+* Contributors: Amadeusz Szymko, Kazu, Kosuke Takeuchi, Kotaro Uetake, Kyoichi Sugahara, Masaki Baba, Masato Saeki, Mehmet Dogru, Mete Fatih Cırıt, Ryohsuke Mitsudome, Satoshi OTA, Taekjin LEE, Takagi, Isamu, Yuki TAKAGI, Yutaka Kondo, Zulfaqar Azmi, badai nguyen, eiki, lei.gu, mkquda
+
 0.43.1 (2025-04-01)
 -------------------
 

--- a/autoware_launch/config/control/control_validator/control_validator.param.yaml
+++ b/autoware_launch/config/control/control_validator/control_validator.param.yaml
@@ -9,11 +9,17 @@
 
     thresholds:
       max_distance_deviation: 1.0
+      acc_error_offset: 0.8
+      acc_error_scale: 0.2
       rolling_back_velocity: 0.5
       over_velocity_offset: 2.0
       over_velocity_ratio: 0.2
       overrun_stop_point_dist: 0.8
+      will_overrun_stop_point_dist: 1.0
+      assumed_limit_acc: 5.0
+      assumed_delay_time: 0.2
       nominal_latency: 0.01
 
+    acc_lpf_gain: 0.97 # Time constant 1.11s
     vel_lpf_gain: 0.9 # Time constant 0.33
     hold_velocity_error_until_stop: true

--- a/autoware_launch/config/perception/object_recognition/detection/image_projection_based_fusion/roi_pointcloud_fusion.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/image_projection_based_fusion/roi_pointcloud_fusion.param.yaml
@@ -4,3 +4,4 @@
     min_cluster_size: 2
     max_cluster_size: 20
     cluster_2d_tolerance: 0.5
+    roi_scale_factor: 1.0

--- a/autoware_launch/config/perception/object_recognition/detection/irregular_object_detection/irregular_object_detector.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/irregular_object_detection/irregular_object_detector.param.yaml
@@ -1,0 +1,41 @@
+/**:
+  ros__parameters:
+    crop_box_filter:
+      parameters:
+        min_x: 5.0
+        max_x: 60.0
+        min_y: -5.0
+        max_y: 5.0
+        max_z: 0.5
+        min_z: -0.5
+        negative: False
+
+    ground_segmentation:
+      plugin: "ground_segmentation::ScanGroundFilterComponent"
+      parameters:
+        global_slope_max_angle_deg: 6.0
+        local_slope_max_angle_deg: 25.0
+        split_points_distance_tolerance: 0.2
+        use_virtual_ground_point: True
+        split_height_distance: 0.2
+        non_ground_height_threshold: 0.05
+        grid_size_m: 0.2
+        grid_mode_switch_radius: 20.0
+        gnd_grid_buffer_size: 5
+        detection_range_z_max: 3.2
+        elevation_grid_mode: true
+        use_recheck_ground_cluster: true
+        use_lowest_point: false
+        low_priority_region_x: -20.0
+        center_pcl_shift: 0.0
+        radial_divider_angle_deg: 1.0
+        # debug parameters
+        publish_processing_time_detail: false
+
+    roi_pointcloud_fusion:
+      parameters:
+        fuse_unknown_only: true
+        min_cluster_size: 2
+        max_cluster_size: 100
+        cluster_2d_tolerance: 0.5
+        roi_scale_factor: 2.0

--- a/autoware_launch/config/perception/object_recognition/detection/lidar_model/centerpoint_common.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/lidar_model/centerpoint_common.param.yaml
@@ -1,0 +1,11 @@
+/**:
+  ros__parameters:
+    diagnostics:
+      # When the processing time exceeds the max_allowed_processing_time,
+      # a warning will be triggered.
+      max_allowed_processing_time_ms: 200.0 # in milliseconds
+      # If the warning is triggered and if a timestamp of last normal processing is more than
+      # max_acceptable_consecutive_delay_ms, an error diagnostic message will be sent.
+      max_acceptable_consecutive_delay_ms: 1000.0
+      # interval of diagnostic callback in milliseconds
+      validation_callback_interval_ms: 100.0 # in milliseconds

--- a/autoware_launch/config/perception/object_recognition/detection/lidar_model/transfusion_common.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/lidar_model/transfusion_common.param.yaml
@@ -1,0 +1,6 @@
+/**:
+  ros__parameters:
+    diagnostics:
+      max_allowed_processing_time_ms: 200.0
+      max_acceptable_consecutive_delay_ms: 1000.0
+      validation_callback_interval_ms: 100.0

--- a/autoware_launch/config/perception/object_recognition/prediction/map_based_prediction.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/prediction/map_based_prediction.param.yaml
@@ -54,3 +54,5 @@
     publish_processing_time: true
     publish_processing_time_detail: true
     publish_debug_markers: true
+    processing_time_tolerance: 0.5 #[s]
+    processing_time_consecutive_excess_tolerance: 1.0 #[s]

--- a/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
@@ -3,39 +3,63 @@
     input_channels:
       detected_objects:
         topic: "/perception/object_recognition/detection/objects"
-        can_spawn_new_tracker: true
         optional:
           name: "detected_objects"
           short_name: "all"
       # LIDAR - rule-based
       lidar_clustering:
         topic: "/perception/object_recognition/detection/clustering/objects"
-        can_spawn_new_tracker: true
+        flags:
+          can_spawn_new_tracker: true
+          can_trust_existence_probability: false
+          can_trust_extension: false
+          can_trust_classification: false
+          can_trust_orientation: false
         optional:
           name: "clustering"
           short_name: "Lcl"
       # LIDAR - DNN
       lidar_centerpoint:
         topic: "/perception/object_recognition/detection/centerpoint/objects"
-        can_spawn_new_tracker: true
+        flags:
+          can_spawn_new_tracker: true
+          can_trust_existence_probability: true
+          can_trust_extension: true
+          can_trust_classification: true
+          can_trust_orientation: true
         optional:
           name: "centerpoint"
           short_name: "Lcp"
       lidar_centerpoint_validated:
         topic: "/perception/object_recognition/detection/centerpoint/validation/objects"
-        can_spawn_new_tracker: true
+        flags:
+          can_spawn_new_tracker: true
+          can_trust_existence_probability: true
+          can_trust_extension: true
+          can_trust_classification: true
+          can_trust_orientation: true
         optional:
           name: "centerpoint"
           short_name: "Lcp"
       lidar_apollo:
         topic: "/perception/object_recognition/detection/apollo/objects"
-        can_spawn_new_tracker: true
+        flags:
+          can_spawn_new_tracker: true
+          can_trust_existence_probability: true
+          can_trust_extension: true
+          can_trust_classification: true
+          can_trust_orientation: true
         optional:
           name: "apollo"
           short_name: "Lap"
       lidar_apollo_validated:
         topic: "/perception/object_recognition/detection/apollo/validation/objects"
-        can_spawn_new_tracker: true
+        flags:
+          can_spawn_new_tracker: true
+          can_trust_existence_probability: true
+          can_trust_extension: true
+          can_trust_classification: true
+          can_trust_orientation: true
         optional:
           name: "apollo"
           short_name: "Lap"
@@ -43,40 +67,70 @@
       # cspell:ignore lidar_pointpainting pointpainting
       lidar_pointpainting:
         topic: "/perception/object_recognition/detection/pointpainting/objects"
-        can_spawn_new_tracker: true
+        flags:
+          can_spawn_new_tracker: true
+          can_trust_existence_probability: true
+          can_trust_extension: true
+          can_trust_classification: true
+          can_trust_orientation: true
         optional:
           name: "pointpainting"
           short_name: "Lpp"
       lidar_pointpainting_validated:
         topic: "/perception/object_recognition/detection/pointpainting/validation/objects"
-        can_spawn_new_tracker: true
+        flags:
+          can_spawn_new_tracker: true
+          can_trust_existence_probability: true
+          can_trust_extension: true
+          can_trust_classification: true
+          can_trust_orientation: true
         optional:
           name: "pointpainting"
           short_name: "Lpp"
       # CAMERA-LIDAR
       camera_lidar_fusion:
         topic: "/perception/object_recognition/detection/clustering/camera_lidar_fusion/objects"
-        can_spawn_new_tracker: true
+        flags:
+          can_spawn_new_tracker: true
+          can_trust_existence_probability: false
+          can_trust_extension: false
+          can_trust_classification: true
+          can_trust_orientation: false
         optional:
           name: "camera_lidar_fusion"
           short_name: "CLf"
       # CAMERA-LIDAR+TRACKER
       detection_by_tracker:
         topic: "/perception/object_recognition/detection/detection_by_tracker/objects"
-        can_spawn_new_tracker: false
+        flags:
+          can_spawn_new_tracker: false
+          can_trust_existence_probability: false
+          can_trust_extension: false
+          can_trust_classification: false
+          can_trust_orientation: false
         optional:
           name: "detection_by_tracker"
           short_name: "dbT"
       # RADAR
       radar:
         topic: "/sensing/radar/detected_objects"
-        can_spawn_new_tracker: true
+        flags:
+          can_spawn_new_tracker: true
+          can_trust_existence_probability: true
+          can_trust_extension: false
+          can_trust_classification: true
+          can_trust_orientation: false
         optional:
           name: "radar"
           short_name: "R"
       radar_far:
         topic: "/perception/object_recognition/detection/radar/far_objects"
-        can_spawn_new_tracker: true
+        flags:
+          can_spawn_new_tracker: true
+          can_trust_existence_probability: true
+          can_trust_extension: false
+          can_trust_classification: true
+          can_trust_orientation: false
         optional:
           name: "radar_far"
           short_name: "Rf"

--- a/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/multi_object_tracker_node.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/multi_object_tracker_node.param.yaml
@@ -12,6 +12,7 @@
     # default tracker node parameters
     publish_rate: 10.0
     world_frame_id: map
+    ego_frame_id: base_link
     enable_delay_compensation: true
     consider_odometry_uncertainty: false
 
@@ -32,7 +33,10 @@
 
     # debug parameters
     publish_processing_time: true
+    publish_processing_time_detail: false
     publish_tentative_objects: false
     publish_debug_markers: true
     diagnostics_warn_delay: 0.5      # [sec]
     diagnostics_error_delay: 1.0     # [sec]
+    diagnostics_warn_extrapolation: 0.5      # [sec]
+    diagnostics_error_extrapolation: 1.0      # [sec]

--- a/autoware_launch/config/perception/object_recognition/tracking/radar_object_tracker/radar_object_tracker.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/radar_object_tracker/radar_object_tracker.param.yaml
@@ -27,3 +27,9 @@
 
     # tracking model parameters
     tracking_config_directory: $(find-pkg-share autoware_launch)/config/perception/object_recognition/tracking/radar_object_tracker/tracking/
+
+    diagnostics:
+      # When the elapsed time from last radar data input exceeds the radar_input_stale_threshold_ms,
+      # a warning will be triggered.
+      radar_input_stale_threshold_ms: 500.0 # [milliseconds]
+      diagnose_callback_interval: 100.0 # [milliseconds]

--- a/autoware_launch/config/perception/object_recognition/tracking/tracking_object_merger/decorative_tracker_merger.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/tracking_object_merger/decorative_tracker_merger.param.yaml
@@ -5,7 +5,7 @@
     merge_frame_id: "map"
     time_sync_threshold: 0.999
     sub_object_timeout_sec: 0.8
-    publish_interpolated_sub_objects: true #for debug
+    publish_interpolated_sub_objects: true # for debug
 
     # choose the input sensor type for each object type
     # "lidar", "radar", "camera" are available
@@ -25,3 +25,8 @@
     # logging
     enable_logging: false
     logging_file_path: "/tmp/decorative_tracker_merger.log"
+
+    # diagnostics
+    delay_main_objects_tolerance: 1.0 # [sec]
+    duration_empty_main_objects_tolerance: 5.0 # [sec]
+    delay_sub_objects_tolerance: 5.0 # [sec]

--- a/autoware_launch/config/perception/occupancy_grid_map/pointcloud_based_occupancy_grid_map.param.yaml
+++ b/autoware_launch/config/perception/occupancy_grid_map/pointcloud_based_occupancy_grid_map.param.yaml
@@ -35,3 +35,5 @@
 
     # debug parameters
     publish_processing_time_detail: false
+    processing_time_tolerance_ms: 50.0 # [ms]
+    processing_time_consecutive_excess_tolerance_ms: 1000.0 # [ms]

--- a/autoware_launch/config/planning/scenario_planning/common/planning_validator/planning_validator.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/common/planning_validator/planning_validator.param.yaml
@@ -4,7 +4,9 @@
     #  0: publish the trajectory even if it is invalid
     #  1: stop publishing the trajectory
     #  2: publish the last validated trajectory
-    invalid_trajectory_handling_type: 0
+    handling_type:
+      noncritical: 0
+      critical: 2
 
     publish_diag: true  # if true, diagnostic msg is published
 
@@ -12,30 +14,48 @@
     # (For example, threshold = 1 means, even if the trajectory is invalid, Diag will not be ERROR if
     #  the next trajectory is valid.)
     diag_error_count_threshold: 0
-
     display_on_terminal: true # show error msg on terminal
 
-    thresholds:
-      interval: 100.0
-      relative_angle: 2.0  # (= 115 degree)
-      curvature: 1.0
-      lateral_acc: 9.8
-      longitudinal_max_acc: 9.8
-      longitudinal_min_acc: -9.8
-      steering: 1.414
-      steering_rate: 10.0
-      velocity_deviation: 100.0
-      distance_deviation: 100.0
-      longitudinal_distance_deviation: 1.0
-      nominal_latency: 1.0
-      yaw_deviation: 1.5708  # (= 90 degrees)
-
-    parameters:
-      # The required trajectory length is calculated as the distance needed
-      # to stop from the current speed at this deceleration.
-      forward_trajectory_length_acceleration: -3.0
-
-      # An error is raised if the required trajectory length is less than this distance.
-      # Setting it to 0 means an error will occur if even slightly exceeding the end of the path,
-      # therefore, a certain margin is necessary.
-      forward_trajectory_length_margin: 2.0
+    validity_checks:
+      latency:
+        enable: true
+        threshold: 1.0
+        is_critical: false
+      interval:
+        enable: true
+        threshold: 100.0
+        is_critical: false
+      curvature:
+        enable: true
+        threshold: 1.0
+        is_critical: false
+      relative_angle:
+        enable: true
+        threshold: 2.0 # (= 115 degree)
+        is_critical: false
+      acceleration:
+        enable: true
+        lateral_th: 9.8
+        longitudinal_max_th: 9.8
+        longitudinal_min_th: -9.8
+        is_critical: false
+      steering:
+        enable: true
+        threshold: 1.414
+        is_critical: false
+      steering_rate:
+        enable: true
+        threshold: 10.0
+        is_critical: false
+      deviation:
+        enable: true
+        velocity_th: 100.0
+        distance_th: 100.0
+        lon_distance_th: 1.0
+        yaw_th: 1.5708 # (= 90 degrees)
+        is_critical: false
+      forward_trajectory_length:
+        enable: true
+        acceleration: -3.0
+        margin: 2.0
+        is_critical: false

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
@@ -42,6 +42,7 @@
         collision_check_soft_margins: [5.0, 4.5, 4.0, 3.5, 3.0, 2.5, 2.0, 1.5, 1.0]  # the maximum margin when ego and objects are oriented.
         collision_check_hard_margins: [0.6]  # this should be larger than `surround_check_distance` of surround_obstacle_checker
         object_recognition_collision_check_max_extra_stopping_margin: 1.0
+        collision_check_outer_margin_factor: 2.0
         th_moving_object_velocity: 1.0
         detection_bound_offset: 15.0
         outer_road_detection_offset: 1.0
@@ -72,22 +73,19 @@
 
         # parallel parking path
         parallel_parking:
-          path_interval: 1.0
-          max_steer_angle: 0.4 #22.9deg
+          max_steer_angle_margin_scale: 0.72
           forward:
             enable_arc_forward_parking: true
             after_forward_parking_straight_distance: 2.0
             forward_parking_velocity: 1.38
             forward_parking_lane_departure_margin: 0.0
             forward_parking_path_interval: 1.0
-            forward_parking_max_steer_angle: 0.4  # 22.9deg
           backward:
             enable_arc_backward_parking: true
             after_backward_parking_straight_distance: 2.0
             backward_parking_velocity: -1.38
             backward_parking_lane_departure_margin: 0.0
             backward_parking_path_interval: 1.0
-            backward_parking_max_steer_angle: 0.4  # 22.9deg
 
         # freespace parking
         freespace_parking:

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -43,7 +43,7 @@
       lane_departure_margin: 0.2
       lane_departure_check_expansion_margin: 0.0
       backward_velocity: -1.0
-      pull_out_max_steer_angle: 0.4  # 22.9deg
+      geometric_pull_out_max_steer_angle_margin_scale: 0.72
       # search start pose backward
       enable_back: true
       search_priority: "efficient_path"  # "efficient_path" or "short_back_distance"

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/crosswalk.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/crosswalk.param.yaml
@@ -16,8 +16,8 @@
         # For the case where the stop position is determined according to the object position.
         stop_distance_from_object_preferred: 3.0 # [m]
         stop_distance_from_object_limit: 3.0 # [m]
-        min_acc_preferred: -1.0 # min acceleration [m/ss]
-        min_jerk_preferred: -1.0 # min jerk [m/sss]
+        min_acc_preferred: -1.2 # min acceleration [m/ss]
+        min_jerk_preferred: -1.2 # min jerk [m/sss]
 
       # params for ego's slow down velocity. These params are not used for the case of "enable_rtc: false".
       slow_down:
@@ -32,9 +32,9 @@
         stuck_vehicle_velocity: 1.0 # [m/s] threshold velocity whether other vehicles are assumed to be stuck or not.
         max_stuck_vehicle_lateral_offset: 2.0 # [m] The feature does not handle the vehicles farther than this value to the ego's path.
         required_clearance: 6.0 # [m] clearance to be secured between the ego and the ahead vehicle
-        min_acc: -1.0 # min acceleration [m/ss]
-        min_jerk: -1.0 # min jerk [m/sss]
-        max_jerk: 1.0 # max jerk [m/sss]
+        min_acc: -1.2 # min acceleration [m/ss]
+        min_jerk: -1.2 # min jerk [m/sss]
+        max_jerk: 1.2 # max jerk [m/sss]
 
       # params for the pass judge logic against the crosswalk users such as pedestrians or bicycles
       pass_judge:
@@ -45,6 +45,8 @@
         ego_pass_later_margin_y: [13.0] # [[s]] time to collision margin vector for object pass first situation (the module judges that ego don't have to stop at TTV + MARGIN < TTC condition)
         ego_pass_later_additional_margin: 0.5 # [s] additional time margin for object pass first situation to suppress chattering
         ego_min_assumed_speed: 2.0 # [m/s] assumed speed to calculate the time to collision point
+
+        consider_obj_on_crosswalk_on_red_light: false # consider and do not ignore objects if they are on the crosswalk when the crosswalk pedestrian traffic light is red
 
         no_stop_decision: # parameters to determine stop cancel. {-$overrun_threshold_length + f($min_acc, $min_jerk)} is compared against distance to stop pose.
           min_acc: -1.5 # min acceleration [m/ss]

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/detection_area.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/detection_area.param.yaml
@@ -8,4 +8,5 @@
       state_clear_time: 2.0
       hold_stop_margin_distance: 0.0
       distance_to_judge_over_stop_line: 0.5
+      enable_rtc: false # if true, the scene modules should be approved by (request to cooperate)rtc function. if false, the module can be run without approval from rtc.
       suppress_pass_judge_when_stopping: false

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/traffic_light.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/traffic_light.param.yaml
@@ -8,3 +8,7 @@
       yellow_light_stop_velocity: 1.0 # Velocity threshold (m/s) below which the vehicle will always stop before the traffic light when the signal turns yellow, regardless of the pass_judge decision.
       enable_pass_judge: true
       enable_rtc: false # If set to true, the scene modules require approval from the rtc (request to cooperate) function. If set to false, the modules can be executed without requiring rtc approval
+
+      restart_suppression:
+        min_behind_distance_to_stop: 0.5 #[m]
+        max_behind_distance_to_stop: 1.0 #[m]

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/out_of_lane.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/out_of_lane.param.yaml
@@ -3,13 +3,13 @@
     out_of_lane:  # module to stop or slowdown before overlapping another lane with other objects
       mode: ttc # mode used to consider a conflict with an object. "threshold", or "ttc"
       skip_if_already_overlapping: false # do not run this module when ego already overlaps another lane
-      ignore_overlaps_over_lane_changeable_lanelets: true  # if true, overlaps on lane changeable lanelets are ignored
       max_arc_length: 100.0  # [m] maximum trajectory arc length that is checked for out_of_lane collisions
 
       threshold:
         time_threshold: 5.0  # [s] consider objects that will reach an overlap within this time
       ttc:
-        threshold: 1.0 # [s] consider objects with an estimated time to collision bellow this value while on the overlap
+        threshold: 1.0 # [s] threshold for difference in time to overlap region between ego and target object to trigger stop decision
+        release_threshold: 3.0 # [s] threshold for difference in time to the overlap region between ego and target object to release stop decision
 
       objects:
         minimum_velocity: 0.5  # [m/s] objects lower than this velocity will be ignored
@@ -22,7 +22,9 @@
         precision: 0.1  # [m] precision when inserting a stop pose in the trajectory
         longitudinal_distance_buffer: 1.5  # [m] safety distance buffer to keep in front of the ego vehicle
         lateral_distance_buffer: 1.0  # [m] safety distance buffer to keep on the side of the ego vehicle
-        min_duration: 1.0  # [s] minimum duration needed before a decision can be canceled
+        min_on_duration: 0.3  # [s] minimum duration needed before a decision can be triggered
+        min_off_duration: 1.0  # [s] minimum duration needed before a decision can be canceled
+        update_distance_th: 10.0 # [m] distance threshold for updating previous stop pose position
         slowdown:
           distance_threshold: 30.0 # [m] insert a slowdown when closer than this distance from an overlap
           velocity: 2.0  # [m/s] slowdown velocity

--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -71,7 +71,7 @@
       <arg name="sensor_model" value="$(var sensor_model)"/>
       <arg name="vehicle_id" value="$(var vehicle_id)"/>
       <arg name="launch_vehicle_interface" value="$(var launch_vehicle_interface)"/>
-      <arg name="config_dir" value="$(find-pkg-share individual_params)/config/$(var vehicle_id)/$(var sensor_model)"/>
+      <arg name="config_dir" value="$(find-pkg-share $(var sensor_model)_description)/config"/>
       <arg name="raw_vehicle_cmd_converter_param_path" value="$(find-pkg-share autoware_launch)/config/vehicle/raw_vehicle_cmd_converter/raw_vehicle_cmd_converter.param.yaml"/>
     </include>
   </group>

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -6,7 +6,7 @@
   <arg name="use_low_height_cropbox" default="false" description="use low height crop filter in clustering"/>
   <arg name="use_vector_map" default="true" description="use vector map in prediction"/>
   <arg name="use_pointcloud_map" default="true" description="use pointcloud map in detection"/>
-  <arg name="use_roi_based_cluster" default="true" description="launch roi_based_cluster in clustering"/>
+  <arg name="use_irregular_object_detector" default="true" description="enable pipeline for small unknown object detection"/>
   <arg name="use_low_intensity_cluster_filter" default="true" description="launch low_intensity_cluster_filter in clustering"/>
   <arg name="use_image_segmentation_based_filter" default="false" description="launch image_segmentation_based_filter in clustering"/>
   <arg name="use_perception_online_evaluator" default="false" description="launch perception online evaluator"/>
@@ -46,7 +46,7 @@
     <arg name="use_low_height_cropbox" value="$(var use_low_height_cropbox)"/>
     <arg name="use_vector_map" value="$(var use_vector_map)"/>
     <arg name="use_pointcloud_map" value="$(var use_pointcloud_map)"/>
-    <arg name="use_roi_based_cluster" value="$(var use_roi_based_cluster)"/>
+    <arg name="use_irregular_object_detector" value="$(var use_irregular_object_detector)"/>
     <arg name="use_low_intensity_cluster_filter" value="$(var use_low_intensity_cluster_filter)"/>
     <arg name="use_image_segmentation_based_filter" value="$(var use_image_segmentation_based_filter)"/>
     <arg name="use_perception_online_evaluator" value="$(var use_perception_online_evaluator)"/>
@@ -96,8 +96,8 @@
       value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/image_projection_based_fusion/roi_cluster_fusion.param.yaml"
     />
     <arg
-      name="object_recognition_detection_roi_pointcloud_fusion_param_path"
-      value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/image_projection_based_fusion/roi_pointcloud_fusion.param.yaml"
+      name="object_recognition_detection_irregular_object_detector_param_path"
+      value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/irregular_object_detection/irregular_object_detector.param.yaml"
     />
     <arg
       name="object_recognition_detection_roi_detected_object_fusion_param_path"

--- a/autoware_launch/launch/components/tier4_simulator_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_simulator_component.launch.xml
@@ -83,6 +83,41 @@
       name="object_recognition_tracking_object_merger_node_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/tracking/tracking_object_merger/decorative_tracker_merger.param.yaml"
     />
+    <arg
+      name="each_traffic_light_map_based_detector_param_path"
+      value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_map_based_detector/TRAFFIC_LIGHT_RECOGNITION_CAMERA_NAMESPACE_traffic_light_map_based_detector.param.yaml"
+    />
+    <arg
+      name="traffic_light_fine_detector_param_path"
+      value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_fine_detector/traffic_light_fine_detector.param.yaml"
+    />
+    <arg name="yolox_traffic_light_detector_param_path" value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/tensorrt_yolox/yolox_traffic_light_detector.param.yaml"/>
+    <arg
+      name="car_traffic_light_classifier_param_path"
+      value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_classifier/car_traffic_light_classifier.param.yaml"
+    />
+    <arg
+      name="pedestrian_traffic_light_classifier_param_path"
+      value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_classifier/pedestrian_traffic_light_classifier.param.yaml"
+    />
+    <arg
+      name="traffic_light_roi_visualizer_param_path"
+      value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_visualization/traffic_light_roi_visualizer.param.yaml"
+    />
+    <arg name="traffic_light_selector_param_path" value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_selector/traffic_light_selector.param.yaml"/>
+    <arg
+      name="traffic_light_occlusion_predictor_param_path"
+      value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_occlusion_predictor/traffic_light_occlusion_predictor.param.yaml"
+    />
+    <arg
+      name="traffic_light_multi_camera_fusion_param_path"
+      value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_multi_camera_fusion/traffic_light_multi_camera_fusion.param.yaml"
+    />
+    <arg name="traffic_light_arbiter_param_path" value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_arbiter/traffic_light_arbiter.param.yaml"/>
+    <arg
+      name="crosswalk_traffic_light_estimator_param_path"
+      value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/crosswalk_traffic_light_estimator/crosswalk_traffic_light_estimator.param.yaml"
+    />
   </include>
   <group if="$(var scenario_simulation)">
     <include file="$(find-pkg-share autoware_dummy_infrastructure)/launch/dummy_infrastructure.launch.xml"/>

--- a/autoware_launch/package.xml
+++ b/autoware_launch/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_launch</name>
-  <version>0.43.1</version>
+  <version>0.44.0</version>
   <description>The autoware_launch package</description>
 
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -617,6 +617,110 @@ Visualization Manager:
                 Reliability Policy: Reliable
                 Value: /localization/pose_estimator/monte_carlo_initial_pose_marker
               Value: true
+            - Auto Set Min/Max:
+                Max Value: 100
+                Min Value: 0
+                Value: false
+              Buffer Size: 1500
+              Class: rviz_plugins::ColoredPoseWithCovarianceHistory
+              Enabled: false
+              Name: PoseWithExeTimeMs
+              Path:
+                Alpha: 0.999
+                Greater Color: 255; 0; 0
+                Less Color: 0; 0; 255
+                Max Color: 255; 255; 0
+                Min Color: 0; 255; 255
+                Value: true
+                Width: 1.0
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                Filter size: 10
+                History Policy: Keep Last
+                Reliability Policy: Reliable
+                Value: /localization/pose_with_covariance
+              Value: false
+              Value Topic: /localization/pose_estimator/exe_time_ms
+              Value Type: Float32
+            - Auto Set Min/Max:
+                Max Value: 30
+                Min Value: 1
+                Value: false
+              Buffer Size: 1500
+              Class: rviz_plugins::ColoredPoseWithCovarianceHistory
+              Enabled: false
+              Name: PoseWithIterationNum
+              Path:
+                Alpha: 0.999
+                Greater Color: 255; 0; 0
+                Less Color: 0; 0; 255
+                Max Color: 255; 255; 0
+                Min Color: 0; 255; 255
+                Value: true
+                Width: 1.0
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                Filter size: 10
+                History Policy: Keep Last
+                Reliability Policy: Reliable
+                Value: /localization/pose_with_covariance
+              Value: false
+              Value Topic: /localization/pose_estimator/iteration_num
+              Value Type: Int32
+            - Auto Set Min/Max:
+                Max Value: 7
+                Min Value: 3
+                Value: false
+              Buffer Size: 1500
+              Class: rviz_plugins::ColoredPoseWithCovarianceHistory
+              Enabled: false
+              Name: PoseWithTransformProbability
+              Path:
+                Alpha: 0.999
+                Greater Color: 255; 255; 0
+                Less Color: 0; 0; 255
+                Max Color: 255; 255; 0
+                Min Color: 0; 255; 255
+                Value: true
+                Width: 1.0
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                Filter size: 10
+                History Policy: Keep Last
+                Reliability Policy: Reliable
+                Value: /localization/pose_with_covariance
+              Value: false
+              Value Topic: /localization/pose_estimator/transform_probability
+              Value Type: Float32
+            - Auto Set Min/Max:
+                Max Value: 3.3
+                Min Value: 2.3
+                Value: false
+              Buffer Size: 1500
+              Class: rviz_plugins::ColoredPoseWithCovarianceHistory
+              Enabled: false
+              Name: PoseWithNearestVoxelTransformationLikelihood
+              Path:
+                Alpha: 0.999
+                Greater Color: 255; 255; 0
+                Less Color: 0; 0; 255
+                Max Color: 255; 255; 0
+                Min Color: 0; 255; 255
+                Value: true
+                Width: 1.0
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                Filter size: 10
+                History Policy: Keep Last
+                Reliability Policy: Reliable
+                Value: /localization/pose_with_covariance
+              Value: false
+              Value Topic: /localization/pose_estimator/nearest_voxel_transformation_likelihood
+              Value Type: Float32
           Enabled: true
           Name: NDT
         - Class: rviz_common/Group

--- a/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_description/CHANGELOG.rst
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_description/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog for package awsim_labs_sensor_kit_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* feat: remove individual_params references (`#1403 <https://github.com/autowarefoundation/autoware_launch/issues/1403>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
 0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)

--- a/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_description/config/sensor_kit_calibration.yaml
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_description/config/sensor_kit_calibration.yaml
@@ -64,18 +64,18 @@ sensor_kit_base_link:
     yaw: 1.575
   velodyne_left_base_link:
     x: 0.0
-    y: 0.56362
+    y: 0.59
     z: -0.30555
     roll: -0.02
     pitch: 0.71
     yaw: 1.575
   velodyne_right_base_link:
     x: 0.0
-    y: -0.56362
+    y: -0.59
     z: -0.30555
-    roll: -0.01
+    roll: -0.02
     pitch: 0.71
-    yaw: -1.580
+    yaw: -1.575
   gnss_link:
     x: -0.1
     y: 0.0

--- a/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_description/package.xml
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>awsim_labs_sensor_kit_description</name>
-  <version>0.43.1</version>
+  <version>0.44.0</version>
   <description>The awsim_labs_sensor_kit_description package</description>
   <maintainer email="piotr.jaroszek@robotec.ai">Piotr Jaroszek</maintainer>
   <license>Apache License 2.0</license>

--- a/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/CHANGELOG.rst
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package awsim_labs_sensor_kit_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* feat: remove individual_params references (`#1403 <https://github.com/autowarefoundation/autoware_launch/issues/1403>`_)
+* chore(sensor_kit_launch): remove unused has_static_tf_only param (`#1393 <https://github.com/autowarefoundation/autoware_launch/issues/1393>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Amadeusz Szymko, Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
 0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)

--- a/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/config/concatenate_and_time_sync_node.param.yaml
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/config/concatenate_and_time_sync_node.param.yaml
@@ -1,7 +1,6 @@
 /**:
   ros__parameters:
     debug_mode: false
-    has_static_tf_only: false
     rosbag_length: 10.0
     maximum_queue_size: 5
     timeout_sec: 0.2

--- a/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/launch/imu.launch.xml
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/launch/imu.launch.xml
@@ -5,14 +5,12 @@
       <arg name="input_topic" value="tamagawa/imu_raw"/>
       <arg name="output_topic" value="imu_data"/>
       <!-- We are using default node values -->
-      <!-- <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/awsim_sensor_kit/imu_corrector.param.yaml"/> -->
     </include>
 
     <include file="$(find-pkg-share autoware_imu_corrector)/launch/gyro_bias_estimator.launch.xml">
       <arg name="input_imu_raw" value="tamagawa/imu_raw"/>
       <arg name="input_odom" value="/localization/kinematic_state"/>
       <!-- We are using default node values -->
-      <!-- <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/awsim_sensor_kit/imu_corrector.param.yaml"/> -->
     </include>
   </group>
 </launch>

--- a/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/package.xml
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>awsim_labs_sensor_kit_launch</name>
-  <version>0.43.1</version>
+  <version>0.44.0</version>
   <description>The awsim_labs_sensor_kit_launch package</description>
   <maintainer email="piotr.jaroszek@robotec.ai">Piotr Jaroszek</maintainer>
   <license>Apache License 2.0</license>

--- a/sensor_kit/awsim_labs_sensor_kit_launch/common_awsim_labs_sensor_launch/CHANGELOG.rst
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/common_awsim_labs_sensor_launch/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package common_awsim_labs_sensor_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
 0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)

--- a/sensor_kit/awsim_labs_sensor_kit_launch/common_awsim_labs_sensor_launch/package.xml
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/common_awsim_labs_sensor_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>common_awsim_labs_sensor_launch</name>
-  <version>0.43.1</version>
+  <version>0.44.0</version>
   <description>The common_sensor_launch package</description>
   <maintainer email="piotr.jaroszek@robotec.ai">Piotr Jaroszek</maintainer>
   <license>Apache License 2.0</license>

--- a/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_description/CHANGELOG.rst
+++ b/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_description/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package awsim_sensor_kit_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
 0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)

--- a/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_description/package.xml
+++ b/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>awsim_sensor_kit_description</name>
-  <version>0.43.1</version>
+  <version>0.44.0</version>
   <description>The awsim_sensor_kit_description package</description>
   <maintainer email="piotr.jaroszek@robotec.ai">Piotr Jaroszek</maintainer>
   <license>Apache License 2.0</license>

--- a/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_launch/CHANGELOG.rst
+++ b/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_launch/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package awsim_sensor_kit_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* feat: remove individual_params references (`#1403 <https://github.com/autowarefoundation/autoware_launch/issues/1403>`_)
+* chore(sensor_kit_launch): remove unused has_static_tf_only param (`#1393 <https://github.com/autowarefoundation/autoware_launch/issues/1393>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Amadeusz Szymko, Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
 0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)

--- a/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_launch/config/concatenate_and_time_sync_node.param.yaml
+++ b/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_launch/config/concatenate_and_time_sync_node.param.yaml
@@ -1,7 +1,6 @@
 /**:
   ros__parameters:
     debug_mode: false
-    has_static_tf_only: false
     rosbag_length: 10.0
     maximum_queue_size: 5
     timeout_sec: 0.01

--- a/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_launch/launch/imu.launch.xml
+++ b/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_launch/launch/imu.launch.xml
@@ -5,14 +5,12 @@
       <arg name="input_topic" value="tamagawa/imu_raw"/>
       <arg name="output_topic" value="imu_data"/>
       <!-- We are using default node values -->
-      <!-- <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/awsim_sensor_kit/imu_corrector.param.yaml"/> -->
     </include>
 
     <include file="$(find-pkg-share autoware_imu_corrector)/launch/gyro_bias_estimator.launch.xml">
       <arg name="input_imu_raw" value="tamagawa/imu_raw"/>
       <arg name="input_odom" value="/localization/kinematic_state"/>
       <!-- We are using default node values -->
-      <!-- <arg name="param_file" value="$(find-pkg-share individual_params)/config/$(env VEHICLE_ID default)/awsim_sensor_kit/imu_corrector.param.yaml"/> -->
     </include>
   </group>
 </launch>

--- a/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_launch/package.xml
+++ b/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>awsim_sensor_kit_launch</name>
-  <version>0.43.1</version>
+  <version>0.44.0</version>
   <description>The awsim_sensor_kit_launch package</description>
   <maintainer email="piotr.jaroszek@robotec.ai">Piotr Jaroszek</maintainer>
   <license>Apache License 2.0</license>

--- a/sensor_kit/sample_sensor_kit_launch/common_sensor_launch/CHANGELOG.rst
+++ b/sensor_kit/sample_sensor_kit_launch/common_sensor_launch/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package common_sensor_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
 0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)

--- a/sensor_kit/sample_sensor_kit_launch/common_sensor_launch/package.xml
+++ b/sensor_kit/sample_sensor_kit_launch/common_sensor_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>common_sensor_launch</name>
-  <version>0.43.1</version>
+  <version>0.44.0</version>
   <description>The common_sensor_launch package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_description/CHANGELOG.rst
+++ b/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_description/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog for package sample_sensor_kit_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* feat: remove individual_params references (`#1403 <https://github.com/autowarefoundation/autoware_launch/issues/1403>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
 0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)

--- a/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_description/config/imu_corrector.param.yaml
+++ b/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_description/config/imu_corrector.param.yaml
@@ -1,0 +1,8 @@
+/**:
+  ros__parameters:
+    angular_velocity_stddev_xx: 0.00339
+    angular_velocity_stddev_yy: 0.00339
+    angular_velocity_stddev_zz: 0.00339
+    angular_velocity_offset_x: -0.005799
+    angular_velocity_offset_y: -0.007148
+    angular_velocity_offset_z: -0.001499

--- a/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_description/package.xml
+++ b/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sample_sensor_kit_description</name>
-  <version>0.43.1</version>
+  <version>0.44.0</version>
   <description>The sample_sensor_kit_description package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/CHANGELOG.rst
+++ b/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package sample_sensor_kit_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* feat: remove individual_params references (`#1403 <https://github.com/autowarefoundation/autoware_launch/issues/1403>`_)
+* chore(sensor_kit_launch): remove unused has_static_tf_only param (`#1393 <https://github.com/autowarefoundation/autoware_launch/issues/1393>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Amadeusz Szymko, Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
 0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)

--- a/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/config/concatenate_and_time_sync_node.param.yaml
+++ b/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/config/concatenate_and_time_sync_node.param.yaml
@@ -1,7 +1,6 @@
 /**:
   ros__parameters:
     debug_mode: false
-    has_static_tf_only: false
     rosbag_length: 10.0
     maximum_queue_size: 5
     timeout_sec: 0.2

--- a/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/launch/imu.launch.xml
+++ b/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/launch/imu.launch.xml
@@ -14,7 +14,7 @@
     </group> -->
 
     <arg name="imu_raw_name" default="tamagawa/imu_raw"/>
-    <arg name="imu_corrector_param_file" default="$(find-pkg-share individual_params)/config/$(var vehicle_id)/sample_sensor_kit/imu_corrector.param.yaml"/>
+    <arg name="imu_corrector_param_file" default="$(find-pkg-share sample_sensor_kit_description)/config/imu_corrector.param.yaml"/>
     <include file="$(find-pkg-share autoware_imu_corrector)/launch/imu_corrector.launch.xml">
       <arg name="input_topic" value="$(var imu_raw_name)"/>
       <arg name="output_topic" value="imu_data"/>

--- a/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/package.xml
+++ b/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sample_sensor_kit_launch</name>
-  <version>0.43.1</version>
+  <version>0.44.0</version>
   <description>The sample_sensor_kit_launch package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_common_launch/CHANGELOG.rst
+++ b/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_common_launch/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package single_lidar_common_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
 0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)

--- a/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_common_launch/package.xml
+++ b/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_common_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>single_lidar_common_launch</name>
-  <version>0.43.1</version>
+  <version>0.44.0</version>
   <description>The single_lidar_common_launch package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_sensor_kit_description/CHANGELOG.rst
+++ b/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_sensor_kit_description/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package single_lidar_sensor_kit_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
 0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)

--- a/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_sensor_kit_description/package.xml
+++ b/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_sensor_kit_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>single_lidar_sensor_kit_description</name>
-  <version>0.43.1</version>
+  <version>0.44.0</version>
   <description>The single_lidar_sensor_kit_description package</description>
   <maintainer email="beginning.fan@autocore.ai">beginning.fan</maintainer>
   <license>Apache License 2.0</license>

--- a/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_sensor_kit_launch/CHANGELOG.rst
+++ b/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_sensor_kit_launch/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package single_lidar_sensor_kit_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
 0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)

--- a/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_sensor_kit_launch/package.xml
+++ b/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_sensor_kit_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>single_lidar_sensor_kit_launch</name>
-  <version>0.43.1</version>
+  <version>0.44.0</version>
   <description>The single_lidar_sensor_kit_launch package</description>
   <maintainer email="beginning.fan@autocore.ai">beginning.fan</maintainer>
   <license>Apache License 2.0</license>

--- a/vehicle/awsim_labs_vehicle_launch/awsim_labs_vehicle_description/CHANGELOG.rst
+++ b/vehicle/awsim_labs_vehicle_launch/awsim_labs_vehicle_description/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package awsim_labs_vehicle_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
 0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)

--- a/vehicle/awsim_labs_vehicle_launch/awsim_labs_vehicle_description/package.xml
+++ b/vehicle/awsim_labs_vehicle_launch/awsim_labs_vehicle_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>awsim_labs_vehicle_description</name>
-  <version>0.43.1</version>
+  <version>0.44.0</version>
   <description>The awsim_labs_vehicle_description package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/vehicle/awsim_labs_vehicle_launch/awsim_labs_vehicle_launch/CHANGELOG.rst
+++ b/vehicle/awsim_labs_vehicle_launch/awsim_labs_vehicle_launch/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package awsim_labs_vehicle_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
 0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)

--- a/vehicle/awsim_labs_vehicle_launch/awsim_labs_vehicle_launch/package.xml
+++ b/vehicle/awsim_labs_vehicle_launch/awsim_labs_vehicle_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>awsim_labs_vehicle_launch</name>
-  <version>0.43.1</version>
+  <version>0.44.0</version>
   <description>The awsim_labs_vehicle_launch package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/vehicle/sample_vehicle_launch/sample_vehicle_description/CHANGELOG.rst
+++ b/vehicle/sample_vehicle_launch/sample_vehicle_description/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package sample_vehicle_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
 0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)

--- a/vehicle/sample_vehicle_launch/sample_vehicle_description/package.xml
+++ b/vehicle/sample_vehicle_launch/sample_vehicle_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sample_vehicle_description</name>
-  <version>0.43.1</version>
+  <version>0.44.0</version>
   <description>The sample_vehicle_description package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/vehicle/sample_vehicle_launch/sample_vehicle_launch/CHANGELOG.rst
+++ b/vehicle/sample_vehicle_launch/sample_vehicle_launch/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package sample_vehicle_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
 0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)

--- a/vehicle/sample_vehicle_launch/sample_vehicle_launch/package.xml
+++ b/vehicle/sample_vehicle_launch/sample_vehicle_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sample_vehicle_launch</name>
-  <version>0.43.1</version>
+  <version>0.44.0</version>
   <description>The sample_vehicle_launch package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>


### PR DESCRIPTION
## Description

This PR bumps up version to 0.44.0. Due to the version upgrade to 0.44.0 being executed without merging the fixes from 0.43.1 into main, a conflict has occurred in `CHANGELOG.rst` between the `main` and `humble` branches.
This PR resolves that conflict, resulting in a discrepancy in `CHANGELOG.rst` with the `main` branch.

## How was this PR tested?

- https://github.com/tier4/autoware_launch/commits/v0.44.0/

## Notes for reviewers

None.

## Effects on system behavior

None.
