### PR TITLE
chore: clean up unused-parameters along with refactoring in motion_velocity_planner

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
@@ -42,14 +42,6 @@
           pedestrian: true
           pointcloud: false
 
-        pointcloud:
-          pointcloud_voxel_grid_x: 0.05
-          pointcloud_voxel_grid_y: 0.05
-          pointcloud_voxel_grid_z: 100000.0
-          pointcloud_cluster_tolerance: 1.0
-          pointcloud_min_cluster_size: 1
-          pointcloud_max_cluster_size: 100000
-
         min_lat_margin: 0.0  # lateral margin between obstacle and trajectory band with ego's width to avoid the conflict with the obstacle_stop
         max_lat_margin: 1.1  # lateral margin between obstacle and trajectory band with ego's width
         lat_hysteresis_margin: 0.2

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop.param.yaml
@@ -62,14 +62,6 @@
             bicycle: false
             pedestrian: false
 
-        pointcloud:
-          pointcloud_voxel_grid_x: 0.05
-          pointcloud_voxel_grid_y: 0.05
-          pointcloud_voxel_grid_z: 100000.0
-          pointcloud_cluster_tolerance: 1.0
-          pointcloud_min_cluster_size: 1
-          pointcloud_max_cluster_size: 100000
-
         # hysteresis for velocity
         obstacle_velocity_threshold_to_stop : 3.0 # stop planning is executed to the obstacle whose velocity is less than this value [m/s]
         obstacle_velocity_threshold_from_stop : 3.5 # stop planning is executed to the obstacle whose velocity is less than this value [m/s]


### PR DESCRIPTION
## Description

Considering the updates in 

- Core: https://github.com/autowarefoundation/autoware_core/pull/409
- universe: https://github.com/autowarefoundation/autoware_universe/pull/10477
- Launch: https://github.com/autowarefoundation/autoware_launch/pull/1410

We can see that the updates in launch miss the cleanup in core and universe.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
