### PR TITLE
feat(obstacle_slow_down): add curve margin

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
@@ -54,6 +54,9 @@
           pedestrian: true
           pointcloud: false
 
+        # Previously and ideally, the min_lat_margin was 0.
+        # However, the objects whose lateral margin is between 0 and 'wheel_off_track_scale times wheel_off_track' are ignored by the obstacle_slow_down module unexpectedly due to the current implementation.
+        # Therefore, we set the min_lat_margin to a large negative value temporarily.
         min_lat_margin: -10.0  # lateral margin between obstacle and trajectory band with ego's width to avoid the conflict with the obstacle_stop
         max_lat_margin: 1.1  # lateral margin between obstacle and trajectory band with ego's width
         lat_hysteresis_margin: 0.2

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
@@ -36,7 +36,7 @@
                 max_lat_margin: 1.0
                 min_ego_velocity: 4.0
                 max_ego_velocity: 8.0
-            wheel_off_track_scale: 10.0
+            wheel_off_track_scale: 0.0
           # car.left.moving.min_ego_velocity: 3.0  # example specific override
 
         moving_object_speed_threshold: 0.5 # [m/s] how fast the object needs to move to be considered as "moving"

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
@@ -36,6 +36,7 @@
                 max_lat_margin: 1.0
                 min_ego_velocity: 4.0
                 max_ego_velocity: 8.0
+            wheel_off_track_scale: 10.0
           # car.left.moving.min_ego_velocity: 3.0  # example specific override
 
         moving_object_speed_threshold: 0.5 # [m/s] how fast the object needs to move to be considered as "moving"

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
@@ -54,7 +54,7 @@
           pedestrian: true
           pointcloud: false
 
-        min_lat_margin: 0.0  # lateral margin between obstacle and trajectory band with ego's width to avoid the conflict with the obstacle_stop
+        min_lat_margin: -10.0  # lateral margin between obstacle and trajectory band with ego's width to avoid the conflict with the obstacle_stop
         max_lat_margin: 1.1  # lateral margin between obstacle and trajectory band with ego's width
         lat_hysteresis_margin: 0.2
 

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
@@ -36,7 +36,7 @@
                 max_lat_margin: 1.0
                 min_ego_velocity: 4.0
                 max_ego_velocity: 8.0
-            wheel_off_track_scale: 0.0
+            wheel_off_track_scale: 0.0 # scale factor for additional stop margin against ego's wheel off-track. Even if this value is set to 0.0, the planner considers the nominal wheel off-track.
           # car.left.moving.min_ego_velocity: 3.0  # example specific override
 
         moving_object_speed_threshold: 0.5 # [m/s] how fast the object needs to move to be considered as "moving"


### PR DESCRIPTION
## Description
follow a new feature https://github.com/autowarefoundation/autoware_universe/pull/11343

This new feature could create a gap between the stopping and slowing-down distances for obstacles. This might occur when an obstacle is not close enough to trigger obstacle_stop but is too close for obstacle_slow_down to engage properly, especially for the case of different `wheel_off_track_scale` values are set to each module. To address this, we will effectively disable the feature that ignores objects with a short lateral distance in obstacle_slow_down by setting obstacle_slow_down.obstacle_filtering.min_lat_margin to a sufficiently small negative value.

Known issue: meaningless markers will appear around the obstacle_stop wall.

<img width="2668" height="1810" alt="image" src="https://github.com/user-attachments/assets/2ed4d049-d8b8-45cb-a6ee-6fdf54cff004" />


## How was this PR tested?
engage available in psim
tier4 scenario test

## Notes for reviewers


None.

## Effects on system behavior

None.
