### PR TITLE
fix(tier4_simulator_component): fix argument name in tier4_simulator_component.launch.xml

### DIFF
--- a/autoware_launch/launch/components/tier4_simulator_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_simulator_component.launch.xml
@@ -15,7 +15,7 @@
   <arg name="vehicle_info_param_file"/>
   <arg name="raw_vehicle_cmd_converter_param_path"/>
   <arg name="occupancy_grid_map_updater" default="binary_bayes_filter" description="options: binary_bayes_filter"/>
-  <arg name="use_point_cloud_container" default="true" description="use point cloud container for simulator perception modules"/>
+  <arg name="use_pointcloud_container" default="true" description="use point cloud container for simulator perception modules"/>
 
   <include file="$(find-pkg-share tier4_simulator_launch)/launch/simulator.launch.xml">
     <arg name="launch_dummy_perception" value="$(var launch_dummy_perception)"/>
@@ -32,7 +32,7 @@
     <arg name="initial_engage_state" value="$(var initial_engage_state)"/>
     <arg name="vehicle_info_param_file" value="$(var vehicle_info_param_file)"/>
     <arg name="raw_vehicle_cmd_converter_param_path" value="$(var raw_vehicle_cmd_converter_param_path)"/>
-    <arg name="use_point_cloud_container" value="$(var use_point_cloud_container)"/>
+    <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
 
     <arg name="fault_injection_param_path" value="$(find-pkg-share autoware_launch)/config/simulator/fault_injection.param.yaml"/>
     <arg


### PR DESCRIPTION
## Description

The `use_point_cloud_container` argument was added to the `tier4_simulator_component.launch.xml` to realize isolated component-wise launching. https://github.com/autowarefoundation/autoware_launch/pull/1479

However, the `tier4_simulator_launch/launch/simulator.launch.xml` in autoware_universe uses `use_pointcloud_container` that doesn't separate "point" and "cloud".
https://github.com/autowarefoundation/autoware_universe/blob/60075cdf11ddb43a4b6c0bfa9c8f59ffb4e6ba19/launch/tier4_simulator_launch/launch/simulator.launch.xml#L27

This PR fixes the `tier4_simulator_component.launch.xml` to make them the same.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
