### PR TITLE
feat: add pointcloud container arg for simulator component

### DIFF
--- a/autoware_launch/launch/components/tier4_simulator_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_simulator_component.launch.xml
@@ -15,6 +15,7 @@
   <arg name="vehicle_info_param_file"/>
   <arg name="raw_vehicle_cmd_converter_param_path"/>
   <arg name="occupancy_grid_map_updater" default="binary_bayes_filter" description="options: binary_bayes_filter"/>
+  <arg name="use_point_cloud_container" default="true" description="use point cloud container for simulator perception modules"/>
 
   <include file="$(find-pkg-share tier4_simulator_launch)/launch/simulator.launch.xml">
     <arg name="launch_dummy_perception" value="$(var launch_dummy_perception)"/>
@@ -31,6 +32,7 @@
     <arg name="initial_engage_state" value="$(var initial_engage_state)"/>
     <arg name="vehicle_info_param_file" value="$(var vehicle_info_param_file)"/>
     <arg name="raw_vehicle_cmd_converter_param_path" value="$(var raw_vehicle_cmd_converter_param_path)"/>
+    <arg name="use_point_cloud_container" value="$(var use_point_cloud_container)"/>
 
     <arg name="fault_injection_param_path" value="$(find-pkg-share autoware_launch)/config/simulator/fault_injection.param.yaml"/>
     <arg


### PR DESCRIPTION
## Description
**This PR must be merged before https://github.com/autowarefoundation/autoware_universe/pull/10770**

We are currently trying to run tier4_simulator_component.launch.xml as standalone launch in order to run Autoware in multi-container setup in this issue. However, probabilistic_occupancy_grid_map.launch.xml fails to launch properly because it cannot find pointcloud_container, which is not created in multi-container settings. (Check [my comment](https://github.com/autowarefoundation/autoware/pull/6184#issuecomment-2948129756) for the details)

This PR adds `use_pointcloud_container` to tier4_simulator launch so that users can configure whether to use pointcloud_container from launch argument to resolve the issue. 

It is set to true by default to keep the behavior when we launch this file from planning_simulator.launch.xml as before. 

# Related Links
- https://github.com/autowarefoundation/autoware/issues/6140
- https://github.com/autowarefoundation/autoware/pull/6184
- https://github.com/autowarefoundation/autoware_universe/pull/10770

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
