### PR TITLE
feat(intersection_collision_checker): add velocity estimation parameters

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/common/planning_validator/intersection_collision_checker.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/common/planning_validator/intersection_collision_checker.param.yaml
@@ -32,8 +32,10 @@
           min_size: 10
           max_size: 10000
         velocity_estimation:
-          max_acceleration: 20.0  # [m/s^2]
+          max_acceleration: 10.0  # [m/s^2]
+          max_velocity: 20.0  # [m/s]
           observation_time: 0.3  # [s]
+          reset_accel_th: 30.0  # [m/s^2]
         latency: 0.3
 
       filter:


### PR DESCRIPTION
## Description

Add velocity estimation parameters `max_velocity` and `reset_accel_th`, required by following PR:
https://github.com/autowarefoundation/autoware_universe/pull/10928

## How was this PR tested?
- PSIM
## Notes for reviewers

None.

## Effects on system behavior

None.
