### PR TITLE
feat(mission_planner): add param to prioritize bus stop lanelet as start lanelet

### DIFF
--- a/autoware_launch/config/planning/mission_planning/mission_planner/mission_planner.param.yaml
+++ b/autoware_launch/config/planning/mission_planning/mission_planner/mission_planner.param.yaml
@@ -12,4 +12,3 @@
     check_footprint_inside_lanes: true
     allow_reroute_in_autonomous_mode: true
     prioritize_bus_stop_as_start_lane: false # If the start pose overlaps with multiple lanelets, prioritize the one tagged as "bus_stop"
-


### PR DESCRIPTION
## Description

Parent Issue: https://github.com/autowarefoundation/autoware_universe/issues/10963

This PR adds parameter to be able to prioritize bus stop lanelet as start lanelet in case the start pose overlaps with multiple lanelets.

## How was this PR tested?

With any map that has overlapping lanelets which one of them tagged as `bus_stop`

## Notes for reviewers

:exclamation: to test :arrow_right:  `prioritize_bus_stop_as_start_lane`: `true`

## Effects on system behavior

None.
