### PR TITLE
feat(bpp, lane_change): enable prepare phase check even when ego is preparing

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -52,6 +52,15 @@
         allow_loose_check_for_cancel: true
         enable_target_lane_bound_check: true
         stopped_object_velocity_threshold: 1.0 # [m/s]
+        prepare:                                        # RSS parameters used during the prepare phase, regardless of whether the ego is searching for a safe path, canceling, or transitioning to another state.
+          expected_front_deceleration: -1.0             # [m/s2]
+          expected_rear_deceleration: -1.0              # [m/s2]
+          rear_vehicle_reaction_time: 1.0               # [s]
+          rear_vehicle_safety_time_margin: 0.8          # [s]
+          lateral_distance_max_threshold: 0.5           # [m]
+          longitudinal_distance_min_threshold: 1.0      # [m]
+          longitudinal_velocity_delta_time: 0.0         # [s]
+          extended_polygon_policy: "along-path"         # [-] available options are `rectangle` or `along-path`
         execution:
           expected_front_deceleration: -1.0
           expected_rear_deceleration: -1.0
@@ -113,10 +122,6 @@
 
       # collision check
       collision_check:
-        enable_for_prepare_phase:
-          general_lanes: false
-          intersection: true
-          turns: true
         prediction_time_resolution: 0.5
         th_incoming_object_yaw: 2.3562 # [rad]
         yaw_diff_threshold: 3.1416 # [rad]


### PR DESCRIPTION
## Description

1. Currently, the safety check is disabled during the prepare phase, except in cases such as when the ego is in turn-direction lanes or intersections. When disabled, the first few seconds of safety checks are skipped.
   - This is usually not an issue if both vehicles are moving. However, if the ego is stopped while the target vehicle is moving, the skipped safety checks can create a potential near-miss situation, since the initial seconds are incorrectly considered “safe.”
   - This PR fixes the issue by enabling the safety check during the prepare phase.

3. Previously, the prepare phase reused the same RSS parameters as the lane change phase. This made lane changes difficult to execute, as the extended ego polygon (both laterally and longitudinally) frequently overlapped during preparation.
   - In this PR, the RSS parameters for the prepare phase are explicitly defined, allowing parameter tuning and correct calculation of the lateral gap.

Related PR: https://github.com/autowarefoundation/autoware_universe/pull/11307

## How was this PR tested?

### 1. Logging simulator

### Before PR

Notice that the target vehicle with **green** bounding box is considered safe, even when ego is close by. 

<img width="533" height="242" alt="screenshot-20250902-073549Z" src="https://github.com/user-attachments/assets/8e60cc7e-ce30-4e8a-a52f-de90e1adddec" />

https://github.com/user-attachments/assets/bb2223ef-d8fc-4e63-b53f-1243c176fb8c

### After PR 

Object remains unsafe 

<img width="849" height="519" alt="image" src="https://github.com/user-attachments/assets/a02e6470-a02a-46d0-bd0d-e4f0154f0f42" />


https://github.com/user-attachments/assets/288a901e-6179-4d8b-8a7a-43231f408a03

### 2. Internal evaluator

TBA

## Notes for reviewers

None.

## Effects on system behavior

None.

## Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Removed | `enable_for_prepare_phase.general_lanes`   | `bool` | `false`         | Param description |
| Removed | `enable_for_prepare_phase.intersection`   | `bool` | `true`         | Param description |
| Removed | `enable_for_prepare_phase.turns`   | `bool` | `true`         | Param description |


| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `safety_check.prepare.expected_front_deceleration`   | `double` | `-1.0`         | The front object's maximum deceleration when the front vehicle perform sudden braking. |
| Added | `safety_check.prepare.expected_rear_deceleration`   | `double` | `-1.0`         | The rear object's maximum deceleration when the rear vehicle perform sudden braking. |
| Added | `safety_check.prepare.rear_vehicle_reaction_time`   | `double` | `1.0`         | The reaction time of the rear vehicle driver which starts from the driver noticing the sudden braking of the front vehicle until the driver step on the brake. |
| Added | `safety_check.prepare.rear_vehicle_safety_time_margin`   | `double` | `0.8`         | The time buffer for the rear vehicle to come into complete stop when its driver perform sudden braking. |
| Added | `safety_check.prepare.lateral_distance_max_threshold`   | `double` | `0.5`         | The lateral distance threshold that is used to determine whether lateral distance between two object is enough and whether lane change is safe. |
| Added | `safety_check.prepare.longitudinal_distance_min_threshold`   | `double` | `1.0`         | The longitudinal distance threshold that is used to determine whether longitudinal distance between two object is enough and whether lane change is safe. |
| Added | `safety_check.prepare.longitudinal_velocity_delta_time`   | `double` | `0.0`         | The time multiplier that is used to compute the actual gap between vehicle at each predicted points (not RSS distance) |
| Added | `safety_check.prepare.extended_polygon_policy`   | `string` | `along-path`         | Policy used to determine the polygon shape for the safety check. Available options are: `rectangle` or `along-path`. |
