### PR TITLE
chore: bump version to v0.45.0 in humble

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,20 @@
 ### Automatically generated from package.xml ###
 autoware_launch/** mfc@leodrive.ai ryohsuke.mitsudome@tier4.jp yukihiro.saito@tier4.jp
+sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_description/** piotr.jaroszek@robotec.ai
+sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/** piotr.jaroszek@robotec.ai
+sensor_kit/awsim_labs_sensor_kit_launch/common_awsim_labs_sensor_launch/** piotr.jaroszek@robotec.ai
+sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_description/** piotr.jaroszek@robotec.ai
+sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_launch/** piotr.jaroszek@robotec.ai
+sensor_kit/sample_sensor_kit_launch/common_sensor_launch/** ryohsuke.mitsudome@tier4.jp yukihiro.saito@tier4.jp
+sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_description/** ryohsuke.mitsudome@tier4.jp yukihiro.saito@tier4.jp
+sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/** ryohsuke.mitsudome@tier4.jp yukihiro.saito@tier4.jp
+sensor_kit/single_lidar_sensor_kit_launch/single_lidar_common_launch/** ryohsuke.mitsudome@tier4.jp yukihiro.saito@tier4.jp
+sensor_kit/single_lidar_sensor_kit_launch/single_lidar_sensor_kit_description/** beginning.fan@autocore.ai
+sensor_kit/single_lidar_sensor_kit_launch/single_lidar_sensor_kit_launch/** beginning.fan@autocore.ai
+vehicle/awsim_labs_vehicle_launch/awsim_labs_vehicle_description/** ryohsuke.mitsudome@tier4.jp yukihiro.saito@tier4.jp
+vehicle/awsim_labs_vehicle_launch/awsim_labs_vehicle_launch/** ryohsuke.mitsudome@tier4.jp yukihiro.saito@tier4.jp
+vehicle/sample_vehicle_launch/sample_vehicle_description/** ryohsuke.mitsudome@tier4.jp yukihiro.saito@tier4.jp
+vehicle/sample_vehicle_launch/sample_vehicle_launch/** ryohsuke.mitsudome@tier4.jp yukihiro.saito@tier4.jp
 
 ### Copied from .github/CODEOWNERS-manual ###
 # /**
@@ -8,7 +23,7 @@ autoware_launch/** yukihiro.saito@tier4.jp ryohsuke.mitsudome@tier4.jp mfc@leodr
 autoware_launch/config/control/** takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp kosuke.takeuchi@tier4.jp yuki.takagi@tier4.jp alqudah.mohammad@tier4.jp kyoichi.sugahara@tier4.jp zulfaqar.azmi@tier4.jp maxime.clement@tier4.jp mamoru.sobue@tier4.jp yukinari.hisaki.2@tier4.jp
 autoware_launch/config/localization/** masahiro.sakamoto@tier4.jp yamato.ando@tier4.jp ryu.yamamoto@tier4.jp kento.yabuuchi.2@tier4.jp shintaro.sakoda@tier4.jp taiki.yamada@tier4.jp anh.nguyen.2@tier4.jp
 autoware_launch/config/map/** masahiro.sakamoto@tier4.jp yamato.ando@tier4.jp ryu.yamamoto@tier4.jp kento.yabuuchi.2@tier4.jp shintaro.sakoda@tier4.jp taiki.yamada@tier4.jp anh.nguyen.2@tier4.jp
-autoware_launch/config/perception/** shunsuke.miura@tier4.jp yoshi.ri@tier4.jp koji.minoda@tier4.jp taekjin.lee@tier4.jp
+autoware_launch/config/perception/** yoshi.ri@tier4.jp taekjin.lee@tier4.jp masato.saeki@tier4.jp lei.gu@tier4.jp
 autoware_launch/config/planning/** takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp kosuke.takeuchi@tier4.jp yuki.takagi@tier4.jp alqudah.mohammad@tier4.jp kyoichi.sugahara@tier4.jp zulfaqar.azmi@tier4.jp maxime.clement@tier4.jp mamoru.sobue@tier4.jp yukinari.hisaki.2@tier4.jp
 autoware_launch/config/simulator/** takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp
 autoware_launch/config/system/** fumihito.ito@tier4.jp isamu.takagi@tier4.jp
@@ -17,9 +32,9 @@ autoware_launch/launch/components/tier4_autoware_api_component.launch.xml isamu.
 autoware_launch/launch/components/tier4_control_component.launch.xml takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp kosuke.takeuchi@tier4.jp yuki.takagi@tier4.jp alqudah.mohammad@tier4.jp kyoichi.sugahara@tier4.jp zulfaqar.azmi@tier4.jp maxime.clement@tier4.jp mamoru.sobue@tier4.jp yukinari.hisaki.2@tier4.jp
 autoware_launch/launch/components/tier4_localization_component.launch.xml masahiro.sakamoto@tier4.jp yamato.ando@tier4.jp ryu.yamamoto@tier4.jp kento.yabuuchi.2@tier4.jp shintaro.sakoda@tier4.jp taiki.yamada@tier4.jp anh.nguyen.2@tier4.jp
 autoware_launch/launch/components/tier4_map_component.launch.xml masahiro.sakamoto@tier4.jp yamato.ando@tier4.jp ryu.yamamoto@tier4.jp kento.yabuuchi.2@tier4.jp shintaro.sakoda@tier4.jp taiki.yamada@tier4.jp anh.nguyen.2@tier4.jp
-autoware_launch/launch/components/tier4_perception_component.launch.xml shunsuke.miura@tier4.jp yoshi.ri@tier4.jp koji.minoda@tier4.jp taekjin.lee@tier4.jp
+autoware_launch/launch/components/tier4_perception_component.launch.xml yoshi.ri@tier4.jp taekjin.lee@tier4.jp masato.saeki@tier4.jp lei.gu@tier4.jp
 autoware_launch/launch/components/tier4_planning_component.launch.xml takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp kosuke.takeuchi@tier4.jp yuki.takagi@tier4.jp alqudah.mohammad@tier4.jp kyoichi.sugahara@tier4.jp zulfaqar.azmi@tier4.jp maxime.clement@tier4.jp mamoru.sobue@tier4.jp yukinari.hisaki.2@tier4.jp
-autoware_launch/launch/components/tier4_sensing_component.launch.xml shunsuke.miura@tier4.jp yoshi.ri@tier4.jp koji.minoda@tier4.jp
+autoware_launch/launch/components/tier4_sensing_component.launch.xml yoshi.ri@tier4.jp taekjin.lee@tier4.jp kenzo.lobos@tier4.jp
 autoware_launch/launch/components/tier4_simulator_component.launch.xml takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp
 autoware_launch/launch/components/tier4_system_component.launch.xml fumihito.ito@tier4.jp isamu.takagi@tier4.jp shumpei.wakabayashi@tier4.jp tomoya.kimura@tier4.jp
 autoware_launch/rviz/**  # no codeowners

--- a/autoware_launch/CHANGELOG.rst
+++ b/autoware_launch/CHANGELOG.rst
@@ -2,182 +2,69 @@
 Changelog for package autoware_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.44.0 (2025-04-18)
+0.45.0 (2025-05-22)
 -------------------
-* feat(out_of_lane): improve out of lane stability (`#1404 <https://github.com/autowarefoundation/autoware_launch/issues/1404>`_)
-  * update out_of_lane parameters
-  * change parameter value
-  * remove unused parameter
-  * fix spelling
+* Merge remote-tracking branch 'origin/main' into tmp/bot/bump_version_base
+* chore(traffic_light_recognition): add comment in config of autoware_traffic_light_map_based_detector (`#1448 <https://github.com/autowarefoundation/autoware_launch/issues/1448>`_)
+  add comment
+* feat(crosswalk): update stop position logic (`#1409 <https://github.com/autowarefoundation/autoware_launch/issues/1409>`_)
+  * change crosswalk param list
   ---------
-* feat(control_validator): add over run estimation feature (`#1394 <https://github.com/autowarefoundation/autoware_launch/issues/1394>`_)
-* feat(autoware_launch): add ColoredPoseWithCovarianceHistory to Localization NDT (`#1382 <https://github.com/autowarefoundation/autoware_launch/issues/1382>`_)
-  * feat: update autoware.rviz
-  - add Localization/NDT ColoredPoseWithCovarianceHistory
-  * add: /localization/pose_estimator/nearest_voxel_transformation_likelihood
-  * change color and alpha
-  * fix: buffer size (15 seconds)
-  * fix: typo
-  * fix: add space
-  ---------
-* feat(traffic_light): add traffic light restart suppression parameters (`#1405 <https://github.com/autowarefoundation/autoware_launch/issues/1405>`_)
-  * feat: add traffic light restart_suppression param
+* feat(perception_component_launch): add common param for pointpainting_fusion (`#1401 <https://github.com/autowarefoundation/autoware_launch/issues/1401>`_)
+  add common param
+* fix(collision_detector): rename parameters to prevent launch issues (`#1447 <https://github.com/autowarefoundation/autoware_launch/issues/1447>`_)
+  rename params
+* feat(control_validator): add lateral jerk validation (`#1440 <https://github.com/autowarefoundation/autoware_launch/issues/1440>`_)
+  fix(control_validator): add lateral jerk threshold to parameters
+* feat(rviz): replace MRM Summary overlay with Error Diag Graph in debug rviz (`#1414 <https://github.com/autowarefoundation/autoware_launch/issues/1414>`_)
+  * feat(rviz): replace MRM Summary overlay with Error Diag Graph
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: remove individual_params references (`#1403 <https://github.com/autowarefoundation/autoware_launch/issues/1403>`_)
-* refactor(planning_validator): separate validation check for steering and steering rate (`#1402 <https://github.com/autowarefoundation/autoware_launch/issues/1402>`_)
-  feat(planning_validator): separate steering rate parameter for improved configuration
-* feat(lidar_transfusion): add transfusion common param file (`#1400 <https://github.com/autowarefoundation/autoware_launch/issues/1400>`_)
-  add transfusion_common param
-* feat(multi_object_tracker): add detailed processing time publishing option (`#1398 <https://github.com/autowarefoundation/autoware_launch/issues/1398>`_)
-  * feat(multi_object_tracker): add detailed processing time publishing option
-  * fix(multi_object_tracker): disable detailed processing time publishing option
+* feat(collision_detector): time buffer and ignore behind rear axle (`#1443 <https://github.com/autowarefoundation/autoware_launch/issues/1443>`_)
+* feat(dynamic_drivable_area_expansion): set extra offsets to 0 (`#1445 <https://github.com/autowarefoundation/autoware_launch/issues/1445>`_)
+* feat(autoware_launch): remove trajectory_deviation from diagnostic graph (`#1442 <https://github.com/autowarefoundation/autoware_launch/issues/1442>`_)
+* feat(autoware_launch): update adapi diags (`#1444 <https://github.com/autowarefoundation/autoware_launch/issues/1444>`_)
+* fix(tier4_perception_launch): add camera ids param for segmentation_pointcloud_fusion (`#1439 <https://github.com/autowarefoundation/autoware_launch/issues/1439>`_)
+  fix: add camera ids for segmentation_pointcloud_fusion
+* fix(probabilistic_occupancy_grid_map): add missing parameter for multi-lidar  (`#1426 <https://github.com/autowarefoundation/autoware_launch/issues/1426>`_)
+  add new parameter for multi-lidar
+* feat(static_obstacle_avoidance): add flag to wait approval when the ego uses opposite lane (`#1431 <https://github.com/autowarefoundation/autoware_launch/issues/1431>`_)
+* feat(behavior_velocity_planner)!: remove unused function parameter for extendLine (`#1422 <https://github.com/autowarefoundation/autoware_launch/issues/1422>`_)
+  remove unused parameter
+* feat(duplicated_node_checker): ignore duplicate get parameter (`#1413 <https://github.com/autowarefoundation/autoware_launch/issues/1413>`_)
+* feat(autoware_bevfusion): added bevfusion config files (`#1416 <https://github.com/autowarefoundation/autoware_launch/issues/1416>`_)
+  feat: added bevfusion files
+* chore(simulator.launch): remove params of traffic_light_selector (`#1415 <https://github.com/autowarefoundation/autoware_launch/issues/1415>`_)
+  remove param
+* feat: add input_timeout in operation_mode_transition_manager (`#1407 <https://github.com/autowarefoundation/autoware_launch/issues/1407>`_)
+* feat(traffic_light): remove unnecessary config file (`#1396 <https://github.com/autowarefoundation/autoware_launch/issues/1396>`_)
+  remove unnecessary file
+* feat(autoware_motion_velocity_planner): point-cloud clustering optimization (`#1410 <https://github.com/autowarefoundation/autoware_launch/issues/1410>`_)
+  * fix
+  * fix
+  * fix
   ---------
-* feat(radar_object_tracker): add diagnostics param (`#1399 <https://github.com/autowarefoundation/autoware_launch/issues/1399>`_)
-  * add diagnostics param
-  * fix param name
-  * change callback param name
+* feat(mvp_run_out): update for new motion_velocity_planner run_out (`#1388 <https://github.com/autowarefoundation/autoware_launch/issues/1388>`_)
+* feat(planning_validator): detect sudden trajectory shift (`#1380 <https://github.com/autowarefoundation/autoware_launch/issues/1380>`_)
+  * update planning validator config
+  * add new planning diagnostic path
+  * visualize planning validator virtual wall by default
+  * move planning validator display under planning/diagnostic namespace
+  * add jerk limit parameter
   ---------
-* feat(multi_object_tracker): vehicle's ego frame as a parameter (`#1397 <https://github.com/autowarefoundation/autoware_launch/issues/1397>`_)
-* revert(lane_departure_checker): "fix(lane_departure_checker): replace curbstone to road_border… (`#1395 <https://github.com/autowarefoundation/autoware_launch/issues/1395>`_)
-  Revert "fix(lane_departure_checker): replace curbstone to road_border (RT1-9845) (`#1391 <https://github.com/autowarefoundation/autoware_launch/issues/1391>`_)"
-  This reverts commit b26f3375d419f5e2e2621d8b36b7d6e8a0ded209.
-* feat(probabilistic_occupancy_grid_map): add diagnostics warning when … (`#1387 <https://github.com/autowarefoundation/autoware_launch/issues/1387>`_)
-  * feat(probabilistic_occupancy_grid_map): add diagnostics warning when latency is too long
-  * style(pre-commit): autofix
-  * feat(probabilistic_occupancy_grid_map):add tolerance duration
-  * feat(probabilistic_occupancy_grid_map):  fix variable names to processing time
-  ---------
-  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(lane_departure_checker): replace curbstone to road_border (RT1-9845) (`#1391 <https://github.com/autowarefoundation/autoware_launch/issues/1391>`_)
-  fix(lane_departure_checker): replace curbstone to road_border
-* feat(lidar_centerpoint): add common param file (`#1377 <https://github.com/autowarefoundation/autoware_launch/issues/1377>`_)
-  * add common param
-  * fix comment and change value to float
-  ---------
-* feat(autoware_launch): remove exec_depend on autoware_launch from tier4_simulator_launch (`#1392 <https://github.com/autowarefoundation/autoware_launch/issues/1392>`_)
-* refactor(planning_validator): restructure planning validator configuration (`#1389 <https://github.com/autowarefoundation/autoware_launch/issues/1389>`_)
-  update planning validator config
-* feat: add parameter for irregular object pipeline (`#1381 <https://github.com/autowarefoundation/autoware_launch/issues/1381>`_)
-  * feat: add parameter for small unknown object pipeline
-  * chore: rename param
-  * refactor
-  * chore: spelling
-  * refactor: file renaming
-  * fix: param rename
-  * refactor: param path update
-  ---------
-* feat(multi_object_tracker): add diagnostics warning when extrapolation time exceeds limit with latency guarantee enabled (`#1378 <https://github.com/autowarefoundation/autoware_launch/issues/1378>`_)
-  * feat(multi_object_tracker): add diagnostics warning when extrapolation time exceeds limit with latency guarantee enabled
-  * style(pre-commit): autofix
-  ---------
-  Co-authored-by: lei.gu <lei.gu@tier4.jp>
-  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(detection_area): integrate RTC feature (`#1383 <https://github.com/autowarefoundation/autoware_launch/issues/1383>`_)
-* feat(start/goal_planner): update max steer angle parameters to use margin scale (`#1368 <https://github.com/autowarefoundation/autoware_launch/issues/1368>`_)
-* feat: add parameter for diagnostics (`#1362 <https://github.com/autowarefoundation/autoware_launch/issues/1362>`_)
-* feat(perception): add parameter for diag (`#1357 <https://github.com/autowarefoundation/autoware_launch/issues/1357>`_)
-  * add parameter for diag
-  * change param name
-  * add unit
-  ---------
-* fix(roi_pointcloud_fusion): add roi scale factor param (`#1376 <https://github.com/autowarefoundation/autoware_launch/issues/1376>`_)
-* feat(control_validator)!: add acceleration check (`#1375 <https://github.com/autowarefoundation/autoware_launch/issues/1375>`_)
-* feat(crosswalk_module): add param to consider objects on crosswalk when pedestrian traffic light is red (`#1374 <https://github.com/autowarefoundation/autoware_launch/issues/1374>`_)
-* feat(crosswalk): fix stop position calclaton params (`#1370 <https://github.com/autowarefoundation/autoware_launch/issues/1370>`_)
-* feat(multi_object_tracker): add input channel flags for selective update per channel (`#1364 <https://github.com/autowarefoundation/autoware_launch/issues/1364>`_)
-  feat(multi_object_tracker): update input channel flags for improved tracking parameters
-* feat(goal_planner): expand outer collision check margin (`#1365 <https://github.com/autowarefoundation/autoware_launch/issues/1365>`_)
-* Contributors: Amadeusz Szymko, Kazu, Kosuke Takeuchi, Kotaro Uetake, Kyoichi Sugahara, Masaki Baba, Masato Saeki, Mehmet Dogru, Mete Fatih Cırıt, Satoshi OTA, Taekjin LEE, Takagi, Isamu, Yuki TAKAGI, Zulfaqar Azmi, badai nguyen, eiki, lei.gu, mkquda
+* feat(planning_validator): add lateral jerk validation parameters (`#1406 <https://github.com/autowarefoundation/autoware_launch/issues/1406>`_)
+* Contributors: Arjun Jagdish Ram, Kento Yabuuchi, Kenzo Lobos Tsunekawa, Kyoichi Sugahara, Masaki Baba, Masato Saeki, Maxime CLEMENT, Mitsuhiro Sakamoto, Ryohsuke Mitsudome, Satoshi OTA, Sho Iwasawa, Takagi, Isamu, Takayuki Murooka, Yuki TAKAGI, badai nguyen, github-actions, mkquda
 
-* feat(out_of_lane): improve out of lane stability (`#1404 <https://github.com/autowarefoundation/autoware_launch/issues/1404>`_)
-  * update out_of_lane parameters
-  * change parameter value
-  * remove unused parameter
-  * fix spelling
-  ---------
-* feat(control_validator): add over run estimation feature (`#1394 <https://github.com/autowarefoundation/autoware_launch/issues/1394>`_)
-* feat(autoware_launch): add ColoredPoseWithCovarianceHistory to Localization NDT (`#1382 <https://github.com/autowarefoundation/autoware_launch/issues/1382>`_)
-  * feat: update autoware.rviz
-  - add Localization/NDT ColoredPoseWithCovarianceHistory
-  * add: /localization/pose_estimator/nearest_voxel_transformation_likelihood
-  * change color and alpha
-  * fix: buffer size (15 seconds)
-  * fix: typo
-  * fix: add space
-  ---------
-* feat(traffic_light): add traffic light restart suppression parameters (`#1405 <https://github.com/autowarefoundation/autoware_launch/issues/1405>`_)
-  * feat: add traffic light restart_suppression param
-  * style(pre-commit): autofix
-  ---------
-  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: remove individual_params references (`#1403 <https://github.com/autowarefoundation/autoware_launch/issues/1403>`_)
-* refactor(planning_validator): separate validation check for steering and steering rate (`#1402 <https://github.com/autowarefoundation/autoware_launch/issues/1402>`_)
-  feat(planning_validator): separate steering rate parameter for improved configuration
-* feat(lidar_transfusion): add transfusion common param file (`#1400 <https://github.com/autowarefoundation/autoware_launch/issues/1400>`_)
-  add transfusion_common param
-* feat(multi_object_tracker): add detailed processing time publishing option (`#1398 <https://github.com/autowarefoundation/autoware_launch/issues/1398>`_)
-  * feat(multi_object_tracker): add detailed processing time publishing option
-  * fix(multi_object_tracker): disable detailed processing time publishing option
-  ---------
-* feat(radar_object_tracker): add diagnostics param (`#1399 <https://github.com/autowarefoundation/autoware_launch/issues/1399>`_)
-  * add diagnostics param
-  * fix param name
-  * change callback param name
-  ---------
-* feat(multi_object_tracker): vehicle's ego frame as a parameter (`#1397 <https://github.com/autowarefoundation/autoware_launch/issues/1397>`_)
-* revert(lane_departure_checker): "fix(lane_departure_checker): replace curbstone to road_border… (`#1395 <https://github.com/autowarefoundation/autoware_launch/issues/1395>`_)
-  Revert "fix(lane_departure_checker): replace curbstone to road_border (RT1-9845) (`#1391 <https://github.com/autowarefoundation/autoware_launch/issues/1391>`_)"
-  This reverts commit b26f3375d419f5e2e2621d8b36b7d6e8a0ded209.
-* feat(probabilistic_occupancy_grid_map): add diagnostics warning when … (`#1387 <https://github.com/autowarefoundation/autoware_launch/issues/1387>`_)
-  * feat(probabilistic_occupancy_grid_map): add diagnostics warning when latency is too long
-  * style(pre-commit): autofix
-  * feat(probabilistic_occupancy_grid_map):add tolerance duration
-  * feat(probabilistic_occupancy_grid_map):  fix variable names to processing time
-  ---------
-  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(lane_departure_checker): replace curbstone to road_border (RT1-9845) (`#1391 <https://github.com/autowarefoundation/autoware_launch/issues/1391>`_)
-  fix(lane_departure_checker): replace curbstone to road_border
-* feat(lidar_centerpoint): add common param file (`#1377 <https://github.com/autowarefoundation/autoware_launch/issues/1377>`_)
-  * add common param
-  * fix comment and change value to float
-  ---------
-* feat(autoware_launch): remove exec_depend on autoware_launch from tier4_simulator_launch (`#1392 <https://github.com/autowarefoundation/autoware_launch/issues/1392>`_)
-* refactor(planning_validator): restructure planning validator configuration (`#1389 <https://github.com/autowarefoundation/autoware_launch/issues/1389>`_)
-  update planning validator config
-* feat: add parameter for irregular object pipeline (`#1381 <https://github.com/autowarefoundation/autoware_launch/issues/1381>`_)
-  * feat: add parameter for small unknown object pipeline
-  * chore: rename param
-  * refactor
-  * chore: spelling
-  * refactor: file renaming
-  * fix: param rename
-  * refactor: param path update
-  ---------
-* feat(multi_object_tracker): add diagnostics warning when extrapolation time exceeds limit with latency guarantee enabled (`#1378 <https://github.com/autowarefoundation/autoware_launch/issues/1378>`_)
-  * feat(multi_object_tracker): add diagnostics warning when extrapolation time exceeds limit with latency guarantee enabled
-  * style(pre-commit): autofix
-  ---------
-  Co-authored-by: lei.gu <lei.gu@tier4.jp>
-  Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(detection_area): integrate RTC feature (`#1383 <https://github.com/autowarefoundation/autoware_launch/issues/1383>`_)
-* feat(start/goal_planner): update max steer angle parameters to use margin scale (`#1368 <https://github.com/autowarefoundation/autoware_launch/issues/1368>`_)
-* feat: add parameter for diagnostics (`#1362 <https://github.com/autowarefoundation/autoware_launch/issues/1362>`_)
-* feat(perception): add parameter for diag (`#1357 <https://github.com/autowarefoundation/autoware_launch/issues/1357>`_)
-  * add parameter for diag
-  * change param name
-  * add unit
-  ---------
-* fix(roi_pointcloud_fusion): add roi scale factor param (`#1376 <https://github.com/autowarefoundation/autoware_launch/issues/1376>`_)
-* feat(control_validator)!: add acceleration check (`#1375 <https://github.com/autowarefoundation/autoware_launch/issues/1375>`_)
-* feat(crosswalk_module): add param to consider objects on crosswalk when pedestrian traffic light is red (`#1374 <https://github.com/autowarefoundation/autoware_launch/issues/1374>`_)
-* feat(crosswalk): fix stop position calclaton params (`#1370 <https://github.com/autowarefoundation/autoware_launch/issues/1370>`_)
-* feat(multi_object_tracker): add input channel flags for selective update per channel (`#1364 <https://github.com/autowarefoundation/autoware_launch/issues/1364>`_)
-  feat(multi_object_tracker): update input channel flags for improved tracking parameters
-* feat(goal_planner): expand outer collision check margin (`#1365 <https://github.com/autowarefoundation/autoware_launch/issues/1365>`_)
-* Contributors: Amadeusz Szymko, Kazu, Kosuke Takeuchi, Kotaro Uetake, Kyoichi Sugahara, Masaki Baba, Masato Saeki, Mehmet Dogru, Mete Fatih Cırıt, Satoshi OTA, Taekjin LEE, Takagi, Isamu, Yuki TAKAGI, Zulfaqar Azmi, badai nguyen, eiki, lei.gu, mkquda
+0.44.1 (2025-05-12)
+-------------------
+* feat(duplicated_node_checker): ignore duplicate get parameter (`#1413 <https://github.com/autowarefoundation/autoware_launch/issues/1413>`_)
+* Contributors: Ryohsuke Mitsudome
 
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
 * feat(out_of_lane): improve out of lane stability (`#1404 <https://github.com/autowarefoundation/autoware_launch/issues/1404>`_)
   * update out_of_lane parameters
   * change parameter value
@@ -263,7 +150,10 @@ Changelog for package autoware_launch
 * feat(multi_object_tracker): add input channel flags for selective update per channel (`#1364 <https://github.com/autowarefoundation/autoware_launch/issues/1364>`_)
   feat(multi_object_tracker): update input channel flags for improved tracking parameters
 * feat(goal_planner): expand outer collision check margin (`#1365 <https://github.com/autowarefoundation/autoware_launch/issues/1365>`_)
-* Contributors: Amadeusz Szymko, Kazu, Kosuke Takeuchi, Kotaro Uetake, Kyoichi Sugahara, Masaki Baba, Masato Saeki, Mehmet Dogru, Mete Fatih Cırıt, Satoshi OTA, Taekjin LEE, Takagi, Isamu, Yuki TAKAGI, Zulfaqar Azmi, badai nguyen, eiki, lei.gu, mkquda
+* Contributors: Amadeusz Szymko, Kazu, Kosuke Takeuchi, Kotaro Uetake, Kyoichi Sugahara, Masaki Baba, Masato Saeki, Mehmet Dogru, Mete Fatih Cırıt, Ryohsuke Mitsudome, Satoshi OTA, Taekjin LEE, Takagi, Isamu, Yuki TAKAGI, Yutaka Kondo, Zulfaqar Azmi, badai nguyen, eiki, lei.gu, mkquda
+
+0.43.1 (2025-04-01)
+-------------------
 
 0.43.0 (2025-03-21)
 -------------------

--- a/autoware_launch/config/control/autoware_collision_detector/collision_detector.param.yaml
+++ b/autoware_launch/config/control/autoware_collision_detector/collision_detector.param.yaml
@@ -15,7 +15,7 @@
       filter_pedestrian: false
       filter_unknown: true
     ignore_behind_rear_axle: true  # If true, collisions detected behind the rear axle of the ego vehicle are ignored
-    time_buffer:
-      on: 0.2  # [s] minimum consecutive detection time before triggering the diagnostic
-      off: 5.0  # [s] minimum consecutive time without collision detection (including the hysteresis) before releasing the diagnostic
+    time_buffer:  # buffer to start or stop publishing the ERROR diagnostic
+      on_duration: 0.2  # [s] minimum consecutive detection time before triggering the diagnostic
+      off_duration: 5.0  # [s] minimum consecutive time without collision detection (including the hysteresis) before releasing the diagnostic
       off_distance_hysteresis: 1.0  # [m] extra distance used to detect collisions once the diagnostic is triggered

--- a/autoware_launch/config/control/autoware_collision_detector/collision_detector.param.yaml
+++ b/autoware_launch/config/control/autoware_collision_detector/collision_detector.param.yaml
@@ -14,3 +14,8 @@
       filter_motorcycle: false
       filter_pedestrian: false
       filter_unknown: true
+    ignore_behind_rear_axle: true  # If true, collisions detected behind the rear axle of the ego vehicle are ignored
+    time_buffer:
+      on: 0.2  # [s] minimum consecutive detection time before triggering the diagnostic
+      off: 5.0  # [s] minimum consecutive time without collision detection (including the hysteresis) before releasing the diagnostic
+      off_distance_hysteresis: 1.0  # [m] extra distance used to detect collisions once the diagnostic is triggered

--- a/autoware_launch/config/control/control_validator/control_validator.param.yaml
+++ b/autoware_launch/config/control/control_validator/control_validator.param.yaml
@@ -9,6 +9,7 @@
 
     thresholds:
       max_distance_deviation: 1.0
+      lateral_jerk: 10.0
       acc_error_offset: 0.8
       acc_error_scale: 0.2
       rolling_back_velocity: 0.5

--- a/autoware_launch/config/control/operation_mode_transition_manager/operation_mode_transition_manager.param.yaml
+++ b/autoware_launch/config/control/operation_mode_transition_manager/operation_mode_transition_manager.param.yaml
@@ -1,5 +1,6 @@
 /**:
   ros__parameters:
+    input_timeout: 3.0
     transition_timeout: 10.0
     frequency_hz: 10.0
 

--- a/autoware_launch/config/perception/object_recognition/detection/image_projection_based_fusion/pointpainting_common.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/image_projection_based_fusion/pointpainting_common.param.yaml
@@ -1,0 +1,11 @@
+/**:
+  ros__parameters:
+    diagnostics:
+      # When the processing time exceeds the max_allowed_processing_time,
+      # a warning will be triggered.
+      max_allowed_processing_time_ms: 200.0 # in milliseconds
+      # If the warning is triggered and if a timestamp of last normal processing is more than
+      # max_acceptable_consecutive_delay_ms, an error diagnostic message will be sent.
+      max_acceptable_consecutive_delay_ms: 1000.0
+      # interval of diagnostic callback in milliseconds
+      pointpainting_validation_callback_interval_ms: 100.0 # in milliseconds

--- a/autoware_launch/config/perception/object_recognition/detection/lidar_model/bevfusion_camera_lidar.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/lidar_model/bevfusion_camera_lidar.param.yaml
@@ -1,0 +1,22 @@
+/**:
+  ros__parameters:
+    # modality
+    sensor_fusion: true
+    # non-network params
+    max_camera_lidar_delay: 0.12
+    # plugins
+    plugins_path: $(find-pkg-share autoware_tensorrt_plugins)/plugins/libautoware_tensorrt_plugins.so
+    # network
+    trt_precision: fp16
+    cloud_capacity: 2000000
+    onnx_path: "$(var model_path)/bevfusion_camera_lidar.onnx"
+    engine_path: "$(var model_path)/bevfusion_camera_lidar.engine"
+    # pre-process params
+    densification_num_past_frames: 1
+    densification_world_frame_id: map
+    # post-process params
+    circle_nms_dist_threshold: 0.5
+    iou_nms_search_distance_2d: 10.0
+    iou_nms_threshold: 0.1
+    yaw_norm_thresholds: [0.3, 0.3, 0.3, 0.3, 0.0] # refers to the class_names
+    score_threshold: 0.1

--- a/autoware_launch/config/perception/object_recognition/detection/lidar_model/bevfusion_common.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/lidar_model/bevfusion_common.param.yaml
@@ -1,0 +1,11 @@
+/**:
+  ros__parameters:
+    diagnostics:
+      # When the processing time exceeds the max_allowed_processing_time,
+      # a warning will be triggered.
+      max_allowed_processing_time_ms: 200.0 # in milliseconds
+      # If the warning is triggered and if a timestamp of last normal processing is more than
+      # max_acceptable_consecutive_delay_ms, an error diagnostic message will be sent.
+      max_acceptable_consecutive_delay_ms: 1000.0
+      # interval of diagnostic callback in milliseconds
+      validation_callback_interval_ms: 100.0 # in milliseconds

--- a/autoware_launch/config/perception/object_recognition/detection/lidar_model/bevfusion_lidar.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/lidar_model/bevfusion_lidar.param.yaml
@@ -1,0 +1,22 @@
+/**:
+  ros__parameters:
+    # modality
+    sensor_fusion: false
+    # non-network params
+    max_camera_lidar_delay: 0.0
+    # plugins
+    plugins_path: $(find-pkg-share autoware_tensorrt_plugins)/plugins/libautoware_tensorrt_plugins.so
+    # network
+    trt_precision: fp16
+    cloud_capacity: 2000000
+    onnx_path: "$(var model_path)/bevfusion_lidar.onnx"
+    engine_path: "$(var model_path)/bevfusion_lidar.engine"
+    # pre-process params
+    densification_num_past_frames: 1
+    densification_world_frame_id: map
+    # post-process params
+    circle_nms_dist_threshold: 0.5
+    iou_nms_search_distance_2d: 10.0
+    iou_nms_threshold: 0.1
+    yaw_norm_thresholds: [0.3, 0.3, 0.3, 0.3, 0.0] # refers to the class_names
+    score_threshold: 0.1

--- a/autoware_launch/config/perception/occupancy_grid_map/multi_lidar_pointcloud_based_occupancy_grid_map.param.yaml
+++ b/autoware_launch/config/perception/occupancy_grid_map/multi_lidar_pointcloud_based_occupancy_grid_map.param.yaml
@@ -14,6 +14,8 @@
 
         # debug parameters
         publish_processing_time_detail: false
+        processing_time_tolerance_ms: 50.0 # [ms]
+        processing_time_consecutive_excess_tolerance_ms: 1000.0 # [ms]
 
       # downsample input pointcloud
       downsample_input_pointcloud: true

--- a/autoware_launch/config/perception/traffic_light_recognition/traffic_light_map_based_detector/camera6_traffic_light_map_based_detector.param.yaml
+++ b/autoware_launch/config/perception/traffic_light_recognition/traffic_light_map_based_detector/camera6_traffic_light_map_based_detector.param.yaml
@@ -1,10 +1,10 @@
 /**:
   ros__parameters:
-    max_vibration_pitch: 0.01745329251   # -0.5 ~ 0.5 deg
-    max_vibration_yaw: 0.01745329251     # -0.5 ~ 0.5 deg
-    max_vibration_height: 0.5            # -0.25 ~ 0.25 m
-    max_vibration_width: 0.5             # -0.25 ~ 0.25 m
-    max_vibration_depth: 0.5             # -0.25 ~ 0.25 m
+    max_vibration_pitch: 0.01745329251   # -0.5 ~ 0.5 deg in camera frame
+    max_vibration_yaw: 0.01745329251     # -0.5 ~ 0.5 deg in camera frame
+    max_vibration_height: 0.5            # -0.25 ~ 0.25 m in camera optical frame
+    max_vibration_width: 0.5             # -0.25 ~ 0.25 m in camera optical frame
+    max_vibration_depth: 0.5             # -0.25 ~ 0.25 m in camera optical frame
     max_detection_range: 200.0
     min_timestamp_offset: -0.3
     max_timestamp_offset: 0.0

--- a/autoware_launch/config/perception/traffic_light_recognition/traffic_light_map_based_detector/camera7_traffic_light_map_based_detector.param.yaml
+++ b/autoware_launch/config/perception/traffic_light_recognition/traffic_light_map_based_detector/camera7_traffic_light_map_based_detector.param.yaml
@@ -1,10 +1,10 @@
 /**:
   ros__parameters:
-    max_vibration_pitch: 0.01745329251   # -0.5 ~ 0.5 deg
-    max_vibration_yaw: 0.01745329251     # -0.5 ~ 0.5 deg
-    max_vibration_height: 0.5            # -0.25 ~ 0.25 m
-    max_vibration_width: 0.5             # -0.25 ~ 0.25 m
-    max_vibration_depth: 0.5             # -0.25 ~ 0.25 m
+    max_vibration_pitch: 0.01745329251   # -0.5 ~ 0.5 deg in camera frame
+    max_vibration_yaw: 0.01745329251     # -0.5 ~ 0.5 deg in camera frame
+    max_vibration_height: 0.5            # -0.25 ~ 0.25 m in camera optical frame
+    max_vibration_width: 0.5             # -0.25 ~ 0.25 m in camera optical frame
+    max_vibration_depth: 0.5             # -0.25 ~ 0.25 m in camera optical frame
     max_detection_range: 200.0
     min_timestamp_offset: -0.04
     max_timestamp_offset: 0.0

--- a/autoware_launch/config/perception/traffic_light_recognition/traffic_light_map_based_detector/traffic_light_traffic_light_map_based_detector.param.yaml
+++ b/autoware_launch/config/perception/traffic_light_recognition/traffic_light_map_based_detector/traffic_light_traffic_light_map_based_detector.param.yaml
@@ -1,10 +1,10 @@
 /**:
   ros__parameters:
-    max_vibration_pitch: 0.01745329251   # -0.5 ~ 0.5 deg
-    max_vibration_yaw: 0.01745329251     # -0.5 ~ 0.5 deg
-    max_vibration_height: 0.5            # -0.25 ~ 0.25 m
-    max_vibration_width: 0.5             # -0.25 ~ 0.25 m
-    max_vibration_depth: 0.5             # -0.25 ~ 0.25 m
+    max_vibration_pitch: 0.01745329251   # -0.5 ~ 0.5 deg in camera frame
+    max_vibration_yaw: 0.01745329251     # -0.5 ~ 0.5 deg in camera frame
+    max_vibration_height: 0.5            # -0.25 ~ 0.25 m in camera optical frame
+    max_vibration_width: 0.5             # -0.25 ~ 0.25 m in camera optical frame
+    max_vibration_depth: 0.5             # -0.25 ~ 0.25 m in camera optical frame
     max_detection_range: 200.0
     min_timestamp_offset: -0.3
     max_timestamp_offset: 0.0

--- a/autoware_launch/config/perception/traffic_light_recognition/traffic_light_selector/traffic_light_selector.param.yaml
+++ b/autoware_launch/config/perception/traffic_light_recognition/traffic_light_selector/traffic_light_selector.param.yaml
@@ -1,3 +1,0 @@
-/**:
-  ros__parameters:
-    max_iou_threshold: -0.5

--- a/autoware_launch/config/planning/preset/default_preset.yaml
+++ b/autoware_launch/config/planning/preset/default_preset.yaml
@@ -117,6 +117,9 @@ launch:
   - arg:
       name: launch_obstacle_velocity_limiter_module
       default: "true"
+  - arg:
+      name: launch_mvp_run_out_module
+      default: "false"
 
   - arg:
       name: motion_stop_planner_type

--- a/autoware_launch/config/planning/scenario_planning/common/planning_validator/planning_validator.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/common/planning_validator/planning_validator.param.yaml
@@ -16,6 +16,11 @@
     diag_error_count_threshold: 0
     display_on_terminal: true # show error msg on terminal
 
+    # if handling type is 2 (use last valid traj), the following parameters are used to enable soft stop
+    enable_soft_stop_on_prev_traj: true
+    soft_stop_deceleration: -1.0 # [m/s^2]
+    soft_stop_jerk_lim: 0.3 # [m/s^3]
+
     validity_checks:
       latency:
         enable: true
@@ -63,3 +68,9 @@
         acceleration: -3.0
         margin: 2.0
         is_critical: false
+      trajectory_shift:
+        enable: true
+        lat_shift_th: 0.5
+        forward_shift_th: 1.0
+        backward_shift_th: 0.1
+        is_critical: true

--- a/autoware_launch/config/planning/scenario_planning/common/planning_validator/planning_validator.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/common/planning_validator/planning_validator.param.yaml
@@ -39,6 +39,10 @@
         longitudinal_max_th: 9.8
         longitudinal_min_th: -9.8
         is_critical: false
+      lateral_jerk:
+        enable: true
+        threshold: 7.0
+        is_critical: false
       steering:
         enable: true
         threshold: 1.414

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/static_obstacle_avoidance.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/static_obstacle_avoidance.param.yaml
@@ -265,6 +265,10 @@
         stop_buffer: 1.0                                # [m] FOR DEVELOPER
 
       policy:
+        # policy for module behavior. select "reliable" or "not_enough".
+        # "reliable": this module fully trusts the perception results and makes all decisions automatically.
+        # "not_enough": because the perception results are not fully reliable, the system waits for the operator's judgment in situations where long-range perception is required.
+        detection_reliability: "reliable"
         # policy for rtc request. select "per_shift_line" or "per_avoidance_maneuver".
         # "per_shift_line": request approval for each shift line.
         # "per_avoidance_maneuver": request approval for avoidance maneuver (avoid + return).

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/drivable_area_expansion.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/drivable_area_expansion.param.yaml
@@ -17,8 +17,8 @@
         arc_length_range: 2.0  # [m] arc length range where an expansion distance is initially applied
       ego:
         extra_wheelbase: 0.0 # [m] extra length to add to the wheelbase
-        extra_front_overhang: 0.5 # [m] extra length to add to the front overhang
-        extra_width: 1.0 # [m] extra length to add to the width
+        extra_front_overhang: 0.0 # [m] extra length to add to the front overhang
+        extra_width: 0.0 # [m] extra length to add to the width
       object_exclusion:
         exclude_static: false # if true, the drivable area is not expanded over static objects
         exclude_dynamic: false # if true, the drivable area is not expanded in the predicted path of dynamic objects

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
@@ -3,4 +3,3 @@
     forward_path_length: 1000.0
     backward_path_length: 5.0
     behavior_output_path_interval: 1.0
-    stop_line_extend_length: 5.0

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/crosswalk.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/crosswalk.param.yaml
@@ -15,7 +15,7 @@
         stop_distance_from_crosswalk: 3.5 # [m] make stop line away from crosswalk
         # For the case where the stop position is determined according to the object position.
         stop_distance_from_object_preferred: 3.0 # [m]
-        stop_distance_from_object_limit: 3.0 # [m]
+        stop_distance_from_crosswalk_limit: 3.0 # [m]
         min_acc_preferred: -1.2 # min acceleration [m/ss]
         min_jerk_preferred: -1.2 # min jerk [m/sss]
 
@@ -48,10 +48,10 @@
 
         consider_obj_on_crosswalk_on_red_light: false # consider and do not ignore objects if they are on the crosswalk when the crosswalk pedestrian traffic light is red
 
-        no_stop_decision: # parameters to determine stop cancel. {-$overrun_threshold_length + f($min_acc, $min_jerk)} is compared against distance to stop pose.
+        no_stop_decision: # parameters to determine stop cancel. the distance f($min_acc, $min_jerk) is compared against min(distance to stop pose, 0.1).
+          enable_no_stop_decision: true
           min_acc: -1.5 # min acceleration [m/ss]
           min_jerk: -1.5 # min jerk [m/sss]
-          overrun_threshold_length: 1.0 # [m] required to avoid giving up against backward movement of the stop position due to approaching pedestrians, etc.
 
         stop_object_velocity_threshold: 0.25 # [m/s] velocity threshold for the module to judge whether the objects is stopped (0.25 m/s = 0.9 kmph)
         min_object_velocity: 1.39 # [m/s] minimum object velocity (compare the estimated velocity by perception module with this parameter and adopt the larger one to calculate TTV. 1.39 m/s = 5.0 kmph)

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/motion_velocity_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/motion_velocity_planner.param.yaml
@@ -12,3 +12,13 @@
       consider_current_pose:
         enable_to_consider_current_pose: true
         time_to_convergence: 1.5 #[s]
+
+    pointcloud:
+      pointcloud_voxel_grid_x: 0.05
+      pointcloud_voxel_grid_y: 0.05
+      pointcloud_voxel_grid_z: 100000.0
+      pointcloud_cluster_tolerance: 1.0
+      pointcloud_min_cluster_size: 1
+      pointcloud_max_cluster_size: 100000
+
+      mask_lat_margin: 2.0

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/run_out.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/run_out.param.yaml
@@ -1,0 +1,72 @@
+/**:
+  ros__parameters:
+    run_out:  # module to stop or slowdown before sudden collisions with obstacles
+      collision:
+        time_margin: 0.5  # [s] extra time margin used to determine collisions
+        time_overlap_tolerance: 0.1  # [s] when calculating overlap time intervals, intervals are grouped if they are separated by less than this tolerance value
+        same_direction_angle_threshold: 0.5  # [rad] threshold to determine if a collision is going in the same direction as the ego trajectory
+        opposite_direction_angle_threshold: 0.5  # [rad] threshold around pi to determine if a collision is going in a direction opposite to the ego trajectory
+
+        ignore_conditions:  # ignore collisions in some conditions
+          if_ego_arrives_first: # collision where ego arrives first
+            enable: true
+            margin: # margins to decide if we can ignore the collision. linearly interpolated based on the collision time and the provided mappings
+              ego_enter_times: [0.0, 3.0]  # [s] predicted times when ego starts overlapping the path of the object
+              time_margins: [0.0, 6.0] # [s] margin values used such that ego needs to enter the overlap before the object with this much margin to decide to ignore the collision
+            max_overlap_duration: 2.0  # [s] the collision is not ignored if ego is predicted to stay on the object's path for longer than this duration
+          if_ego_arrives_first_and_cannot_stop: # collision where ego arrives first (margins not considered) and cannot stop before the collision
+            enable: true
+            deceleration_limit: 5.0 # [m/s²] deceleration used to determine if ego can stop before a collision
+
+      slowdown:  # comfortable slowdown when detecting a collision
+        on_time_buffer: 0.1   # [s] successive collision detection time required to start the slowdown decision
+        off_time_buffer: 0.5  # [s] successive non-collision detection time required to remove the slowdown decision
+        distance_buffer: 2.0  # [m] longitudinal distance between the collision and the slowdown positions
+        deceleration_limit: 4.0  # [m/s²] maximum deceleration that can be applied by the preventive slowdown
+
+      stop:  # emergency stop when detecting a collision
+        on_time_buffer: 0.5   # [s] successive collision detection time required to start the stopping decision
+        off_time_buffer: 0.5  # [s] successive non-collision detection time required to remove a stopping decision
+        distance_buffer: 2.0  # [m] longitudinal safety distance to keep between ego and the collision position
+        deceleration_limit: 5.0  # [m/s²] if a stop causes a deceleration higher than this limit, an ERROR diagnostic is published
+        keep_condition:  # keep the stop decision if we still find any collision with the object within some time+distance range
+          time: 5.0  # [s] time along the ego trajectory
+          distance: 5.0  # [m] distance along the ego trajectory
+
+      ego:
+        # additional margins to calculate the ego footprint used for collision detection
+        lateral_margin: 0.0 # [m] extra lateral margin
+        longitudinal_margin: 0.0 # [m] extra longitudinal margin
+
+      objects:
+        target_labels: ["PEDESTRIAN", "BICYCLE", "MOTORCYCLE"]
+        # for each target labels we can specify the following parameters
+        DEFAULT:
+          ignore:  # options to ignore some objects
+            if_stopped: false # if true, object with a velocity bellow the threshold are ignored
+            stopped_velocity_threshold: 0.5  # [m/s]
+            if_on_ego_trajectory: true  # if true, object located on the ego trajectory footprint are ignored
+            if_behind_ego: true  # if true, objects located behind the ego vehicles are ignored
+            polygon_types: ["NONE"]  # types of polygons in the vector map used to ignore objects
+            lanelet_subtypes: ["NONE"]  # subtypes of lanelets in the vector map used to ignore objects
+          ignore_collisions:  # option to ignore some collisions with the object
+            polygon_types: ["NONE"]  # types of polygons in the vector map where collisions are ignored
+            lanelet_subtypes: ["NONE"]  # subtypes of lanelets in the vector map used where collisions are ignored
+          confidence_filtering:
+            threshold: 0.0  # [-] only use predicted paths with a higher confidence value than this threshold
+            only_use_highest: true  # if true, only the path(s) with the highest confidence are used
+          cut_predicted_paths:  # options to cut predicted paths of dynamic objects
+            if_crossing_ego_from_behind: true # if true, cut after crossing the ego vehicle
+            polygon_types: ["NONE"]  # types of polygons in the vector map used to cut predicted paths
+            linestring_types: ["guard_rail"]  # types of linestrings in the vector map used to cut predicted paths
+            lanelet_subtypes: ["NONE"]  # subtypes of lanelets in the vector map used to cut predicted paths
+        PEDESTRIAN:
+          ignore:
+            lanelet_subtypes: ["crosswalk", "walkway"]
+          cut_predicted_paths:
+            lanelet_subtypes: ["crosswalk", "walkway"]
+        BICYCLE:
+          ignore_collisions:
+            lanelet_subtypes: ["crosswalk", "walkway"]
+      debug:
+        object_label: "PEDESTRIAN"  # debug markers specific to each object classification labels will only be published for this one

--- a/autoware_launch/config/system/diagnostics/autoware-main.yaml
+++ b/autoware_launch/config/system/diagnostics/autoware-main.yaml
@@ -14,6 +14,7 @@ units:
       - { type: link, link: /autoware/vehicle }
       - { type: link, link: /autoware/system }
       - { type: link, link: /autoware/control/local }
+      - { type: link, link: /adapi/mrm_request/delegate }
 
   - path: /autoware/modes/remote
     type: and
@@ -21,9 +22,12 @@ units:
       - { type: link, link: /autoware/vehicle }
       - { type: link, link: /autoware/system }
       - { type: link, link: /autoware/control/remote }
+      - { type: link, link: /adapi/mrm_request/delegate }
 
   - path: /autoware/modes/stop
-    type: ok
+    type: and
+    list:
+      - { type: link, link: /adapi/mrm_request/delegate }
 
   - path: /autoware/modes/autonomous
     type: and
@@ -35,6 +39,7 @@ units:
       - { type: link, link: /autoware/control }
       - { type: link, link: /autoware/vehicle }
       - { type: link, link: /autoware/system }
+      - { type: link, link: /adapi/mrm_request/delegate }
 
   - path: /autoware/modes/pull_over
     type: and
@@ -68,3 +73,8 @@ units:
     type: and
     list:
       - { type: link, link: /autoware/system/service_log_checker }
+
+  - path: /adapi/mrm_request/delegate
+    type: diag
+    node: /adapi/node/mrm_request
+    name: delegate

--- a/autoware_launch/config/system/diagnostics/control.yaml
+++ b/autoware_launch/config/system/diagnostics/control.yaml
@@ -7,7 +7,6 @@ units:
       - { type: link, link: /autoware/control/node_alive_monitoring/vehicle_cmd_gate }
       - { type: link, link: /autoware/control/emergency_braking }
       - { type: link, link: /autoware/control/performance_monitoring/lane_departure }
-      - { type: link, link: /autoware/control/performance_monitoring/trajectory_deviation }
       - { type: link, link: /autoware/control/performance_monitoring/control_state }
 
   - path: /autoware/control/local
@@ -46,11 +45,6 @@ units:
     type: diag
     node: lane_departure_checker_node
     name: lane_departure
-
-  - path: /autoware/control/performance_monitoring/trajectory_deviation
-    type: diag
-    node: lane_departure_checker_node
-    name: trajectory_deviation
 
   - path: /autoware/control/performance_monitoring/control_state
     type: diag

--- a/autoware_launch/config/system/diagnostics/localization.yaml
+++ b/autoware_launch/config/system/diagnostics/localization.yaml
@@ -14,8 +14,8 @@ units:
 
   - path: /autoware/localization/state
     type: diag
-    node: component_state_diagnostics
-    name: localization_state
+    node: /adapi/node/localization
+    name: state
 
   - path: /autoware/localization/topic_rate_check/transform
     type: diag

--- a/autoware_launch/config/system/diagnostics/planning.yaml
+++ b/autoware_launch/config/system/diagnostics/planning.yaml
@@ -23,6 +23,7 @@ units:
       - { type: link, link: /autoware/planning/trajectory_validation/steering }
       - { type: link, link: /autoware/planning/trajectory_validation/steering_rate }
       - { type: link, link: /autoware/planning/trajectory_validation/velocity_deviation }
+      - { type: link, link: /autoware/planning/trajectory_validation/trajectory_shift }
 
   - path: /autoware/planning/routing/state
     type: diag
@@ -88,3 +89,8 @@ units:
     type: diag
     node: planning_validator
     name: trajectory_validation_velocity_deviation
+
+  - path: /autoware/planning/trajectory_validation/trajectory_shift
+    type: diag
+    node: planning_validator
+    name: trajectory_validation_trajectory_shift

--- a/autoware_launch/config/system/diagnostics/planning.yaml
+++ b/autoware_launch/config/system/diagnostics/planning.yaml
@@ -27,8 +27,8 @@ units:
 
   - path: /autoware/planning/routing/state
     type: diag
-    node: component_state_diagnostics
-    name: route_state
+    node: /adapi/node/routing
+    name: state
 
   - path: /autoware/planning/topic_rate_check/route
     type: diag

--- a/autoware_launch/config/system/duplicated_node_checker/duplicated_node_checker.param.yaml
+++ b/autoware_launch/config/system/duplicated_node_checker/duplicated_node_checker.param.yaml
@@ -4,3 +4,4 @@
     add_duplicated_node_names_to_msg: true # if true, duplicated node names are added to msg
     nodes_to_ignore:  # List of nodes to ignore when checking for duplicates
       - /rviz2
+      - /simulation/getParameter

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -221,7 +221,6 @@
       name="traffic_light_roi_visualizer_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_visualization/traffic_light_roi_visualizer.param.yaml"
     />
-    <arg name="traffic_light_selector_param_path" value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_selector/traffic_light_selector.param.yaml"/>
     <arg
       name="traffic_light_occlusion_predictor_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_occlusion_predictor/traffic_light_occlusion_predictor.param.yaml"

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -15,6 +15,7 @@
   <arg name="use_object_filter" default="true" description="launch object filter to filter-out detected object"/>
   <arg name="use_obstacle_segmentation_single_frame_filter" default="false" description="use single frame filter at the ground segmentation"/>
   <arg name="use_obstacle_segmentation_time_series_filter" default="true" description="use time series filter at the ground segmentation"/>
+  <arg name="segmentation_pointcloud_fusion_camera_ids" default="[0,2,4]" description="list of camera ids used for segmentation_pointcloud_fusion node, mainly using front camera"/>
 
   <arg name="occupancy_grid_map_method" default="pointcloud_based" description="options: pointcloud_based, laserscan_based, multi_lidar_pointcloud_based"/>
   <arg name="occupancy_grid_map_updater" default="binary_bayes_filter" description="options: binary_bayes_filter"/>
@@ -57,6 +58,7 @@
     <arg name="objects_validation_method" value="$(var detected_objects_validation_method)"/>
     <arg name="use_obstacle_segmentation_single_frame_filter" value="$(var use_obstacle_segmentation_single_frame_filter)"/>
     <arg name="use_obstacle_segmentation_time_series_filter" value="$(var use_obstacle_segmentation_time_series_filter)"/>
+    <arg name="segmentation_pointcloud_fusion_camera_ids" value="$(var segmentation_pointcloud_fusion_camera_ids)"/>
 
     <!-- traffic light recognition options to switch launch function/module -->
     <arg name="use_traffic_light_recognition" value="$(var use_traffic_light_recognition)"/>

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -106,6 +106,10 @@
       value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/image_projection_based_fusion/roi_detected_object_fusion.param.yaml"
     />
     <arg
+      name="object_recognition_detection_pointpainting_fusion_common_param_path"
+      value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/image_projection_based_fusion/pointpainting_common.param.yaml"
+    />
+    <arg
       name="object_recognition_detection_obstacle_pointcloud_based_validator_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/detected_object_validation/obstacle_pointcloud_based_validator.param.yaml"
     />

--- a/autoware_launch/launch/components/tier4_planning_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_planning_component.launch.xml
@@ -83,6 +83,7 @@
     <arg name="motion_velocity_planner_dynamic_obstacle_stop_module_param_path" value="$(var motion_config_path)/motion_velocity_planner/dynamic_obstacle_stop.param.yaml"/>
     <arg name="motion_velocity_planner_out_of_lane_module_param_path" value="$(var motion_config_path)/motion_velocity_planner/out_of_lane.param.yaml"/>
     <arg name="motion_velocity_planner_obstacle_velocity_limiter_param_path" value="$(var motion_config_path)/motion_velocity_planner/obstacle_velocity_limiter.param.yaml"/>
+    <arg name="motion_velocity_planner_run_out_param_path" value="$(var motion_config_path)/motion_velocity_planner/run_out.param.yaml"/>
     <arg
       name="motion_velocity_planner_velocity_smoother_type_param_path"
       value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/common/autoware_velocity_smoother/Analytical.param.yaml"

--- a/autoware_launch/launch/components/tier4_simulator_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_simulator_component.launch.xml
@@ -104,7 +104,6 @@
       name="traffic_light_roi_visualizer_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_visualization/traffic_light_roi_visualizer.param.yaml"
     />
-    <arg name="traffic_light_selector_param_path" value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_selector/traffic_light_selector.param.yaml"/>
     <arg
       name="traffic_light_occlusion_predictor_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_occlusion_predictor/traffic_light_occlusion_predictor.param.yaml"

--- a/autoware_launch/package.xml
+++ b/autoware_launch/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_launch</name>
-  <version>0.44.0</version>
+  <version>0.45.0</version>
   <description>The autoware_launch package</description>
 
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -2290,6 +2290,18 @@ Visualization Manager:
                             Reliability Policy: Reliable
                             Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/dynamic_obstacle_stop/virtual_walls
                           Value: true
+                        - Class: rviz_default_plugins/MarkerArray
+                          Enabled: true
+                          Name: VirtualWall (RunOut)
+                          Namespaces:
+                            {}
+                          Topic:
+                            Depth: 5
+                            Durability Policy: Volatile
+                            History Policy: Keep Last
+                            Reliability Policy: Reliable
+                            Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/run_out/virtual_walls
+                          Value: true
                       Enabled: true
                       Name: VirtualWall
                     - Class: rviz_common/Group
@@ -2462,6 +2474,18 @@ Visualization Manager:
                                 History Policy: Keep Last
                                 Reliability Policy: Reliable
                                 Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/dynamic_obstacle_stop/debug_markers
+                              Value: true
+                            - Class: rviz_default_plugins/MarkerArray
+                              Enabled: true
+                              Name: RunOut
+                              Namespaces:
+                                {}
+                              Topic:
+                                Depth: 5
+                                Durability Policy: Volatile
+                                History Policy: Keep Last
+                                Reliability Policy: Reliable
+                                Value: /planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/run_out/debug_markers
                               Value: true
                           Enabled: false
                           Name: MotionVelocityPlanner
@@ -3929,6 +3953,18 @@ Visualization Manager:
                     History Policy: Keep Last
                     Reliability Policy: Reliable
                     Value: /planning/debug/objects_of_interest/obstacle_cruise_planner
+                  Value: true
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: RunOut
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/debug/objects_of_interest/run_out
                   Value: true
               Enabled: true
               Name: Objects Of Interest

--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -2566,6 +2566,46 @@ Visualization Manager:
                 Reliability Policy: Best Effort
                 Value: /planning/planning_diagnostics/planning_error_monitor/debug/marker
               Value: true
+            - Class: rviz_common/Group
+              Displays:
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: DebugMarker
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/planning_validator/debug/marker
+                  Value: true
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: VirtualWall
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/planning_validator/virtual_wall
+                  Value: true
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: false
+                  Name: Output
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Reliable
+                    Value: /planning/planning_validator/output/markers
+                  Value: false
+              Enabled: true
+              Name: PlanningValidator
           Enabled: false
           Name: Diagnostic
       Enabled: true

--- a/autoware_launch/rviz/perception.rviz
+++ b/autoware_launch/rviz/perception.rviz
@@ -373,21 +373,23 @@ Visualization Manager:
               Width: 550
           Enabled: true
           Name: Vehicle
-        - Class: rviz_plugins/MrmSummaryOverlayDisplay
-          Enabled: false
-          Font Size: 10
-          Left: 512
-          Max Letter Num: 100
-          Name: MRM Summary
-          Text Color: 25; 255; 240
-          Top: 64
+        - Class: autoware_string_stamped_rviz_plugin/StringStampedOverlayDisplay
+          Enabled: true
+          Font Size: 11
+          Left: 10
+          Max Letter Num: 70
+          Name: Error Diag Graph
+          Text Color: 51; 201; 220
+          Time To Erase Last Diag: 2
+          Time To Keep Last Diag: 1
+          Top: 100
           Topic:
-            Depth: 5
+            Depth: 1
             Durability Policy: Volatile
             History Policy: Keep Last
             Reliability Policy: Reliable
-            Value: /system/emergency/hazard_status
-          Value: false
+            Value: /logging_diag_graph/debug/error_graph_text
+          Value: true
           Value height offset: 0
       Enabled: true
       Name: System
@@ -4471,7 +4473,7 @@ Visualization Manager:
         Reliability Policy: Best Effort
         Value: /sensing/camera/image
       Value: true
-    - Class: rviz_plugins/StringStampedOverlayDisplay
+    - Class: autoware_string_stamped_rviz_plugin/StringStampedOverlayDisplay
       Enabled: true
       Font Size: 15
       Left: 24
@@ -4485,22 +4487,6 @@ Visualization Manager:
         History Policy: Keep Last
         Reliability Policy: Best Effort
         Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/internal_state
-      Value: true
-      Value height offset: 0
-    - Class: rviz_plugins/MrmSummaryOverlayDisplay
-      Enabled: true
-      Font Size: 16
-      Left: 24
-      Max Letter Num: 100
-      Name: MrmSummaryOverlayDisplay
-      Text Color: 25; 255; 240
-      Top: 120
-      Topic:
-        Depth: 5
-        Durability Policy: Volatile
-        History Policy: Keep Last
-        Reliability Policy: Reliable
-        Value: /system/emergency/hazard_status
       Value: true
       Value height offset: 0
   Enabled: true

--- a/autoware_launch/rviz/planning_bev.rviz
+++ b/autoware_launch/rviz/planning_bev.rviz
@@ -167,21 +167,23 @@ Visualization Manager:
               Width: 550
           Enabled: true
           Name: Vehicle
-        - Class: rviz_plugins/MrmSummaryOverlayDisplay
-          Enabled: false
-          Font Size: 10
-          Left: 512
-          Max Letter Num: 100
-          Name: MRM Summary
-          Text Color: 25; 255; 240
-          Top: 64
+        - Class: autoware_string_stamped_rviz_plugin/StringStampedOverlayDisplay
+          Enabled: true
+          Font Size: 11
+          Left: 10
+          Max Letter Num: 70
+          Name: Error Diag Graph
+          Text Color: 51; 201; 220
+          Time To Erase Last Diag: 2
+          Time To Keep Last Diag: 1
+          Top: 100
           Topic:
-            Depth: 5
+            Depth: 1
             Durability Policy: Volatile
             History Policy: Keep Last
             Reliability Policy: Reliable
-            Value: /system/emergency/hazard_status
-          Value: false
+            Value: /logging_diag_graph/debug/error_graph_text
+          Value: true
           Value height offset: 0
       Enabled: true
       Name: System
@@ -4273,7 +4275,7 @@ Visualization Manager:
         Reliability Policy: Best Effort
         Value: /sensing/camera/image
       Value: true
-    - Class: rviz_plugins/StringStampedOverlayDisplay
+    - Class: autoware_string_stamped_rviz_plugin/StringStampedOverlayDisplay
       Enabled: true
       Font Size: 15
       Left: 24
@@ -4287,22 +4289,6 @@ Visualization Manager:
         History Policy: Keep Last
         Reliability Policy: Best Effort
         Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/internal_state
-      Value: true
-      Value height offset: 0
-    - Class: rviz_plugins/MrmSummaryOverlayDisplay
-      Enabled: true
-      Font Size: 15
-      Left: 24
-      Max Letter Num: 100
-      Name: MrmSummaryOverlayDisplay
-      Text Color: 51; 201; 220
-      Top: 120
-      Topic:
-        Depth: 5
-        Durability Policy: Volatile
-        History Policy: Keep Last
-        Reliability Policy: Reliable
-        Value: /system/emergency/hazard_status
       Value: true
       Value height offset: 0
   Enabled: true

--- a/autoware_launch/rviz/planning_tpv.rviz
+++ b/autoware_launch/rviz/planning_tpv.rviz
@@ -372,21 +372,23 @@ Visualization Manager:
               Width: 550
           Enabled: true
           Name: Vehicle
-        - Class: rviz_plugins/MrmSummaryOverlayDisplay
-          Enabled: false
-          Font Size: 10
-          Left: 512
-          Max Letter Num: 100
-          Name: MRM Summary
-          Text Color: 25; 255; 240
-          Top: 64
+        - Class: autoware_string_stamped_rviz_plugin/StringStampedOverlayDisplay
+          Enabled: true
+          Font Size: 11
+          Left: 10
+          Max Letter Num: 70
+          Name: Error Diag Graph
+          Text Color: 51; 201; 220
+          Time To Erase Last Diag: 2
+          Time To Keep Last Diag: 1
+          Top: 100
           Topic:
-            Depth: 5
+            Depth: 1
             Durability Policy: Volatile
             History Policy: Keep Last
             Reliability Policy: Reliable
-            Value: /system/emergency/hazard_status
-          Value: false
+            Value: /logging_diag_graph/debug/error_graph_text
+          Value: true
           Value height offset: 0
       Enabled: true
       Name: System
@@ -4486,7 +4488,7 @@ Visualization Manager:
         Reliability Policy: Best Effort
         Value: /sensing/camera/image
       Value: true
-    - Class: rviz_plugins/StringStampedOverlayDisplay
+    - Class: autoware_string_stamped_rviz_plugin/StringStampedOverlayDisplay
       Enabled: true
       Font Size: 15
       Left: 24
@@ -4500,22 +4502,6 @@ Visualization Manager:
         History Policy: Keep Last
         Reliability Policy: Best Effort
         Value: /planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/debug/internal_state
-      Value: true
-      Value height offset: 0
-    - Class: rviz_plugins/MrmSummaryOverlayDisplay
-      Enabled: true
-      Font Size: 16
-      Left: 24
-      Max Letter Num: 100
-      Name: MrmSummaryOverlayDisplay
-      Text Color: 51; 201; 220
-      Top: 120
-      Topic:
-        Depth: 5
-        Durability Policy: Volatile
-        History Policy: Keep Last
-        Reliability Policy: Reliable
-        Value: /system/emergency/hazard_status
       Value: true
       Value height offset: 0
   Enabled: true

--- a/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_description/CHANGELOG.rst
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_description/CHANGELOG.rst
@@ -2,20 +2,26 @@
 Changelog for package awsim_labs_sensor_kit_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.44.0 (2025-04-18)
+0.45.0 (2025-05-22)
 -------------------
+
+0.44.1 (2025-05-12)
+-------------------
+
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
 * feat: remove individual_params references (`#1403 <https://github.com/autowarefoundation/autoware_launch/issues/1403>`_)
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
 
-* feat: remove individual_params references (`#1403 <https://github.com/autowarefoundation/autoware_launch/issues/1403>`_)
+0.43.1 (2025-04-01)
+-------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
 * Contributors: Mete Fatih Cırıt
-
-0.43.0 (2025-03-28)
--------------------
 
 0.42.0 (2025-03-28)
 -------------------

--- a/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_description/package.xml
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>awsim_labs_sensor_kit_description</name>
-  <version>0.44.0</version>
+  <version>0.45.0</version>
   <description>The awsim_labs_sensor_kit_description package</description>
   <maintainer email="piotr.jaroszek@robotec.ai">Piotr Jaroszek</maintainer>
   <license>Apache License 2.0</license>

--- a/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/CHANGELOG.rst
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/CHANGELOG.rst
@@ -2,22 +2,27 @@
 Changelog for package awsim_labs_sensor_kit_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.44.0 (2025-04-18)
+0.45.0 (2025-05-22)
 -------------------
+
+0.44.1 (2025-05-12)
+-------------------
+
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
 * feat: remove individual_params references (`#1403 <https://github.com/autowarefoundation/autoware_launch/issues/1403>`_)
 * chore(sensor_kit_launch): remove unused has_static_tf_only param (`#1393 <https://github.com/autowarefoundation/autoware_launch/issues/1393>`_)
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Amadeusz Szymko, Mete Fatih Cırıt
+* Contributors: Amadeusz Szymko, Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
 
-* feat: remove individual_params references (`#1403 <https://github.com/autowarefoundation/autoware_launch/issues/1403>`_)
-* chore(sensor_kit_launch): remove unused has_static_tf_only param (`#1393 <https://github.com/autowarefoundation/autoware_launch/issues/1393>`_)
+0.43.1 (2025-04-01)
+-------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Amadeusz Szymko, Mete Fatih Cırıt
-
-0.43.0 (2025-03-28)
--------------------
+* Contributors: Mete Fatih Cırıt
 
 0.42.0 (2025-03-28)
 -------------------

--- a/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/package.xml
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>awsim_labs_sensor_kit_launch</name>
-  <version>0.44.0</version>
+  <version>0.45.0</version>
   <description>The awsim_labs_sensor_kit_launch package</description>
   <maintainer email="piotr.jaroszek@robotec.ai">Piotr Jaroszek</maintainer>
   <license>Apache License 2.0</license>

--- a/sensor_kit/awsim_labs_sensor_kit_launch/common_awsim_labs_sensor_launch/CHANGELOG.rst
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/common_awsim_labs_sensor_launch/CHANGELOG.rst
@@ -2,18 +2,28 @@
 Changelog for package common_awsim_labs_sensor_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.44.0 (2025-04-18)
+0.45.0 (2025-05-22)
+-------------------
+* Merge remote-tracking branch 'origin/main' into tmp/bot/bump_version_base
+* feat(ring_outlier_filter): update node parameters (`#1421 <https://github.com/autowarefoundation/autoware_launch/issues/1421>`_)
+* Contributors: Kotaro Uetake, github-actions
+
+0.44.1 (2025-05-12)
+-------------------
+
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
+0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
 * Contributors: Mete Fatih Cırıt
-
-* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
-* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
-
-0.43.0 (2025-03-28)
--------------------
 
 0.42.0 (2025-03-28)
 -------------------

--- a/sensor_kit/awsim_labs_sensor_kit_launch/common_awsim_labs_sensor_launch/config/ring_outlier_filter_node.param.yaml
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/common_awsim_labs_sensor_launch/config/ring_outlier_filter_node.param.yaml
@@ -1,8 +1,7 @@
 /**:
   ros__parameters:
     distance_ratio: 1.03
-    object_length_threshold: 0.1
-    num_points_threshold: 4
+    object_length_threshold: 0.05
     max_rings_num: 128
     max_points_num_per_ring: 4000
     publish_outlier_pointcloud: false

--- a/sensor_kit/awsim_labs_sensor_kit_launch/common_awsim_labs_sensor_launch/package.xml
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/common_awsim_labs_sensor_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>common_awsim_labs_sensor_launch</name>
-  <version>0.44.0</version>
+  <version>0.45.0</version>
   <description>The common_sensor_launch package</description>
   <maintainer email="piotr.jaroszek@robotec.ai">Piotr Jaroszek</maintainer>
   <license>Apache License 2.0</license>

--- a/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_description/CHANGELOG.rst
+++ b/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_description/CHANGELOG.rst
@@ -2,18 +2,25 @@
 Changelog for package awsim_sensor_kit_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.44.0 (2025-04-18)
+0.45.0 (2025-05-22)
+-------------------
+
+0.44.1 (2025-05-12)
+-------------------
+
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
+0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
 * Contributors: Mete Fatih Cırıt
-
-* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
-* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
-
-0.43.0 (2025-03-28)
--------------------
 
 0.42.0 (2025-03-28)
 -------------------

--- a/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_description/package.xml
+++ b/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>awsim_sensor_kit_description</name>
-  <version>0.44.0</version>
+  <version>0.45.0</version>
   <description>The awsim_sensor_kit_description package</description>
   <maintainer email="piotr.jaroszek@robotec.ai">Piotr Jaroszek</maintainer>
   <license>Apache License 2.0</license>

--- a/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_launch/CHANGELOG.rst
+++ b/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_launch/CHANGELOG.rst
@@ -2,22 +2,27 @@
 Changelog for package awsim_sensor_kit_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.44.0 (2025-04-18)
+0.45.0 (2025-05-22)
 -------------------
+
+0.44.1 (2025-05-12)
+-------------------
+
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
 * feat: remove individual_params references (`#1403 <https://github.com/autowarefoundation/autoware_launch/issues/1403>`_)
 * chore(sensor_kit_launch): remove unused has_static_tf_only param (`#1393 <https://github.com/autowarefoundation/autoware_launch/issues/1393>`_)
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Amadeusz Szymko, Mete Fatih Cırıt
+* Contributors: Amadeusz Szymko, Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
 
-* feat: remove individual_params references (`#1403 <https://github.com/autowarefoundation/autoware_launch/issues/1403>`_)
-* chore(sensor_kit_launch): remove unused has_static_tf_only param (`#1393 <https://github.com/autowarefoundation/autoware_launch/issues/1393>`_)
+0.43.1 (2025-04-01)
+-------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Amadeusz Szymko, Mete Fatih Cırıt
-
-0.43.0 (2025-03-28)
--------------------
+* Contributors: Mete Fatih Cırıt
 
 0.42.0 (2025-03-28)
 -------------------

--- a/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_launch/package.xml
+++ b/sensor_kit/awsim_sensor_kit_launch/awsim_sensor_kit_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>awsim_sensor_kit_launch</name>
-  <version>0.44.0</version>
+  <version>0.45.0</version>
   <description>The awsim_sensor_kit_launch package</description>
   <maintainer email="piotr.jaroszek@robotec.ai">Piotr Jaroszek</maintainer>
   <license>Apache License 2.0</license>

--- a/sensor_kit/sample_sensor_kit_launch/common_sensor_launch/CHANGELOG.rst
+++ b/sensor_kit/sample_sensor_kit_launch/common_sensor_launch/CHANGELOG.rst
@@ -2,14 +2,28 @@
 Changelog for package common_sensor_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.44.0 (2025-04-18)
+0.45.0 (2025-05-22)
+-------------------
+* Merge remote-tracking branch 'origin/main' into tmp/bot/bump_version_base
+* feat(ring_outlier_filter): update node parameters (`#1421 <https://github.com/autowarefoundation/autoware_launch/issues/1421>`_)
+* Contributors: Kotaro Uetake, github-actions
+
+0.44.1 (2025-05-12)
+-------------------
+
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
+0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
 * Contributors: Mete Fatih Cırıt
-
-0.43.0 (2025-02-12)
--------------------
 
 0.41.0 (2025-02-12)
 -------------------

--- a/sensor_kit/sample_sensor_kit_launch/common_sensor_launch/config/ring_outlier_filter_node.param.yaml
+++ b/sensor_kit/sample_sensor_kit_launch/common_sensor_launch/config/ring_outlier_filter_node.param.yaml
@@ -1,8 +1,7 @@
 /**:
   ros__parameters:
     distance_ratio: 1.03
-    object_length_threshold: 0.1
-    num_points_threshold: 4
+    object_length_threshold: 0.05
     max_rings_num: 128
     max_points_num_per_ring: 4000
     publish_outlier_pointcloud: false

--- a/sensor_kit/sample_sensor_kit_launch/common_sensor_launch/package.xml
+++ b/sensor_kit/sample_sensor_kit_launch/common_sensor_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>common_sensor_launch</name>
-  <version>0.44.0</version>
+  <version>0.45.0</version>
   <description>The common_sensor_launch package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_description/CHANGELOG.rst
+++ b/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_description/CHANGELOG.rst
@@ -2,15 +2,26 @@
 Changelog for package sample_sensor_kit_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.44.0 (2025-04-18)
+0.45.0 (2025-05-22)
 -------------------
+
+0.44.1 (2025-05-12)
+-------------------
+
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
 * feat: remove individual_params references (`#1403 <https://github.com/autowarefoundation/autoware_launch/issues/1403>`_)
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
 
-0.43.0 (2025-02-12)
+0.43.1 (2025-04-01)
 -------------------
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt
 
 0.41.0 (2025-02-12)
 -------------------

--- a/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_description/package.xml
+++ b/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sample_sensor_kit_description</name>
-  <version>0.44.0</version>
+  <version>0.45.0</version>
   <description>The sample_sensor_kit_description package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/CHANGELOG.rst
+++ b/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/CHANGELOG.rst
@@ -2,16 +2,27 @@
 Changelog for package sample_sensor_kit_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.44.0 (2025-04-18)
+0.45.0 (2025-05-22)
 -------------------
+
+0.44.1 (2025-05-12)
+-------------------
+
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
 * feat: remove individual_params references (`#1403 <https://github.com/autowarefoundation/autoware_launch/issues/1403>`_)
 * chore(sensor_kit_launch): remove unused has_static_tf_only param (`#1393 <https://github.com/autowarefoundation/autoware_launch/issues/1393>`_)
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Amadeusz Szymko, Mete Fatih Cırıt
+* Contributors: Amadeusz Szymko, Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
 
-0.43.0 (2025-02-12)
+0.43.1 (2025-04-01)
 -------------------
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt
 
 0.41.0 (2025-02-12)
 -------------------

--- a/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/package.xml
+++ b/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sample_sensor_kit_launch</name>
-  <version>0.44.0</version>
+  <version>0.45.0</version>
   <description>The sample_sensor_kit_launch package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_common_launch/CHANGELOG.rst
+++ b/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_common_launch/CHANGELOG.rst
@@ -2,18 +2,28 @@
 Changelog for package single_lidar_common_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.44.0 (2025-04-18)
+0.45.0 (2025-05-22)
+-------------------
+* Merge remote-tracking branch 'origin/main' into tmp/bot/bump_version_base
+* feat(ring_outlier_filter): update node parameters (`#1421 <https://github.com/autowarefoundation/autoware_launch/issues/1421>`_)
+* Contributors: Kotaro Uetake, github-actions
+
+0.44.1 (2025-05-12)
+-------------------
+
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
+0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
 * Contributors: Mete Fatih Cırıt
-
-* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
-* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
-
-0.43.0 (2025-03-28)
--------------------
 
 0.42.0 (2025-03-28)
 -------------------

--- a/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_common_launch/config/ring_outlier_filter_node.param.yaml
+++ b/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_common_launch/config/ring_outlier_filter_node.param.yaml
@@ -1,8 +1,7 @@
 /**:
   ros__parameters:
     distance_ratio: 1.03
-    object_length_threshold: 0.1
-    num_points_threshold: 4
+    object_length_threshold: 0.05
     max_rings_num: 128
     max_points_num_per_ring: 4000
     publish_outlier_pointcloud: false

--- a/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_common_launch/package.xml
+++ b/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_common_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>single_lidar_common_launch</name>
-  <version>0.44.0</version>
+  <version>0.45.0</version>
   <description>The single_lidar_common_launch package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_sensor_kit_description/CHANGELOG.rst
+++ b/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_sensor_kit_description/CHANGELOG.rst
@@ -2,18 +2,25 @@
 Changelog for package single_lidar_sensor_kit_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.44.0 (2025-04-18)
+0.45.0 (2025-05-22)
+-------------------
+
+0.44.1 (2025-05-12)
+-------------------
+
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
+0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
 * Contributors: Mete Fatih Cırıt
-
-* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
-* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
-
-0.43.0 (2025-03-28)
--------------------
 
 0.42.0 (2025-03-28)
 -------------------

--- a/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_sensor_kit_description/package.xml
+++ b/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_sensor_kit_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>single_lidar_sensor_kit_description</name>
-  <version>0.44.0</version>
+  <version>0.45.0</version>
   <description>The single_lidar_sensor_kit_description package</description>
   <maintainer email="beginning.fan@autocore.ai">beginning.fan</maintainer>
   <license>Apache License 2.0</license>

--- a/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_sensor_kit_launch/CHANGELOG.rst
+++ b/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_sensor_kit_launch/CHANGELOG.rst
@@ -2,18 +2,25 @@
 Changelog for package single_lidar_sensor_kit_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.44.0 (2025-04-18)
+0.45.0 (2025-05-22)
+-------------------
+
+0.44.1 (2025-05-12)
+-------------------
+
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
+0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
 * Contributors: Mete Fatih Cırıt
-
-* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
-* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
-
-0.43.0 (2025-03-28)
--------------------
 
 0.42.0 (2025-03-28)
 -------------------

--- a/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_sensor_kit_launch/package.xml
+++ b/sensor_kit/single_lidar_sensor_kit_launch/single_lidar_sensor_kit_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>single_lidar_sensor_kit_launch</name>
-  <version>0.44.0</version>
+  <version>0.45.0</version>
   <description>The single_lidar_sensor_kit_launch package</description>
   <maintainer email="beginning.fan@autocore.ai">beginning.fan</maintainer>
   <license>Apache License 2.0</license>

--- a/vehicle/awsim_labs_vehicle_launch/awsim_labs_vehicle_description/CHANGELOG.rst
+++ b/vehicle/awsim_labs_vehicle_launch/awsim_labs_vehicle_description/CHANGELOG.rst
@@ -2,7 +2,21 @@
 Changelog for package awsim_labs_vehicle_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.44.0 (2025-04-18)
+0.45.0 (2025-05-22)
+-------------------
+
+0.44.1 (2025-05-12)
+-------------------
+
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
+0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
@@ -12,17 +26,20 @@ Changelog for package awsim_labs_vehicle_description
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
 * Contributors: Mete Fatih Cırıt
 
-* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
-* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
+0.43.0 (2025-03-24)
+-------------------
 
-* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
-* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
+0.42.0 (2025-03-21)
+-------------------
 
-* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
-* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
+0.41.0 (2025-02-07)
+-------------------
 
-0.43.0 (2025-03-22)
+0.40.0 (2025-01-09)
+-------------------
+
+0.39.0 (2024-11-26)
+-------------------
+
+0.38.0 (2024-11-14)
 -------------------

--- a/vehicle/awsim_labs_vehicle_launch/awsim_labs_vehicle_description/package.xml
+++ b/vehicle/awsim_labs_vehicle_launch/awsim_labs_vehicle_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>awsim_labs_vehicle_description</name>
-  <version>0.44.0</version>
+  <version>0.45.0</version>
   <description>The awsim_labs_vehicle_description package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/vehicle/awsim_labs_vehicle_launch/awsim_labs_vehicle_launch/CHANGELOG.rst
+++ b/vehicle/awsim_labs_vehicle_launch/awsim_labs_vehicle_launch/CHANGELOG.rst
@@ -2,7 +2,21 @@
 Changelog for package awsim_labs_vehicle_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.44.0 (2025-04-18)
+0.45.0 (2025-05-22)
+-------------------
+
+0.44.1 (2025-05-12)
+-------------------
+
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
+0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
@@ -12,17 +26,20 @@ Changelog for package awsim_labs_vehicle_launch
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
 * Contributors: Mete Fatih Cırıt
 
-* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
-* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
+0.43.0 (2025-03-24)
+-------------------
 
-* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
-* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
+0.42.0 (2025-03-21)
+-------------------
 
-* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
-* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
+0.41.0 (2025-02-07)
+-------------------
 
-0.43.0 (2025-03-22)
+0.40.0 (2025-01-09)
+-------------------
+
+0.39.0 (2024-11-26)
+-------------------
+
+0.38.0 (2024-11-14)
 -------------------

--- a/vehicle/awsim_labs_vehicle_launch/awsim_labs_vehicle_launch/package.xml
+++ b/vehicle/awsim_labs_vehicle_launch/awsim_labs_vehicle_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>awsim_labs_vehicle_launch</name>
-  <version>0.44.0</version>
+  <version>0.45.0</version>
   <description>The awsim_labs_vehicle_launch package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/vehicle/sample_vehicle_launch/sample_vehicle_description/CHANGELOG.rst
+++ b/vehicle/sample_vehicle_launch/sample_vehicle_description/CHANGELOG.rst
@@ -2,7 +2,21 @@
 Changelog for package sample_vehicle_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.44.0 (2025-04-18)
+0.45.0 (2025-05-22)
+-------------------
+
+0.44.1 (2025-05-12)
+-------------------
+
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
+0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
@@ -12,17 +26,20 @@ Changelog for package sample_vehicle_description
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
 * Contributors: Mete Fatih Cırıt
 
-* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
-* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
+0.43.0 (2025-03-24)
+-------------------
 
-* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
-* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
+0.42.0 (2025-03-21)
+-------------------
 
-* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
-* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
+0.41.0 (2025-02-07)
+-------------------
 
-0.43.0 (2025-03-22)
+0.40.0 (2025-01-09)
+-------------------
+
+0.39.0 (2024-11-26)
+-------------------
+
+0.38.0 (2024-11-14)
 -------------------

--- a/vehicle/sample_vehicle_launch/sample_vehicle_description/package.xml
+++ b/vehicle/sample_vehicle_launch/sample_vehicle_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sample_vehicle_description</name>
-  <version>0.44.0</version>
+  <version>0.45.0</version>
   <description>The sample_vehicle_description package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/vehicle/sample_vehicle_launch/sample_vehicle_launch/CHANGELOG.rst
+++ b/vehicle/sample_vehicle_launch/sample_vehicle_launch/CHANGELOG.rst
@@ -2,7 +2,21 @@
 Changelog for package sample_vehicle_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.44.0 (2025-04-18)
+0.45.0 (2025-05-22)
+-------------------
+
+0.44.1 (2025-05-12)
+-------------------
+
+0.44.0 (2025-05-01)
+-------------------
+* Merge commit 'bdbc8e8' into bump-up-version-to-0.44.0
+* chore: bump version to 0.44.0 (`#1411 <https://github.com/autowarefoundation/autoware_launch/issues/1411>`_)
+* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
+* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
+* Contributors: Mete Fatih Cırıt, Ryohsuke Mitsudome, Yutaka Kondo
+
+0.43.1 (2025-04-01)
 -------------------
 * chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
@@ -12,17 +26,20 @@ Changelog for package sample_vehicle_launch
 * feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
 * Contributors: Mete Fatih Cırıt
 
-* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
-* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
+0.43.0 (2025-03-24)
+-------------------
 
-* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
-* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
+0.42.0 (2025-03-21)
+-------------------
 
-* chore: set all versions to 0.43.0 (`#1384 <https://github.com/autowarefoundation/autoware_launch/issues/1384>`_)
-* feat(*_launch): move here (`#1369 <https://github.com/autowarefoundation/autoware_launch/issues/1369>`_)
-* Contributors: Mete Fatih Cırıt
+0.41.0 (2025-02-07)
+-------------------
 
-0.43.0 (2025-03-22)
+0.40.0 (2025-01-09)
+-------------------
+
+0.39.0 (2024-11-26)
+-------------------
+
+0.38.0 (2024-11-14)
 -------------------

--- a/vehicle/sample_vehicle_launch/sample_vehicle_launch/package.xml
+++ b/vehicle/sample_vehicle_launch/sample_vehicle_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>sample_vehicle_launch</name>
-  <version>0.44.0</version>
+  <version>0.45.0</version>
   <description>The sample_vehicle_launch package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>


### PR DESCRIPTION
## Description

This PR bumps the version to v0.45.0 in the humble branch which was already done in the main branch.
https://github.com/autowarefoundation/autoware_launch/pull/1453

Plus, since the description of v0.43.0 was missing in the CHANGELOG.rst, I've also added them.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
