### PR TITLE
fix(multi_object_tracker): remove confident_count_threshold parameter

### DIFF
--- a/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/multi_object_tracker_node.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/multi_object_tracker_node.param.yaml
@@ -22,15 +22,6 @@
     tracker_lifetime: 1.0  # [s]
     min_known_object_removal_iou: 0.1  # [ratio]
     min_unknown_object_removal_iou: 0.001  # [ratio]
-    confident_count_threshold:
-      UNKNOWN: 3
-      CAR: 3
-      TRUCK: 3
-      BUS: 3
-      TRAILER: 3
-      MOTORBIKE: 3
-      BICYCLE: 3
-      PEDESTRIAN: 3
 
     # pruning parameters
     # list of generalized IoU thresholds for each class


### PR DESCRIPTION
## Description

tracker configuration `confident_count_threshold` has been deprecated by https://github.com/autowarefoundation/autoware.universe/issues/10378

remove unused parameter
https://github.com/autowarefoundation/autoware_universe/pull/11132

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
