### PR TITLE
fix(hdd_monitor,cpu_monitor): use unix sockets for IPC with helper applications

### DIFF
--- a/autoware_launch/config/system/system_monitor/cpu_monitor.param.yaml
+++ b/autoware_launch/config/system/system_monitor/cpu_monitor.param.yaml
@@ -5,4 +5,4 @@
     usage_warn_count: 1
     usage_error_count: 2
     usage_avg: true
-    msr_reader_socket_path: /tmp/msr_reader.sock
+    msr_reader_socket_path: "/tmp/msr_reader.sock"

--- a/autoware_launch/config/system/system_monitor/cpu_monitor.param.yaml
+++ b/autoware_launch/config/system/system_monitor/cpu_monitor.param.yaml
@@ -5,4 +5,4 @@
     usage_warn_count: 1
     usage_error_count: 2
     usage_avg: true
-    msr_reader_port: 7634
+    msr_reader_socket_path: /tmp/msr_reader.sock

--- a/autoware_launch/config/system/system_monitor/hdd_monitor.param.yaml
+++ b/autoware_launch/config/system/system_monitor/hdd_monitor.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    hdd_reader_port: 7635
+    hdd_reader_socket_path: /tmp/hdd_reader.sock
     num_disks: 1
     disks: # Until multi type lists are allowed, name N the disks as disk0...disk{N-1}
       disk0:

--- a/autoware_launch/config/system/system_monitor/hdd_monitor.param.yaml
+++ b/autoware_launch/config/system/system_monitor/hdd_monitor.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    hdd_reader_socket_path: /tmp/hdd_reader.sock
+    hdd_reader_socket_path: "/tmp/hdd_reader.sock"
     num_disks: 1
     disks: # Until multi type lists are allowed, name N the disks as disk0...disk{N-1}
       disk0:


### PR DESCRIPTION
## Description
Use AF_UNIX domain sockets for IPC between the "autoware_system_monitor" component (hdd_monitor, cpu_monitor) and its helper applications (hdd_reader, msr_reader) instead of TCP/IP sockets to avoid cross-talking among multiple ECUs.

This Pull Request is related to [PR #11199 for autwarefoundation/autoware_universe](https://github.com/autowarefoundation/autoware_universe/pull/11199).

## How was this PR tested?
- The "autoware_system_monitor" component built with [PR #11199 for autwarefoundation/autoware_universe](https://github.com/autowarefoundation/autoware_universe/pull/11199) reads values from the yaml files and changes the parameters accordingly.
- The "autoware_system_monitor" and its helper applications (hdd_reader, msr_reader) can communicate through the AF_UNIX domain sockets.

## Notes for reviewers

- Version mismatch between the autoware_universe binaries and the autoware_launch yaml files won't trigger any problem because the port numbers (for old versions) and the socket names (for new versions) are the defaults.
  - Even if the versions don't match, the values in the yaml files are ignored and the default values in the binaries are used.

## Effects on system behavior

None.
