### PR TITLE
feat(autoware_lidar_centerpoint): update score_threshold to score_thresholds for class-wise thresholds

### DIFF
--- a/autoware_launch/config/perception/object_recognition/detection/lidar_model/centerpoint.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/lidar_model/centerpoint.param.yaml
@@ -14,7 +14,8 @@
       iou_nms_search_distance_2d: 10.0
       iou_nms_threshold: 0.1
       yaw_norm_thresholds: [0.3, 0.3, 0.3, 0.3, 0.0]
-      score_threshold: 0.35
+      # CAR, TRUCK, BUS, BICYCLE, PEDESTRIAN
+      score_thresholds: [0.35, 0.35, 0.35, 0.35, 0.35]
     densification_params:
       world_frame_id: map
       num_past_frames: 1

--- a/autoware_launch/config/perception/object_recognition/detection/lidar_model/centerpoint_sigma.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/lidar_model/centerpoint_sigma.param.yaml
@@ -14,7 +14,8 @@
       iou_nms_search_distance_2d: 10.0
       iou_nms_threshold: 0.1
       yaw_norm_thresholds: [0.3, 0.3, 0.3, 0.3, 0.0]
-      score_threshold: 0.35
+      # CAR, TRUCK, BUS, BICYCLE, PEDESTRIAN
+      score_thresholds: [0.35, 0.35, 0.35, 0.35, 0.35]
     densification_params:
       world_frame_id: map
       num_past_frames: 1

--- a/autoware_launch/config/perception/object_recognition/detection/lidar_model/centerpoint_tiny.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/lidar_model/centerpoint_tiny.param.yaml
@@ -14,7 +14,8 @@
       iou_nms_search_distance_2d: 10.0
       iou_nms_threshold: 0.1
       yaw_norm_thresholds: [0.3, 0.3, 0.3, 0.3, 0.0]
-      score_threshold: 0.35
+      # CAR, TRUCK, BUS, BICYCLE, PEDESTRIAN
+      score_thresholds: [0.35, 0.35, 0.35, 0.35, 0.35]
     densification_params:
       world_frame_id: map
       num_past_frames: 1

--- a/autoware_launch/config/perception/object_recognition/detection/lidar_model/pointpainting.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/lidar_model/pointpainting.param.yaml
@@ -11,7 +11,8 @@
       circle_nms_dist_threshold: 0.3
       iou_nms_search_distance_2d: 10.0
       iou_nms_threshold: 0.1
-      score_threshold: 0.45
+      # CAR, TRUCK, BUS, BICYCLE, PEDESTRIAN
+      score_thresholds: [0.45, 0.45, 0.45, 0.45, 0.45]
       yaw_norm_thresholds: [0.3, 0.3, 0.3, 0.3, 0.0]
     densification_params:
       world_frame_id: "map"


### PR DESCRIPTION
## Description
Update the default launcher configs for CenterPoint and PointPainting to update `score_threshold` to `score_thresholds` to accept class-wise thresholds. 

## How was this PR tested?
Please check the [PR](https://github.com/autowarefoundation/autoware_universe/pull/10881).
 
## Notes for reviewers

None.

## Effects on system behavior

None.
