### PR TITLE
fix(ground_segmentation): extend mode switch radius

### DIFF
--- a/autoware_launch/config/perception/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml
+++ b/autoware_launch/config/perception/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml
@@ -23,7 +23,7 @@
         split_height_distance: 0.2
         non_ground_height_threshold: 0.20
         grid_size_m: 0.5
-        grid_mode_switch_radius: 20.0
+        grid_mode_switch_radius: 150.0
         gnd_grid_buffer_size: 4
         detection_range_z_max: 2.5
         elevation_grid_mode: true


### PR DESCRIPTION
## Description

- To avoid ground_segmentation fail in case of high density lidar vehicle before slope. 
- [TIER IV internal link](https://star4.slack.com/archives/C076ZGRC15X/p1747816669068269?thread_ts=1747637811.471089&cid=C076ZGRC15X)
## How was this PR tested?


## Notes for reviewers

None.

## Effects on system behavior

None.
