### PR TITLE
fix(traffic_light_module): remove 'required_time_to_departure' parameter

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/traffic_light.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/traffic_light.param.yaml
@@ -17,4 +17,3 @@
         use_remaining_time: false
         last_time_allowed_to_pass: 2.0 # [s] relative time against at the time of turn to red
         velocity_threshold: 0.5 # [m/s] change the decision logic whether the current velocity is faster or not
-        required_time_to_departure: 3.0 # [s] prevent low speed pass


### PR DESCRIPTION
## Description

Removed the 'required_time_to_departure' parameter to simplify traffic light decision logic.

- https://github.com/autowarefoundation/autoware_universe/pull/11581

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
