### PR TITLE
feat(boundary_departure): configurable departure points and type based on time

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/boundary_departure_prevention.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/boundary_departure_prevention.param.yaml
@@ -14,8 +14,8 @@
         near_boundary: 3.5
         departure: 2.0
 
-      on_time_buffer_s: 0.08
-      off_time_buffer_s: 0.08
+      on_time_buffer_s: 0.15
+      off_time_buffer_s: 0.15
 
       abnormality:
         normal:

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/boundary_departure_prevention.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/boundary_departure_prevention.param.yaml
@@ -9,6 +9,14 @@
         angle_deg: 5.0
         goal_dist_m: 1.0
 
+      th_cutoff_time_s:
+        predicted_path: 4.0
+        near_boundary: 3.5
+        departure: 2.0
+
+      on_time_buffer_s: 0.08
+      off_time_buffer_s: 0.08
+
       abnormality:
         normal:
           enable: true

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/boundary_departure_prevention.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/boundary_departure_prevention.param.yaml
@@ -10,7 +10,7 @@
         goal_dist_m: 1.0
 
       th_cutoff_time_s:
-        predicted_path: 4.0
+        predicted_path: 3.5
         near_boundary: 3.5
         departure: 2.0
 


### PR DESCRIPTION
## Description

Currently ego's predicted path is used as is, and all departure points and critical departure points are accepted as is. This has caused a lot of false positive to occur especially when path chatters.

This PR provides two configurable option:

1. Trim ego points and update departure type based on cutoff time.
2. add hysteresis (on_time_buffer and off_time_buffer) as countermeasure to chattering predicted path.

Related PR: https://github.com/autowarefoundation/autoware_universe/pull/11073

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
