### PR TITLE
fix:  `pointcloud_contaner` is launched on `autoware.launch.xml` by default (#1523)

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -58,6 +58,12 @@
     </include>
   </group>
 
+  <!-- Pointcloud container -->
+  <include file="$(find-pkg-share autoware_launch)/launch/pointcloud_container.launch.py">
+    <arg name="use_multithread" value="true"/>
+    <arg name="container_name" value="$(var pointcloud_container_name)"/>
+  </include>
+
   <!-- Vehicle -->
   <group if="$(var launch_vehicle)">
     <include file="$(find-pkg-share tier4_vehicle_launch)/launch/vehicle.launch.xml">

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -3,7 +3,7 @@
   <arg
     name="launch_pointcloud_container"
     default="false"
-    description="if true, launch pointcloud container. Please note that it is not intended to launch pointcloud_container_name with the same name in both tier4_sensing_component.launch.xml and tier4_perception_component.launch.xml."
+    description="if true, launch pointcloud container. Please note that it is not intended to launch pointcloud_container_name with the same name in other launch files."
   />
   <arg name="pointcloud_container_name" default="pointcloud_container" description="name of pointcloud container"/>
   <arg name="use_sim_time" default="false"/>

--- a/autoware_launch/launch/components/tier4_sensing_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_sensing_component.launch.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="launch_pointcloud_container" default="true" description="if true, launch pointcloud container"/>
-  <arg name="pointcloud_container_name" default="pointcloud_container" description="name of pointcloud container"/>
+  <arg
+    name="launch_pointcloud_container"
+    default="false"
+    description="if true, launch pointcloud container. Please note that it is not intended to launch pointcloud_container_name with the same name in other launch files."
+  />
+  <arg name="pointcloud_container_name" description="name of pointcloud container"/>
   <arg name="launch_sensing_driver" default="true"/>
   <arg name="sensor_model" default="sample_sensor_kit"/>
   <arg name="use_sim_time" default="false"/>


### PR DESCRIPTION
## Description
This is a backport of https://github.com/autowarefoundation/autoware_launch/pull/1523 to humble branch. 

## How was this PR tested?
I have tested locally that the issue with PSim is fixed on humble branch.

## Notes for reviewers

None.

## Effects on system behavior

None.
