### PR TITLE
feat(start_planner): update search priority to prioritize CLOTHOID over SHIFT

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -54,7 +54,7 @@
       # search start pose backward
       enable_back: true
       # Planner priority list. Example: ["SHIFT", "GEOMETRIC", "CLOTHOID"]
-      search_priority: ["SHIFT", "GEOMETRIC"]
+      search_priority: ["CLOTHOID", "SHIFT"]
       # Search policy: "planner_priority" or "distance_priority"
       search_policy: "planner_priority"
       max_back_distance: 20.0


### PR DESCRIPTION
## Description

change the priority to set the CLOTHOID planner as the highest priority, with the SHIFT planner as the second priority. 
We have confirmed that path generation with these priorities can handle most of the currently anticipated use cases.

The conventional geometric planner will be disabled due to its instability.

## How was this PR tested?

- [x] Passed TIERIV's internal CI checks
  - [x] [Test link part 1](https://evaluation.tier4.jp/evaluation/reports/9c83dc14-366b-5c3b-89e1-dcd27ace4433?project_id=prd_jt)
  - [x] [Test link part 2](https://evaluation.tier4.jp/evaluation/reports/ecbdfde7-3724-5b72-8791-91754dfb0477?project_id=prd_jt)
  - [x] [Test link part 3](https://evaluation.tier4.jp/evaluation/reports/98026ff1-0fa2-5021-b690-95531db17ea1?project_id=prd_jt)
- [x] launch planning_simulator and engage autonomous mode

## Notes for reviewers

None.

## Effects on system behavior

None.
