### PR TITLE
feat(run_out): add option for strict cutting of predicted paths

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/run_out.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/run_out.param.yaml
@@ -60,8 +60,11 @@
           cut_predicted_paths:  # options to cut predicted paths of dynamic objects
             if_crossing_ego_from_behind: true # if true, cut after crossing the ego vehicle
             polygon_types: ["NONE"]  # types of polygons in the vector map used to cut predicted paths
-            linestring_types: ["guard_rail"]  # types of linestrings in the vector map used to cut predicted paths
+            linestring_types: ["NONE"]  # types of linestrings in the vector map used to cut predicted paths
             lanelet_subtypes: ["NONE"]  # subtypes of lanelets in the vector map used to cut predicted paths
+            strict_polygon_types: ["NONE"]  # same as polygon_types but the cut is not subjected to the preserved duration/distance
+            strict_linestring_types: ["guard_rail"]  # same as linestring_types but the cut is not subjected to the preserved duration/distance
+            strict_lanelet_subtypes: ["NONE"]  # same as lanelet_subtypes but the cut is not subjected to the preserved duration/distance
           preserved_duration: 0.0  # [s] when cutting a predicted path or ignoring an object, at least this much duration is preserved from the predicted paths
           preserved_distance: 0.0 # [m] when cutting a predicted path or ignoring an object, at least this much distance is preserved from the predicted paths
           standstill_duration_after_cut: 2.0  # [s] after cutting a predicted path, assume the object stands still at the last point for this duration


### PR DESCRIPTION
## Description

Improve the predicted paths filtering used by the `run_out` module (`motion_velocity_planner`).
It is now possible to _strictly_ cut predicted paths based on map geometries (polygons, lanelets, or linestrings). This means that the cutting is always applied without considering the preserved distance or duration.

Required for the universe PR: https://github.com/autowarefoundation/autoware_universe/pull/10887

## How was this PR tested?

Psim

## Effects on system behavior

More control over the map based predicted paths filtering.
