### PR TITLE
feat: add launch_pointcloud_container to tier4_localization_component.launch.xml

### DIFF
--- a/autoware_launch/launch/components/tier4_localization_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_localization_component.launch.xml
@@ -6,6 +6,19 @@
   <arg name="input_pointcloud" default="/sensing/lidar/concatenated/pointcloud" description="The topic will be used in the localization util module"/>
   <arg name="localization_pointcloud_container_name" default="/pointcloud_container" description="The target container to which pointcloud preprocessing nodes in localization be attached"/>
   <arg name="initial_pose" default="[]" description="initial pose (x, y, z, quat_x, quat_y, quat_z, quat_w)"/>
+  <arg
+    name="launch_pointcloud_container"
+    default="false"
+    description="if true, launch pointcloud container. Please note that it is not intended to launch pointcloud_container_name with the same name in other launch files."
+  />
+
+  <!-- Pointcloud container -->
+  <group if="$(var launch_pointcloud_container)">
+    <include file="$(find-pkg-share autoware_launch)/launch/pointcloud_container.launch.py">
+      <arg name="use_multithread" value="true"/>
+      <arg name="container_name" value="$(var localization_pointcloud_container_name)"/>
+    </include>
+  </group>
 
   <group>
     <include file="$(find-pkg-share tier4_localization_launch)/launch/localization.launch.xml">


### PR DESCRIPTION
## Description

This is follow up PR for https://github.com/autowarefoundation/autoware_launch/pull/1513. This also adds pointcloud container arguments for localization launch in order to launch localization component in independent container if user wish to do so. By default, it won't launch the pointcloud container and use the one from the top autoware.launch.xml.

## How was this PR tested?
I have tested locally that it does not affect the current behavior of autoware with logging simulator.

## Notes for reviewers

None.

## Effects on system behavior

None.
