### PR TITLE
feat: add global parameters to tier4_localization_component.launch.xml

### DIFF
--- a/autoware_launch/launch/components/tier4_localization_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_localization_component.launch.xml
@@ -7,6 +7,17 @@
   <arg name="localization_pointcloud_container_name" default="/pointcloud_container" description="The target container to which pointcloud preprocessing nodes in localization be attached"/>
   <arg name="initial_pose" default="[]" description="initial pose (x, y, z, quat_x, quat_y, quat_z, quat_w)"/>
 
+  <arg name="use_sim_time" default="false"/>
+  <arg name="vehicle_model" default="sample_vehicle"/>
+
+  <!-- Global parameters -->
+  <group scoped="false">
+    <include file="$(find-pkg-share autoware_global_parameter_loader)/launch/global_params.launch.py">
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
+      <arg name="vehicle_model" value="$(var vehicle_model)"/>
+    </include>
+  </group>
+
   <group>
     <include file="$(find-pkg-share tier4_localization_launch)/launch/localization.launch.xml">
       <arg name="pose_source" value="$(var pose_source)"/>


### PR DESCRIPTION
## Description
This is a follow up PR from https://github.com/autowarefoundation/autoware_launch/pull/1469.
This adds global parameter loader to localization component launch file so that localization component can be launched independently. 

## How was this PR tested?
I have tested that it does not affect the overall behavior of autoware.launch.xml with logging simulator.

## Notes for reviewers

None.

## Effects on system behavior

None.
