### PR TITLE
fix(autoware_launch): fix glog component namespace of pointcloud container

### DIFF
--- a/autoware_launch/launch/pointcloud_container.launch.py
+++ b/autoware_launch/launch/pointcloud_container.launch.py
@@ -42,7 +42,7 @@ def generate_launch_description():
         package="autoware_glog_component",
         plugin="autoware::glog_component::GlogComponent",
         name="glog_component",
-        namespace="pointcloud_container",
+        namespace=["/", LaunchConfiguration("container_name")],
     )
 
     pointcloud_container = ComposableNodeContainer(


### PR DESCRIPTION
## Description

Rename glog_component namespace to avoid node name conflicts when multiple pointcloud containers are launched.

## How was this PR tested?

Run rosbag replay simulation.

## Notes for reviewers

None.

## Effects on system behavior

None.
