### PR TITLE
feat(tracking): add lidar_centerpoint_short_range configuration for multi-object tracker

### DIFF
--- a/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
@@ -36,7 +36,7 @@
           can_trust_classification: true
           can_trust_orientation: true
         optional:
-          name: "centerpoint_shortrange"
+          name: "centerpoint_short_range"
           short_name: "LcpS"
       lidar_apollo:
         flags:


### PR DESCRIPTION
## Description

Add centerpoint short range channel to the multi object tracker configuration.

This option is to be used for short range detection to be enabled in multi-channel mode.

Please see https://github.com/autowarefoundation/autoware_universe/pull/10956

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
