### PR TITLE
feat(autoware_launch): remove trajectory_deviation from diagnostic graph

### DIFF
--- a/autoware_launch/config/system/diagnostics/control.yaml
+++ b/autoware_launch/config/system/diagnostics/control.yaml
@@ -7,7 +7,6 @@ units:
       - { type: link, link: /autoware/control/node_alive_monitoring/vehicle_cmd_gate }
       - { type: link, link: /autoware/control/emergency_braking }
       - { type: link, link: /autoware/control/performance_monitoring/lane_departure }
-      - { type: link, link: /autoware/control/performance_monitoring/trajectory_deviation }
       - { type: link, link: /autoware/control/performance_monitoring/control_state }
 
   - path: /autoware/control/local
@@ -46,11 +45,6 @@ units:
     type: diag
     node: lane_departure_checker_node
     name: lane_departure
-
-  - path: /autoware/control/performance_monitoring/trajectory_deviation
-    type: diag
-    node: lane_departure_checker_node
-    name: trajectory_deviation
 
   - path: /autoware/control/performance_monitoring/control_state
     type: diag


### PR DESCRIPTION
## Description

Reflect https://github.com/autowarefoundation/autoware_universe/pull/10337.
The diag `lane_departure_checker_node: trajectory_deviation` is no longer used.

## How was this PR tested?

Check that the vehicle drives in autonomous mode using planning simulator.

## Notes for reviewers

None.

## Effects on system behavior

None.
