### PR TITLE
fix(start_planner): increase ignore object velocity threshold to avoid chattering judgement

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/start_planner/start_planner.param.yaml
@@ -126,7 +126,7 @@
           # detection range
           object_check_forward_distance: 10.0
           object_check_backward_distance: 100.0
-          ignore_object_velocity_threshold: 0.25
+          ignore_object_velocity_threshold: 1.0
           # ObjectTypesToCheck
           object_types_to_check:
             check_car: true


### PR DESCRIPTION
## Description

There is a feature in start_planner that performs collision detection against dynamic objects during start maneuvers, and within this feature, there exists a threshold for determining whether an object is dynamic or not.
Originally, due to circumstances on the goal_planner side, this threshold was changed from 1.0 to 0.25 in the [PR](https://github.com/autowarefoundation/autoware_launch/pull/1471), but this change was not actually necessary for the start_planner side.

As shown in the attached image, even though the velocity of the vehicle positioned behind is low, the threshold is set as low as 0.25 [m/s], which causes unnecessary stops to be inserted. Therefore, we will revert it to the original value of 1.0.
<img width="1260" height="1196" alt="image" src="https://github.com/user-attachments/assets/98d7900b-6b51-4e06-8a56-174e0d041a47" />

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [ ] Passed TIERIV's internal CI checks
  - [ ] [Test link part 1](https://evaluation.tier4.jp/evaluation/reports/9f21d937-50c7-56df-b50e-35771ac7985d?project_id=prd_jt)
  - [ ] [Test link part 2](https://evaluation.tier4.jp/evaluation/reports/289d6444-9681-5967-bd28-1f9539f9fe9c?project_id=prd_jt)
  - [ ] [Test link part 3](https://evaluation.tier4.jp/evaluation/reports/5a0bd4b1-e972-5c31-9120-3e5a6e3094c2?project_id=prd_jt)
- [x] launch planning_simulator and engage autonomous mode

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

#### Modifications

| Version | Parameter Name                     | Type     | Default Value | Description                                                                                                                              |
| :------ | :--------------------------------- | :------- | :------------ | :--------------------------------------------------------------------------------------------------------------------------------------- |
| Old     | `ignore_object_velocity_threshold` | `double` | `0.25`        | Velocity threshold for determining whether an object should be considered as a target during collision detection against dynamic objects |
| New     | `ignore_object_velocity_threshold` | `double` | `1.0`         | same as original                                                                                                                         |

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
