### PR TITLE
fix(autoware_launch): update trajectory relay to use parameters inste…

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -120,8 +120,8 @@
     <!-- This is a temporary addition for migration purposes. -->
     <!-- https://github.com/orgs/autowarefoundation/discussions/5033#discussioncomment-13704802 -->
     <node pkg="topic_tools" exec="relay" name="trajectory_relay">
-      <remap from="input" to="/planning/scenario_planning/trajectory"/>
-      <remap from="output" to="/planning/trajectory"/>
+      <param name="input_topic" value="/planning/scenario_planning/trajectory"/>
+      <param name="output_topic" value="/planning/trajectory"/>
     </node>
   </group>
 


### PR DESCRIPTION
There was a bug in https://github.com/autowarefoundation/autoware_launch/pull/1543.
I replaced the remap with param and confirmed that it works.

<img width="1184" height="597" alt="image" src="https://github.com/user-attachments/assets/5d1ca8a6-aa36-4006-a1da-026ff735a60b" />


## Description

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
