### PR TITLE
fix(lane_change): reduces sampling number

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -149,7 +149,7 @@
         max_lateral_jerk: 100.0             # [m/s3]
         overhang_tolerance: 0.0             # [m]
         unsafe_hysteresis_threshold: 5      # [/]
-        deceleration_sampling_num: 1 # [/]
+        deceleration_sampling_num: 1        # [/] Used to sample the approved lane change path, specifically for checking safety against leading objects.
 
       lane_change_finish_judge_buffer: 2.0      # [m]
       finish_judge_lateral_threshold: 0.1        # [m]

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -149,7 +149,7 @@
         max_lateral_jerk: 100.0             # [m/s3]
         overhang_tolerance: 0.0             # [m]
         unsafe_hysteresis_threshold: 5      # [/]
-        deceleration_sampling_num: 5 # [/]
+        deceleration_sampling_num: 1 # [/]
 
       lane_change_finish_judge_buffer: 2.0      # [m]
       finish_judge_lateral_threshold: 0.1        # [m]


### PR DESCRIPTION
## Description

**Issue**
The safety check is continuously executed for an approved lane change path. [During this process, the lane change module samples acceleration, assuming the ego vehicle can slow down if it is changing lanes behind another object](https://github.com/autowarefoundation/autoware_universe/pull/7943). This assumption relies on other modules to decelerate the ego vehicle to avoid collisions.

However, the same sampling is also applied to rear-moving or overtaking objects. Since no countermeasure currently exists for these cases, this can lead to false positives—allowing a lane change even when there is a potential collision.

**Fix**
The following [PR#11342 in autoware.universe](https://github.com/autowarefoundation/autoware_universe/pull/11342) introduces a fix. However, due to an internal evaluation failure, the parameter has been reduced to 1 for now.

📘 **Note**: The failure was not due to an actual collision, but rather a scenario configuration issue.

**User Adjustment**
If users want to make it easier to change lanes behind an object, they can increase the parameter value to 5.

## How was this PR tested?

Internal degradation check

[TIER IV Internal Link - ControlDLR Test](https://evaluation.tier4.jp/evaluation/reports/fdb9d3d8-4fe3-5939-879c-a1346b775981?project_id=prd_jt)
[TIER IV Internal Link - FuncVerification Test](https://evaluation.tier4.jp/evaluation/reports/3df7d95f-4bc9-5563-9b2e-c7ecfba56b74?project_id=prd_jt)
[TIER IV Internal Link - CommonScenario_Basic Test](https://evaluation.tier4.jp/evaluation/reports/4ff527fc-06fc-5888-a199-2389cec3e35d?project_id=prd_jt)

## Notes for reviewers

None.

## Effects on system behavior

None.
