### PR TITLE
fix(diagnostics): remove edits from AWSIM diagnostic file

### DIFF
--- a/autoware_launch/config/system/diagnostics/autoware-awsim.yaml
+++ b/autoware_launch/config/system/diagnostics/autoware-awsim.yaml
@@ -1,5 +1,2 @@
 files:
   - { path: $(dirname)/autoware-main.yaml }
-
-edits:
-  - { type: remove, path: /autoware/system/duplicated_node_checker }


### PR DESCRIPTION
## Description

The `autoware_diagnostic_graph_aggregator` crashes when running with the `e2e_simulator.launch.xml`, preventing engaging the autonomous mode when using AWSIM.

The format of the `autoware-awsim.yaml` seems to cause the crash and removing the `edits` fixes the issue.

## How was this PR tested?

AWSIM Labs

## Notes for reviewers

None.

## Effects on system behavior

None.
