### PR TITLE
feat(goal_planner, start_planner): ignore_object_velocity_threshold: 0.25

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/goal_planner/goal_planner.param.yaml
@@ -152,7 +152,7 @@
           # detection range
           object_check_forward_distance: 100.0
           object_check_backward_distance: 100.0
-          ignore_object_velocity_threshold: 1.0
+          ignore_object_velocity_threshold: 0.25
           # ObjectTypesToCheck
           object_types_to_check:
             check_car: true

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -116,7 +116,7 @@
           # detection range
           object_check_forward_distance: 10.0
           object_check_backward_distance: 100.0
-          ignore_object_velocity_threshold: 1.0
+          ignore_object_velocity_threshold: 0.25
           # ObjectTypesToCheck
           object_types_to_check:
             check_car: true


### PR DESCRIPTION
## Description

With the current parameters, slow-moving objects like pedestrians can sometimes be ignored during safety checks, but they should be checked.
This parameter was set to 1.0 in https://github.com/autowarefoundation/autoware_launch/pull/573 to prevent chattering in the safety judgment for stationary objects.

In this pull request, we will set it to 0.25 instead of 0 to avoid reintroducing this issue. This ensures:

- Safety checks for slow-moving objects

![image](https://github.com/user-attachments/assets/b8b4519c-529e-4376-a5f8-de846580c079)

- No reaction to perfectly stationary objects

![image](https://github.com/user-attachments/assets/d9fc2af6-b1e8-4a0e-8eab-4b476cc32a6f)

The 0.25 m/s value was tuned with real data to avoid misjudging stationary pedestrians whose speed might register above 0.1 m/s. (internal rosbag https://docs.google.com/presentation/d/1gVIR9_z081VjveOndFJRIr5g84THlPcYY7LuPUMdass/edit?slide=id.g34e18da4d3c_0_4207#slide=id.g34e18da4d3c_0_4207)

https://github.com/user-attachments/assets/3a72d0ae-9cbd-450d-8f38-1d8448643457

![image](https://github.com/user-attachments/assets/cd0196e8-eed0-4017-9e00-bdcf72bfd900)


## How was this PR tested?

psim
2025/05/31 https://evaluation.tier4.jp/evaluation/reports/58213911-4702-5921-a1a9-2348b9f1d0d4/?project_id=prd_jt 
2025/06/04 https://evaluation.ci.tier4.jp/evaluation/reports/fc98babd-d598-5b59-838d-b06d3af83103?project_id=prd_jt

## Notes for reviewers

None.

## Effects on system behavior

None.
