### PR TITLE
feat(autoware_launch): change short-circuit of diag setting

### DIFF
--- a/autoware_launch/config/system/diagnostics/localization.yaml
+++ b/autoware_launch/config/system/diagnostics/localization.yaml
@@ -1,6 +1,6 @@
 units:
   - path: /autoware/localization
-    type: short-circuit-and
+    type: and
     list:
       - type: link
         link: /autoware/localization/state

--- a/autoware_launch/config/system/diagnostics/planning.yaml
+++ b/autoware_launch/config/system/diagnostics/planning.yaml
@@ -1,6 +1,6 @@
 units:
   - path: /autoware/planning
-    type: short-circuit-and
+    type: and
     list:
       - type: link
         link: /autoware/planning/routing/state


### PR DESCRIPTION
## Description

The short-circuit-and type is deprecated, so use and type instead.
Dependencies will be defined using the dependent field.

## How was this PR tested?

Check autonomous driving in planning simulator.

## Notes for reviewers

None.

## Effects on system behavior

None.
