### PR TITLE
fix: add missing nebula diagnostics parameters

### DIFF
--- a/sensor_kit/sample_sensor_kit_launch/common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/sensor_kit/sample_sensor_kit_launch/common_sensor_launch/launch/nebula_node_container.launch.py
@@ -136,6 +136,8 @@ def launch_setup(context, *args, **kwargs):
                         "packet_mtu_size",
                         "setup_sensor",
                         "udp_only",
+                        "diag_span",
+                        "advanced_diagnostics",
                     ),
                 },
             ],
@@ -279,6 +281,8 @@ def generate_launch_description():
     add_launch_arg("use_multithread", "False", "use multithread")
     add_launch_arg("use_intra_process", "False", "use ROS 2 component container communication")
     add_launch_arg("lidar_container_name", "nebula_node_container")
+    add_launch_arg("advanced_diagnostics", "false", "advanced_diagnostics")
+    add_launch_arg("diag_span", "1000", "diag_span")
     add_launch_arg("output_as_sensor_frame", "True", "output final pointcloud in sensor frame")
     add_launch_arg(
         "vehicle_mirror_param_file", description="path to the file of vehicle mirror position yaml"


### PR DESCRIPTION
The lack of these two parameters will cause the lidar to fail to start. "diag_span" and  "advanced_diagnostics",

## Description

This PR adds the missing parameters diag_span and advanced_diagnostics to the nebula node configuration.
Without these two parameters, the LiDAR driver fails to initialize properly, resulting in a failure to start the sensor node.

## How was this PR tested?

The updated launch file was tested with the Nebula driver in a ROS 2 Humble environment, and the LiDAR was confirmed to start and publish point cloud data normally.

## Notes for reviewers

None.

## Effects on system behavior

No functional behavior change. This PR ensures the correct startup of the LiDAR by providing necessary diagnostics parameters.
