### PR TITLE
feat(rviz): add ControlModeDisplay panel to RViz configuration

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -20,6 +20,8 @@ Panels:
     Name: AutowareDateTimePanel
   - Class: rviz_plugins::AutowareStatePanel
     Name: AutowareStatePanel
+  - Class: rviz_plugins/ControlModeDisplay
+    Name: ControlModeDisplay
 Visualization Manager:
   Class: ""
   Displays:


### PR DESCRIPTION
## Description

The Operation Mode currently displayed in the state panel references information from `/api/operation_mode/state`, but this topic is only published when a state transition occurs in the OperationModeTransitionManager.

Therefore, when performing rosbag-based analysis, depending on when the rosbag recording started, this topic may not be included, making it difficult to understand the current operation mode.

Since there is a need to check the vehicle's current control state during rosbag analysis, I would like to display `/vehicle/status/control_mode` in the default setting to assist with analysis.

## How was this PR tested?

confirmed expected rviz plugin is visualized with psim
![image](https://github.com/user-attachments/assets/45636537-3e98-456b-94fd-b12e2761ce42)


## Notes for reviewers

None.

## Effects on system behavior

None.
