### PR TITLE
fix(simulator): fix pose_instability_detector_param_path path

### DIFF
--- a/autoware_launch/launch/components/tier4_simulator_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_simulator_component.launch.xml
@@ -58,6 +58,7 @@
     <arg name="localization_error_monitor_param_path" value="$(find-pkg-share autoware_launch)/config/localization/localization_error_monitor.param.yaml"/>
     <arg name="ekf_localizer_param_path" value="$(find-pkg-share autoware_launch)/config/localization/ekf_localizer.param.yaml"/>
     <arg name="stop_filter_param_path" value="$(find-pkg-share autoware_launch)/config/localization/stop_filter.param.yaml"/>
+    <arg name="pose_instability_detector_param_path" value="$(find-pkg-share autoware_launch)/config/localization/pose_instability_detector.param.yaml"/>
     <arg name="pose_initializer_param_path" value="$(find-pkg-share autoware_launch)/config/localization/pose_initializer.param.yaml"/>
     <arg name="twist2accel_param_path" value="$(find-pkg-share autoware_launch)/config/localization/twist2accel.param.yaml"/>
     <arg name="laserscan_based_occupancy_grid_map_param_path" value="$(find-pkg-share autoware_launch)/config/perception/occupancy_grid_map/laserscan_based_occupancy_grid_map.param.yaml"/>


### PR DESCRIPTION
## Description

currently psim with localization can not run.
due to https://github.com/autowarefoundation/autoware_universe/pull/10961 , autoware_launch pose_instability_detector_param_path is necessary to be used.


## How was this PR tested?

run psim with 
```
  <arg
    name="localization_sim_mode"
    default="pose_twist_estimator"
    description="Select localization mode. Options are 'none', 'api' or 'pose_twist_estimator'. 'pose_twist_estimator' starts most of the localization modules except for the ndt_scan_matcher. 'api' starts an external API for initial position estimation. 'none' does not start any localization-related process."
  />
```

- [[PR check][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/023f822e-fe69-5324-83c1-f76a3b9d6b7b?project_id=prd_jt)
- [[PR check][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/64a4a3ba-e602-540d-97c2-9cd5b396efcf?project_id=prd_jt)
- [[PR check][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/fda7fa6e-5b66-5b10-9c23-b4b292315b13?project_id=prd_jt)


## Notes for reviewers

None.

## Effects on system behavior

None.
