### PR TITLE
fix(boundary_departure): critical departure not cleared

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/boundary_departure_prevention.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/boundary_departure_prevention.param.yaml
@@ -17,7 +17,9 @@
       on_time_buffer_s:
         near_boundary: 0.15
         critical_departure: 0.15
-      off_time_buffer_s: 0.15
+      off_time_buffer_s:
+        near_boundary: 0.15
+        critical_departure: 0.15
 
       abnormality:
         normal:


### PR DESCRIPTION
## Description

Adding off time buffer to clear critical departure points.

Before:

Critical departure points persist despite critical departure no longer detected.

https://github.com/user-attachments/assets/cdfd19df-2a98-4290-91c6-16f6c5cc4f7a

After:

Critical departure points cleared once critical departure no longer detected.

https://github.com/user-attachments/assets/26afe413-225b-4bbf-add4-1f9519c3df1e

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
