### PR TITLE
feat(autoware_launch): add input topic parameters for planning and control modules

### DIFF
--- a/autoware_launch/launch/components/tier4_control_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_control_component.launch.xml
@@ -11,6 +11,10 @@
   <arg name="use_sim_time" default="false"/>
   <arg name="vehicle_model" default="sample_vehicle"/>
 
+  <!-- Input topic parameters for control modules -->
+  <arg name="control_input_objects_topic_name" default="/perception/object_recognition/objects"/>
+  <arg name="control_input_pointcloud_topic_name" default="/perception/obstacle_segmentation/pointcloud"/>
+
   <!-- Global parameters -->
   <group scoped="false">
     <include file="$(find-pkg-share autoware_global_parameter_loader)/launch/global_params.launch.py">
@@ -27,6 +31,10 @@
     <arg name="vehicle_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
     <arg name="vehicle_id" value="$(var vehicle_id)"/>
     <arg name="enable_obstacle_collision_checker" value="false"/>
+
+    <!-- Input topic parameters -->
+    <arg name="input_objects_topic_name" value="$(var control_input_objects_topic_name)"/>
+    <arg name="input_pointcloud_topic_name" value="$(var control_input_pointcloud_topic_name)"/>
     <arg name="trajectory_follower_node_param_path" value="$(find-pkg-share autoware_launch)/config/control/trajectory_follower/trajectory_follower_node.param.yaml"/>
     <arg
       name="lat_controller_param_path"

--- a/autoware_launch/launch/components/tier4_planning_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_planning_component.launch.xml
@@ -7,6 +7,10 @@
   <arg name="use_sim_time" default="false"/>
   <arg name="vehicle_model" default="sample_vehicle"/>
 
+  <!-- Input topic parameters for planning modules -->
+  <arg name="planning_input_objects_topic_name" default="/perception/object_recognition/objects"/>
+  <arg name="planning_input_pointcloud_topic_name" default="/perception/obstacle_segmentation/pointcloud"/>
+
   <!-- Global parameters -->
   <group scoped="false">
     <include file="$(find-pkg-share autoware_global_parameter_loader)/launch/global_params.launch.py">
@@ -22,6 +26,10 @@
     <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
     <arg name="enable_all_modules_auto_mode" value="$(var enable_all_modules_auto_mode)"/>
     <arg name="is_simulation" value="$(var is_simulation)"/>
+
+    <!-- Input topic parameters -->
+    <arg name="input_objects_topic_name" value="$(var planning_input_objects_topic_name)"/>
+    <arg name="input_pointcloud_topic_name" value="$(var planning_input_pointcloud_topic_name)"/>
 
     <!-- common -->
     <arg name="common_config_path" value="$(find-pkg-share autoware_launch)/config/planning/scenario_planning/common"/>


### PR DESCRIPTION
## Description

- **Important**: This PR expected to be merged together with the corresponding changes in the `autoware_universe` repository ([PR #11389](https://github.com/autowarefoundation/autoware_universe/pull/11389)).

This PR adds configurable topic parameters for perception inputs (`objects` and `pointcloud`) at the component level while preserving existing default topic names.

- Added `control_input_objects_topic_name` and `control_input_pointcloud_topic_name` parameters to control component
- Added `planning_input_objects_topic_name` and `planning_input_pointcloud_topic_name` parameters to planning component
- All parameters maintain existing default values (`/perception/object_recognition/objects` and `/perception/obstacle_segmentation/pointcloud`)
- Parameters are passed down to respective launch modules

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

- [x] Passed TIERIV's internal CI checks
  - [x] [Test link part 1](https://evaluation.tier4.jp/evaluation/oidc/auth/cb/?code=ory_ac_ZRjtObPnxq8cHN4kU4yjUPz7-BhqQDJGqRpFrarufJk.Ojf9F90ReiBGgvXxLdvtO_R_cbLwZdw8uf9r_AdK7WM&scope=openid+profile+email+offline_access&state=4ebb480b03b941f3a701e5c6bb77d66c)
  - [x] [Test link part 2](https://evaluation.tier4.jp/evaluation/oidc/auth/cb/?code=ory_ac_W3E2kGrboqloUxDATp2RNaYj8uKYXG0dDNnqoa81dDc.pc4IN6Vo17qEe_dYxUnIevj03bAdpBEoPKh23qfRyG4&scope=openid+profile+email+offline_access&state=7a98e6fb13354024bb087ecee0ae9e44)
  - [x] [Test link part 3](https://evaluation.tier4.jp/evaluation/oidc/auth/cb/?code=ory_ac_BKO5YsENEvOpmMORQc0f9FqOkAFloFK4foaObjSciqc.ZQyKpem9_bQjUmrRbpkRoiCxvTGRcg9VDGQ0SyqayUY&scope=openid+profile+email+offline_access&state=60032077eca645c49e0282fd9646ff30)
- [x] launch planning_simulator and engage autonomous mode

## Notes for reviewers

None

## Interface changes

### ROS Parameter Changes

#### Additions

| Parameter Name                         | Type     | Default Value                                  | Description                                                |
| :------------------------------------- | :------- | :--------------------------------------------- | :--------------------------------------------------------- |
| `control_input_objects_topic_name`     | `string` | `/perception/object_recognition/objects`       | Topic name for object recognition data (control)           |
| `control_input_pointcloud_topic_name`  | `string` | `/perception/obstacle_segmentation/pointcloud` | Topic name for obstacle segmentation pointcloud (control)  |
| `planning_input_objects_topic_name`    | `string` | `/perception/object_recognition/objects`       | Topic name for object recognition data (planning)          |
| `planning_input_pointcloud_topic_name` | `string` | `/perception/obstacle_segmentation/pointcloud` | Topic name for obstacle segmentation pointcloud (planning) |

## Effects on system behavior

None. This change maintains existing default behavior while enabling topic name configuration at the component level. The parameters preserve the original hardcoded topic names as defaults, ensuring backward compatibility.
