### PR TITLE
feat(tier4_perception): enable multi-channel tracker merger by default

### DIFF
--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -43,7 +43,7 @@
   <arg name="use_obstacle_segmentation_single_frame_filter" default="false" description="use single frame filter at the ground segmentation"/>
   <arg name="use_obstacle_segmentation_time_series_filter" default="true" description="use time series filter at the ground segmentation"/>
   <arg name="segmentation_pointcloud_fusion_camera_ids" default="[0,2,4]" description="list of camera ids used for segmentation_pointcloud_fusion node, mainly using front camera"/>
-  <arg name="use_multi_channel_tracker_merger" default="false" description="if true, multi channel tracker merger is used. Otherwise, merged object is used."/>
+  <arg name="use_multi_channel_tracker_merger" default="true" description="if true, multi channel tracker merger is used. Otherwise, merged object is used."/>
   <arg name="tracker_publish_merged_objects" default="false"/>
 
   <arg name="occupancy_grid_map_method" default="pointcloud_based" description="options: pointcloud_based, laserscan_based, multi_lidar_pointcloud_based"/>


### PR DESCRIPTION
## Description

Since the multi-channel multi-object-tracker mode is implemented, tested, and improved, benefit of the multi-channel mode became obvious. 

This PR enables the multi-channel mode by default.

Implementation of https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-architecture/perception/reference_implementation/#architecture-for-object-recognition

## How was this PR tested?

## Notes for reviewers
This change will be implemented after the following PRs.
https://github.com/autowarefoundation/autoware_universe/pull/11386
https://github.com/autowarefoundation/autoware_launch/pull/1647

This PR will be merged with the documentation update
https://github.com/autowarefoundation/autoware-documentation/pull/689

## Effects on system behavior

None.
