### PR TITLE
feat(autoware_launch): add use_sim_time to system component

### DIFF
--- a/autoware_launch/launch/components/tier4_system_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_system_component.launch.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="use_sim_time" default="false"/>
   <arg name="diagnostic_graph_aggregator_param_path" default="$(find-pkg-share autoware_diagnostic_graph_aggregator)/config/default.param.yaml"/>
   <arg name="diagnostic_graph_aggregator_graph_path" default="$(find-pkg-share autoware_launch)/config/system/diagnostics/autoware-main.yaml"/>
+
+  <set_parameter name="use_sim_time" value="$(var use_sim_time)"/>
 
   <include file="$(find-pkg-share tier4_system_launch)/launch/system.launch.xml">
     <arg name="run_mode" value="$(var system_run_mode)"/>


### PR DESCRIPTION
## Description

Add use_sim_time argument for launching system component alone.

## How was this PR tested?

Check [rosbag replay simulation](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/).

## Notes for reviewers

None.

## Effects on system behavior

None.
