### PR TITLE
feat(out_of_lane): validate predicted paths on lanelets

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/out_of_lane.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/out_of_lane.param.yaml
@@ -16,6 +16,7 @@
         predicted_path_min_confidence : 0.1  # when using predicted paths, ignore the ones whose confidence is lower than this value.
         cut_predicted_paths_beyond_red_lights: true # if true, predicted paths are cut beyond the stop line of red traffic lights
         ignore_behind_ego: false # if true, objects behind the ego vehicle are ignored
+        validate_predicted_paths_on_lanelets: true  # if true, an out of lane collision is only considered if the predicted path fully follows a sequence of lanelets that include the out of lane lanelet
 
       action:  # action to insert in the trajectory if an object causes a conflict at an overlap
         use_map_stop_lines: true  # if true, try to stop at stop lines defined in the vector map


### PR DESCRIPTION
## Description

Add an option to the `out_of_lane` module to validate predicted paths before considering an out of lane collision.

Universe PR: https://github.com/autowarefoundation/autoware_universe/pull/10882

## How was this PR tested?

Psim and rosbag.

## Notes for reviewers

None.

## Effects on system behavior

Less false positives with the `out_of_lane`.
