### PR TITLE
fix(obstacle_stop): fix for failing scenario

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_stop.param.yaml
@@ -10,7 +10,7 @@
         terminal_stop_margin : 3.0 # Stop margin at the goal. This value cannot exceed stop margin. [m]
         min_behavior_stop_margin: 3.0 # [m]
 
-        max_negative_velocity: -0.1 # [m/s] maximum velocity of opposing traffic to consider stop planning
+        max_negative_velocity: -1.0 # [m/s] maximum velocity of opposing traffic to consider stop planning
         stop_margin_opposing_traffic: 10.0 # Ideal stop-margin from moving opposing obstacle when ego comes to a stop
         effective_deceleration_opposing_traffic: 4.0 # Setting a higher value brings the final stop-margin closer to the ideal value above
 


### PR DESCRIPTION
## Description
Changes to the obstacle-stop param for the minimum velocity parameter below which the opposing vehicle handling is trigerred.

This change was made to address an issue with a failing scenario where due to a bug with prediction, an obstacle ahead that slowly comes to a stop is predicted to eventually move in reverse, causing the stop-point to drastically shift backward. 

Ticket: https://tier4.atlassian.net/browse/RT1-10538
## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
