### PR TITLE
fix(lane_change): reduce static object threshold

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -51,7 +51,7 @@
       safety_check:
         allow_loose_check_for_cancel: true
         enable_target_lane_bound_check: true
-        stopped_object_velocity_threshold: 1.0 # [m/s]
+        stopped_object_velocity_threshold: 0.3          # [m/s] Object whose velocity is less than the threshold is treated as static object.
         prepare:                                        # RSS parameters used during the prepare phase, regardless of whether the ego is searching for a safe path, canceling, or transitioning to another state.
           expected_front_deceleration: -1.0             # [m/s2]
           expected_rear_deceleration: -1.0              # [m/s2]


### PR DESCRIPTION
## Description

Reduced the velocity threshold used to classify object as static object.

## How was this PR tested?

[TIER IV Internal Link - ControlDLR Test](https://evaluation.tier4.jp/evaluation/reports/aa4c0eb9-48c2-5a71-b6ba-85752f7fc28a?project_id=prd_jt)
[TIER IV Internal Link - FuncVerification Test](https://evaluation.tier4.jp/evaluation/reports/d4724236-e573-5d8c-8e82-ff2ae4c4c233?project_id=prd_jt)
[TIER IV Internal Link - CommonScenario_Basic Test](https://evaluation.tier4.jp/evaluation/reports/c4542b93-79de-529d-918e-795b2250becf?project_id=prd_jt)

## Notes for reviewers

None.

## Effects on system behavior

None.
