### PR TITLE
feat(dynamic_drivable_area_expansion): set extra offsets to 0

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/drivable_area_expansion.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/drivable_area_expansion.param.yaml
@@ -17,8 +17,8 @@
         arc_length_range: 2.0  # [m] arc length range where an expansion distance is initially applied
       ego:
         extra_wheelbase: 0.0 # [m] extra length to add to the wheelbase
-        extra_front_overhang: 0.5 # [m] extra length to add to the front overhang
-        extra_width: 1.0 # [m] extra length to add to the width
+        extra_front_overhang: 0.0 # [m] extra length to add to the front overhang
+        extra_width: 0.0 # [m] extra length to add to the width
       object_exclusion:
         exclude_static: false # if true, the drivable area is not expanded over static objects
         exclude_dynamic: false # if true, the drivable area is not expanded in the predicted path of dynamic objects


### PR DESCRIPTION
## Description

Remove the extra offsets used by default in the dynamic drivable area expansion.

## How was this PR tested?

Evaluator (TIER IV internal link): https://evaluation.tier4.jp/evaluation/reports/46508015-858e-55b6-b865-d2d974ae8a27?project_id=prd_jt

## Notes for reviewers

None.

## Effects on system behavior

None.
