### PR TITLE
feat(run_out): strictly cut predicted paths crossing vegetation areas

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/run_out.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/run_out.param.yaml
@@ -62,7 +62,7 @@
             polygon_types: ["NONE"]  # types of polygons in the vector map used to cut predicted paths
             linestring_types: ["NONE"]  # types of linestrings in the vector map used to cut predicted paths
             lanelet_subtypes: ["NONE"]  # subtypes of lanelets in the vector map used to cut predicted paths
-            strict_polygon_types: ["NONE"]  # same as polygon_types but the cut is not subjected to the preserved duration/distance
+            strict_polygon_types: ["area.vegetation"]  # same as polygon_types but the cut is not subjected to the preserved duration/distance
             strict_linestring_types: ["guard_rail", "fence"]  # same as linestring_types but the cut is not subjected to the preserved duration/distance
             strict_lanelet_subtypes: ["NONE"]  # same as lanelet_subtypes but the cut is not subjected to the preserved duration/distance
           preserved_duration: 0.0  # [s] when cutting a predicted path or ignoring an object, at least this much duration is preserved from the predicted paths


### PR DESCRIPTION
## Description

Set the `run_out` module to cut predicted paths that cross polygons with type `area` and subtype `vegetation`.
Requires https://github.com/autowarefoundation/autoware_universe/pull/11412

## How was this PR tested?

Psim

## Notes for reviewers

None.

## Effects on system behavior

The `run_out` module ignore collisions with predicted paths crossing vegetation.
