### PR TITLE
feat(boundary_departure): rename parameter

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/boundary_departure_prevention.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/boundary_departure_prevention.param.yaml
@@ -3,7 +3,7 @@
     boundary_departure_prevention:
       boundary_types_to_detect: [road_border]
       th_max_lateral_query_num: 5
-      th_dist_hysteresis_m: 1.0
+      th_point_merge_distance_m: 1.0
       th_pt_shift:
         dist_m: 0.2
         angle_deg: 5.0


### PR DESCRIPTION
## Description

The PR aims to fix issues with merging closeby departure points and departure intervals.

### Merging closeby departure points

#### Before

Close-by points scatter

<img width="909" height="183" alt="unmerged" src="https://github.com/user-attachments/assets/133a3826-05c8-43cb-912b-97e38112bb8c" />

https://github.com/user-attachments/assets/eb5fce33-ac1d-4a65-bf82-fbfc03310b0d

#### After

Merging nearby points

<img width="1044" height="279" alt="merge_distance drawio" src="https://github.com/user-attachments/assets/fd76b8c1-2afa-4b63-a3ad-2dd2bc2a9503" />

Result

<img width="909" height="93" alt="merged" src="https://github.com/user-attachments/assets/9d54a761-9ae5-48fb-ac19-27bd7bcb49c0" />

https://github.com/user-attachments/assets/e6b4d752-497a-4cf5-b138-a7377c50362d

### Merging closeby departure interval

Departure points is grouped together

<img width="1392" height="342" alt="lane_departure_prevention_use_cases-Page-8" src="https://github.com/user-attachments/assets/81b86a11-4533-47a7-8790-12419618616d" />

Example

<img width="2340" height="300" alt="merging1" src="https://github.com/user-attachments/assets/79df54af-7634-42be-9f47-1d7d8a1b3689" />

<img width="2220" height="303" alt="merging2" src="https://github.com/user-attachments/assets/e8ec3e0c-c8c5-4166-92bb-e05086634160" />

<img width="2250" height="303" alt="merging3" src="https://github.com/user-attachments/assets/dc1d45eb-997a-4234-ad9c-9b6a1941ddd3" />

But if the point is inline, it is not merged. So this PR aims to fix this as well

<img width="675" height="375" alt="not merged to fix" src="https://github.com/user-attachments/assets/b1c1a6d3-1c71-4969-907d-89e312064a8d" />

From 

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
