### PR TITLE
fix: add missing diagnostics parameters to nebula_node_container.launch.py

### DIFF
--- a/sensor_kit/sample_sensor_kit_launch/common_sensor_launch/launch/nebula_node_container.launch.py
+++ b/sensor_kit/sample_sensor_kit_launch/common_sensor_launch/launch/nebula_node_container.launch.py
@@ -136,6 +136,8 @@ def launch_setup(context, *args, **kwargs):
                         "packet_mtu_size",
                         "setup_sensor",
                         "udp_only",
+                        "advanced_diagnostics",
+                        "diag_span",
                     ),
                 },
             ],
@@ -280,6 +282,8 @@ def generate_launch_description():
     add_launch_arg("use_intra_process", "False", "use ROS 2 component container communication")
     add_launch_arg("lidar_container_name", "nebula_node_container")
     add_launch_arg("output_as_sensor_frame", "True", "output final pointcloud in sensor frame")
+    add_launch_arg("advanced_diagnostics", "false", "advanced_diagnostics")
+    add_launch_arg("diag_span", "1000", "diag_span")
     add_launch_arg(
         "vehicle_mirror_param_file", description="path to the file of vehicle mirror position yaml"
     )


### PR DESCRIPTION
## Description

This PR adds two missing parameters to the Nebula LiDAR node launch file:

- `diag_span`
- `advanced_diagnostics`

Without these parameters, the Nebula driver fails to initialize and publish point cloud data.

## How was this PR tested?

Tested in a ROS 2 Humble environment with the Nebula driver.  
Confirmed that the LiDAR node successfully starts and publishes `/points_raw` after adding the missing parameters.

## Notes for reviewers

None.

## Effects on system behavior

No behavioral changes for users already using correct parameters.  
This PR fixes a critical startup issue for Nebula-based LiDAR configurations.
