### PR TITLE
feat(turn_signal_decider): add threshold based on distance to lane bound for turning off blinker

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -24,7 +24,7 @@
     turn_signal_search_time: 3.0
     turn_signal_shift_length_threshold: 0.3
     turn_signal_remaining_shift_length_threshold: 0.1
-    turn_signal_remaining_distance_to_bound_threshold: 1.3 # Distance from ego vehicle's front edge to the far-side boundary of the target merging lane.
+    turn_signal_remaining_distance_to_bound_threshold: 1.3 # Distance from ego vehicle's front edge to the far-side boundary of the target merging lane. The turn signal will be turned off when the value is less than the threshold.
     turn_signal_on_swerving: true
 
     enable_akima_spline_first: false


### PR DESCRIPTION
## Description

### Issue

Currently, the blinker stays active throughout a behavior planning maneuver and only turns off once the maneuver is fully completed — for example, when the remaining shift distance falls below a certain threshold.

This can create a safety risk near intersections because it gives unclear signals to other drivers and may lead to accidents.

For instance, if the ego vehicle hasn’t finished a pull-out maneuver and continues driving straight toward an intersection, the ongoing blinker (e.g., right signal) contradicts the actual planner output (e.g., going straight).
An oncoming vehicle preparing to turn left might see the ego’s right blinker and wrongly assume it intends to turn right. This misunderstanding could cause the other driver to proceed, creating a high risk of collision.

https://github.com/user-attachments/assets/c4680d39-1545-47eb-a38b-ef8abfc89c8b

### Solution

To avoid this kind of ambiguity and improve communication with nearby drivers, this PR adds a new condition to turn off the blinker earlier.

The blinker will now deactivate based on the remaining lateral distance to the target lane boundary.
If this distance is smaller than the configurable parameter `turn_signal_remaining_distance_to_bound_threshold`, the blinker will turn off immediately.

The value of `turn_signal_remaining_distance_to_bound_threshold` assumes that, at this distance, no other vehicle can safely pass from behind.

⚠️ : This PR only affects start planner module.

📃 : The default `turn_signal_remaining_distance_to_bound_threshold` based on taxi description's wheel thread 

## Related links

- launcher: https://github.com/autowarefoundation/autoware_universe/pull/11519

## How was this PR tested?

### PSIM

Here is the video for start planner

https://github.com/user-attachments/assets/10da4ee9-b086-4148-8e1a-a4265784f8bf

It doesn't affect lane change and avoidance

https://github.com/user-attachments/assets/cfcc872b-cc3f-4b67-8667-49466cc5180a

https://github.com/user-attachments/assets/f6966b2b-c3c3-4b7a-bedf-842586834ef1

### Interval evaluation

TBA

## Notes for reviewers

None.

## ROS Parameter Changes

### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `turn_signal_remaining_distance_to_bound_threshold`   | `double` | `1.4`         | Distance from ego vehicle's front edge to the far-side boundary of the target merging lane. The turn signal will be turned off when the value is less than the threshold.
 
## Effects on system behavior

None.
