### PR TITLE
feat(obstacle_slow_down): change lpf settings

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/obstacle_slow_down.param.yaml
@@ -6,8 +6,8 @@
         slow_down_min_jerk: -1.0        # slow down min jerk [m/sss]
 
         lpf_gain_slow_down_vel: 0.0 # low-pass filter gain for slow down velocity
-        lpf_gain_lateral_distance: 0.9 # low-pass filter gain for lateral distance from obstacle to ego's path
-        lpf_gain_dist_to_slow_down: 0.9 # low-pass filter gain for distance to slow down start
+        lpf_gain_lateral_distance: 0.8 # low-pass filter gain for lateral distance from obstacle to ego's path
+        lpf_gain_dist_to_slow_down: 0.8 # low-pass filter gain for distance to slow down start
 
         time_margin_on_target_velocity: 1.5 # [s]
 


### PR DESCRIPTION
## Description
This PR dissable `lpf_gain_slow_down_vel` because this lpf breaks deceleration constraints.
We assume this is acceptable, as the lateral distance to the object and the slow-down section calculations themselves are still processed by an LPF.

## How was this PR tested?
psim and tier4 scenario test

## Notes for reviewers

None.

## Effects on system behavior

None.
