### PR TITLE
feat(behavior_path_planner): lane change overwrite parameter update

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -146,6 +146,11 @@
         unsafe_hysteresis_threshold: 5      # [/]
         deceleration_sampling_num: 5 # [/]
 
+      # L2 overwrite unsafe options
+      l2_overwrite:
+        enable: false
+        rewrite_overshoot_threshold: 5.0  # [m]
+
       lane_change_finish_judge_buffer: 2.0      # [m]
       finish_judge_lateral_threshold: 0.1        # [m]
       finish_judge_lateral_angle_deviation: 1.0 # [deg]


### PR DESCRIPTION
## Description

This is an update following BPP LC overwrite mechanism update. Make sure that lane change will end correctly after we manually drive over it.

https://github.com/autowarefoundation/autoware_universe/pull/11248

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
