### PR TITLE
feat(obstacle_stop_module): add parameters for "outside" region obstacles

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop.param.yaml
@@ -74,6 +74,7 @@
 
         outside_obstacle:
           estimation_time_horizon: 1.0
+          max_lateral_velocity: 5.0 # maximum lateral velocity to consider the obstacle as a stop obstacle [m/s]
           pedestrian_deceleration_rate: 1.0 # planner perceives pedestrians will stop with this rate to avoid unnecessary stops [m/ss]
           bicycle_deceleration_rate: 2.0 # planner perceives bicycles will stop with this rate to avoid unnecessary stops [m/ss]
 

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop.param.yaml
@@ -75,8 +75,8 @@
         outside_obstacle:
           estimation_time_horizon: 1.0
           max_lateral_velocity: 5.0 # maximum lateral velocity to consider the obstacle as a stop obstacle [m/s]
-          pedestrian_deceleration_rate: 1.0 # planner perceives pedestrians will stop with this rate to avoid unnecessary stops [m/ss]
-          bicycle_deceleration_rate: 2.0 # planner perceives bicycles will stop with this rate to avoid unnecessary stops [m/ss]
+          pedestrian_deceleration: 1.0 # planner perceives pedestrians will stop with this rate to avoid unnecessary stops [m/ss]
+          bicycle_deceleration: 2.0 # planner perceives bicycles will stop with this rate to avoid unnecessary stops [m/ss]
 
         crossing_obstacle:
           collision_time_margin : 1.0 # time threshold of collision between obstacle adn ego for cruise or stop [s]

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop.param.yaml
@@ -54,13 +54,13 @@
 
           outside:
             unknown: false
-            car: false
-            truck: false
-            bus: false
-            trailer: false
-            motorcycle: false
-            bicycle: false
-            pedestrian: false
+            car: true
+            truck: true
+            bus: true
+            trailer: true
+            motorcycle: true
+            bicycle: true
+            pedestrian: true
 
         # hysteresis for velocity
         obstacle_velocity_threshold_to_stop : 3.0 # stop planning is executed to the obstacle whose velocity is less than this value [m/s]
@@ -73,10 +73,9 @@
         stop_obstacle_hold_time_threshold : 1.0 # maximum time for holding closest stop obstacle
 
         outside_obstacle:
-          max_lateral_time_margin: 4.5 # time threshold of lateral margin between the obstacles and ego's footprint [s]
-          num_of_predicted_paths: 1 # number of the highest confidence predicted path to check collision between obstacle and ego
-          pedestrian_deceleration_rate: 0.5 # planner perceives pedestrians will stop with this rate to avoid unnecessary stops [m/ss]
-          bicycle_deceleration_rate: 0.5 # planner perceives bicycles will stop with this rate to avoid unnecessary stops [m/ss]
+          estimation_time_horizon: 1.0
+          pedestrian_deceleration_rate: 1.0 # planner perceives pedestrians will stop with this rate to avoid unnecessary stops [m/ss]
+          bicycle_deceleration_rate: 2.0 # planner perceives bicycles will stop with this rate to avoid unnecessary stops [m/ss]
 
         crossing_obstacle:
           collision_time_margin : 1.0 # time threshold of collision between obstacle adn ego for cruise or stop [s]


### PR DESCRIPTION
## Description
This PR adds new parameters as part of the feature update for the outside region.

With this update, the reliability of the stop functionality for obstacles in the outside region has been improved. Therefore, this feature is now enabled by default for all object types except for unknown.

The time parameter is set to a very short duration, over which the constant velocity assumption is considered valid.
Furthermore, the deceleration parameter is set to a value that pedestrians can easily achieve.

If you want to learn more about the design philosophy, please see feature PR https://github.com/autowarefoundation/autoware_core/pull/517

## How was this PR tested?
psim 
tier4 scenario tests

## Notes for reviewers

None.

## Effects on system behavior

None.
