### PR TITLE
feat(start_planner_module): add param to prevent departure if the previous traffic light (v2i) is green in high speed roads

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -144,6 +144,8 @@
         safety_check_params:
           # safety check configuration
           enable_safety_check: true
+          prev_light_check_distance: 0.0 # [m] Prevent departure if the previous traffic light (v2i) is green in high speed roads. Set to 0 to disable this feature
+          threshold_speed_for_prev_light_check: 50.0 # [kph] Threshold to determine if the ego vehicle is about to pull out onto a high-speed road
           # collision check parameters
           publish_debug_marker: false
           rss_params:


### PR DESCRIPTION
## Description

This PR adds parameter to prevent departure if the previous traffic light (v2i) is green in high speed roads

Parent Issue: https://github.com/autowarefoundation/autoware_universe/issues/10963

Related Issue: https://github.com/autowarefoundation/autoware_universe/pull/10978

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
