### PR TITLE
feat(obstacle_slow_down): update velocity calclation

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
@@ -5,8 +5,8 @@
         slow_down_min_acc: -1.0         # slow down min deceleration [m/ss]
         slow_down_min_jerk: -1.0        # slow down min jerk [m/sss]
 
-        lpf_gain_slow_down_vel: 0.99 # low-pass filter gain for slow down velocity
-        lpf_gain_lat_dist: 0.999 # low-pass filter gain for lateral distance from obstacle to ego's path
+        lpf_gain_slow_down_vel: 0.9 # low-pass filter gain for slow down velocity
+        lpf_gain_lateral_distance: 0.7 # low-pass filter gain for lateral distance from obstacle to ego's path
         lpf_gain_dist_to_slow_down: 0.7 # low-pass filter gain for distance to slow down start
 
         time_margin_on_target_velocity: 1.5 # [s]


### PR DESCRIPTION
## Description
**Regarding lpf_gain_slow_down_vel**
This change updates the time constant from 10 seconds to a more practical 1 second. The new value is better suited for driving on public roads.

**Regarding lpf_gain_lat_dist**
The previous implementation had a bug where it did not function as a proper Low-Pass Filter (LPF). Instead, it calculated a weighted average of the current and previous raw values. As a result, the value 0.999 effectively meant using the value from the previous cycle.

This bug has been fixed in the corresponding PR (https://github.com/autowarefoundation/autoware_universe/pull/11502). Accordingly, this PR updates the parameter to function correctly as an LPF with a 0.33s time constant.

Although this is a bug fix, it introduces a significant behavioral difference. Therefore, the parameter name has been intentionally changed to reflect this.


Note: The planning cycle is approximately 0.1s.

universe PR: https://github.com/autowarefoundation/autoware_universe/pull/11502

## How was this PR tested?
psim and tier4 scenario test

## Notes for reviewers

None.

## Effects on system behavior

None.
