### PR TITLE
fix(tier4_planning_component): missing argument in planning component launch file

### DIFF
--- a/autoware_launch/launch/components/tier4_planning_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_planning_component.launch.xml
@@ -6,6 +6,7 @@
   <arg name="is_simulation" default="false"/>
   <arg name="use_sim_time" default="false"/>
   <arg name="vehicle_model" default="sample_vehicle"/>
+  <arg name="pointcloud_container_name" default="pointcloud_container"/>
 
   <!-- Global parameters -->
   <group scoped="false">


### PR DESCRIPTION
## Description

This PR fixes an issue where the planning module cannot be launched using tier4_planning_component.launch.xml unless the pointcloud_container_name argument is explicitly provided.

## How was this PR tested?

```
ros2 launch autoware_launch tier4_planning_component.launch.xml \
    vehicle_model:=sample_vehicle
```

## Error message

```
[INFO] [launch]: All log files can be found below /home/yuqi/.ros/log/2025-07-16-13-20-08-390711-80a957c661af-129103
[INFO] [launch]: Default logging verbosity is set to INFO
[ERROR] [launch]: Caught exception in launch (see debug for traceback): launch configuration 'pointcloud_container_name' does not exist
```

## Notes for reviewers

The tier4_planning_component.launch.xml file is typically used by autoware.launch.xml, which defines the pointcloud_container_name argument. However, when launching the planning module standalone (as shown above), the user must supply this argument manually, since no default value is set.

This can be confusing for users who expect the planning module to work out of the box. To address this, this PR introduces a default value for pointcloud_container_name, improving usability and consistency.

## Effects on system behavior

None. This change simply sets a default launch argument and does not modify runtime behavior.