### PR TITLE
feat(velocity_smoother): adjusting jerk weight

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/common/autoware_velocity_smoother/JerkFiltered.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/common/autoware_velocity_smoother/JerkFiltered.param.yaml
@@ -1,7 +1,7 @@
 /**:
   ros__parameters:
-    jerk_weight: 10.0        # weight for "smoothness" cost for jerk
-    over_v_weight: 100000.0  # weight for "over speed limit" cost
-    over_a_weight: 5000.0    # weight for "over accel limit" cost
-    over_j_weight: 2000.0    # weight for "over jerk limit" cost
+    jerk_weight: 0.1         # weight for "smoothness" cost for jerk
+    over_v_weight: 10000.0   # weight for "over speed limit" cost
+    over_a_weight: 500.0     # weight for "over accel limit" cost
+    over_j_weight: 200.0     # weight for "over jerk limit" cost
     jerk_filter_ds: 0.1      # resampling ds for jerk filter


### PR DESCRIPTION
## Description
The velocity_smoother module attempts to 
- Increase velocity as much as possible
- Minimize jerk as much as possible
while satisfing the acceleration/deceleration and jerk constraints specified in common.param.yaml.

This PR reduces the weight for the objective of "minimizing jerk as much as possible."
This will make the vehicle's movement more aligned with the nominal parameters in common.param.yaml, leading to more predictable behavior.

Furthermore, since the nominal jerk constraint is still maintained with a strong weight, jerk will continue to be suppressed below the nominal set value even after this change.

This updated value has a proven track record of several years based on real-world vehicle operation.

## How was this PR tested?
- [x] tier4 scenario test
- [x] psim
- [x] real vehicle test

## Notes for reviewers

None.

## Effects on system behavior

None.
