### PR TITLE
fix(boundary_departure): reduce brake delay

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/boundary_departure_prevention.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/boundary_departure_prevention.param.yaml
@@ -77,7 +77,7 @@
         #  0: OK (Default)
         #  1: WARN
         #  2: ERROR
-        near_boundary: 1
+        near_boundary: 0
         approaching_departure: 1
         critical_departure: 2
 
@@ -97,7 +97,7 @@
           th_jerk_mps3:
             min: -1.0
             max: -1.5
-          brake_delay_s: 1.3
+          brake_delay_s: 0.3
           dist_error_m: 1.0
           th_dist_to_boundary_m:
             left:


### PR DESCRIPTION
## Description

The PR modified 2 items:

- reduce logging level for near boundary, as to prevent the module from printing redundant log when the vehicle is operated at narrow areas.
- reduce brake_delay_s to relax the stopping criteria.

## How was this PR tested?

[TIER IV Internal Link - ControlDLR Test](https://evaluation.tier4.jp/evaluation/reports/27dc7420-c207-5501-b089-55fc274a9cab?project_id=prd_jt)
[TIER IV Internal Link - FuncVerification Test](https://evaluation.tier4.jp/evaluation/reports/5d695f8b-ca16-5676-b2f4-5a4e5fb01d02?project_id=prd_jt)
[TIER IV Internal Link - CommonScenario_Basic Test](https://evaluation.tier4.jp/evaluation/reports/0476e862-f28f-5306-b41c-090d79994610?project_id=prd_jt)

## Notes for reviewers

None.

## Effects on system behavior

None.
