### PR TITLE
Feat/pointcloud container

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -58,12 +58,6 @@
     </include>
   </group>
 
-  <!-- Pointcloud container -->
-  <include file="$(find-pkg-share autoware_launch)/launch/pointcloud_container.launch.py">
-    <arg name="use_multithread" value="true"/>
-    <arg name="container_name" value="$(var pointcloud_container_name)"/>
-  </include>
-
   <!-- Vehicle -->
   <group if="$(var launch_vehicle)">
     <include file="$(find-pkg-share tier4_vehicle_launch)/launch/vehicle.launch.xml">

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="launch_pointcloud_container" default="false" description="if true, launch pointcloud container"/>
+  <arg name="pointcloud_container_name" default="pointcloud_container" description="name of pointcloud container"/>
+
+  <!-- Pointcloud container -->
+  <group if="$(var launch_pointcloud_container)">
+    <include file="$(find-pkg-share autoware_launch)/launch/pointcloud_container.launch.py">
+      <arg name="use_multithread" value="true"/>
+      <arg name="container_name" value="$(var pointcloud_container_name)"/>
+    </include>
+  </group>
+
   <arg name="use_empty_dynamic_object_publisher" default="false" description="if true, /perception/object_recognition/objects topic has an empty DynamicObjectArray"/>
   <arg name="use_traffic_light_recognition" default="true" description="use traffic light recognition module, if false, traffic light recognition module will not be launched"/>
 

--- a/autoware_launch/launch/components/tier4_sensing_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_sensing_component.launch.xml
@@ -1,5 +1,22 @@
 <?xml version="1.0"?>
 <launch>
+  <!-- Launch parameters -->
+  <arg name="launch_pointcloud_container" default="true" description="if true, launch pointcloud container"/>
+  <arg name="pointcloud_container_name" default="pointcloud_container" description="name of pointcloud container"/>
+  <arg name="launch_sensing_driver" default="true"/>
+  <arg name="sensor_model" default="sample_sensor_kit"/>
+  <arg name="use_sim_time" default="false"/>
+  <arg name="vehicle_model" default="sample_vehicle"/>
+
+  <!-- Pointcloud container -->
+  <group if="$(var launch_pointcloud_container)">
+    <include file="$(find-pkg-share autoware_launch)/launch/pointcloud_container.launch.py">
+      <arg name="use_multithread" value="true"/>
+      <arg name="container_name" value="$(var pointcloud_container_name)"/>
+    </include>
+  </group>
+
+  <!-- Wait for container to be ready before launching sensing -->
   <include file="$(find-pkg-share tier4_sensing_launch)/launch/sensing.launch.xml">
     <arg name="launch_driver" value="$(var launch_sensing_driver)"/>
     <arg name="sensor_model" value="$(var sensor_model)"/>

--- a/autoware_launch/launch/components/tier4_sensing_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_sensing_component.launch.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <launch>
-  <!-- Launch parameters -->
   <arg name="launch_pointcloud_container" default="true" description="if true, launch pointcloud container"/>
   <arg name="pointcloud_container_name" default="pointcloud_container" description="name of pointcloud container"/>
   <arg name="launch_sensing_driver" default="true"/>
@@ -16,7 +15,6 @@
     </include>
   </group>
 
-  <!-- Wait for container to be ready before launching sensing -->
   <include file="$(find-pkg-share tier4_sensing_launch)/launch/sensing.launch.xml">
     <arg name="launch_driver" value="$(var launch_sensing_driver)"/>
     <arg name="sensor_model" value="$(var sensor_model)"/>


### PR DESCRIPTION
## Description

When attempting to launch `tier4_sensing.launch.xml` and `tier4_perception.launch.xml` separately in a multi-container setup, there's a problem where they cannot run as composite nodes due to the absence of the `pointcloud_container` that was originally present in `autoware.launch.xml`.
This PR addresses the issue by making each launch file create its own `pointcloud_container`, enabling standalone execution. Note that the behavior remains unchanged when launching using the default `autoware.launch.xml` file.

## How was this PR tested?

- https://github.com/youtalk/autoware/pull/211

## Notes for reviewers

None.

## Effects on system behavior

None.
