### PR TITLE
feat(run_out): ignore all stopped objects by default

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/run_out.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/run_out.param.yaml
@@ -43,7 +43,7 @@
         # for each target labels we can specify the following parameters
         DEFAULT:
           ignore:  # options to ignore some objects
-            if_stopped: false # if true, object with a velocity bellow the threshold are ignored
+            if_stopped: true # if true, object with a velocity bellow the threshold are ignored
             stopped_velocity_threshold: 0.25  # [m/s]
             if_on_ego_trajectory: true  # if true, object located on the ego trajectory footprint are ignored
             if_behind_ego: true  # if true, objects located behind the ego vehicles are ignored
@@ -70,7 +70,6 @@
           standstill_duration_after_cut: 2.0  # [s] after cutting a predicted path, assume the object stands still at the last point for this duration
         PEDESTRIAN:
           ignore:
-            if_stopped: true
             lanelet_subtypes: ["crosswalk", "walkway"]
           cut_predicted_paths:
             lanelet_subtypes: ["crosswalk", "walkway"]


### PR DESCRIPTION
## Description

This PR tunes the `run_out` module to ignore all objects that are stopped.
Previously, this was only the case for pedestrians.

This change is motivated by issues caused by stopped bicycles or motorcycles which could cause unwanted stops due to their predicted paths.

## How was this PR tested?

Psim

## Notes for reviewers

None.

## Effects on system behavior

None.
