### PR TITLE
feat(image_object_locator): add near range camera VRU detector to perception pipeline

### DIFF
--- a/autoware_launch/config/perception/object_recognition/detection/camera_vru_detection/near_range_camera_vru_detector.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/camera_vru_detection/near_range_camera_vru_detector.param.yaml
@@ -1,0 +1,28 @@
+/**:
+  ros__parameters:
+    target_frame: "base_link"
+    detection_target_class:
+      UNKNOWN : false
+      CAR : false
+      TRUCK : false
+      BUS : false
+      TRAILER : false
+      MOTORCYCLE : false
+      BICYCLE : false
+      PEDESTRIAN : true
+
+    roi_confidence_threshold: 0.80 # [0.0, 1.0]
+    roi_truncation_validation:
+      enabled: [false, false, false, false, false, false, false, false]
+      remove_truncated: [false, false, false, false, false, false, false, false]
+      image_border_truncation_horizontal_margin_ratio: 0.0 # [0.0, 0.5]
+      image_border_truncation_vertical_margin_ratio: 0.0 # [0.0, 0.5]
+
+    # if an object is detected farther than this, it will be filtered out
+    detection_max_range: 10.0 # [m]
+    # if object height is unavailable, this will be used instead
+    pseudo_height: 1.5 # [m]
+
+    pedestrian_detection_config:
+      width_min: 0.5 # [m]
+      width_max: 0.8 # [m]

--- a/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
@@ -104,3 +104,14 @@
         optional:
           name: "radar"
           short_name: "Rad"
+      # CAMERA VRU
+      camera_vru:
+        flags:
+          can_spawn_new_tracker: true
+          can_trust_existence_probability: true
+          can_trust_extension: false
+          can_trust_classification: true
+          can_trust_orientation: false
+        optional:
+          name: "camera_vru"
+          short_name: "CamVRU"

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -45,6 +45,8 @@
   <arg name="segmentation_pointcloud_fusion_camera_ids" default="[0,2,4]" description="list of camera ids used for segmentation_pointcloud_fusion node, mainly using front camera"/>
   <arg name="use_multi_channel_tracker_merger" default="true" description="if true, multi channel tracker merger is used. Otherwise, merged object is used."/>
   <arg name="tracker_publish_merged_objects" default="false"/>
+  <arg name="use_camera_vru_detector" default="false" description="enable pipeline for camera VRU object detection"/>
+  <arg name="camera_vru_detector_rois_ids" default="[0]" description="list of ROIs ids used for detecting VRU."/>
 
   <arg name="occupancy_grid_map_method" default="pointcloud_based" description="options: pointcloud_based, laserscan_based, multi_lidar_pointcloud_based"/>
   <arg name="occupancy_grid_map_updater" default="binary_bayes_filter" description="options: binary_bayes_filter"/>
@@ -100,6 +102,8 @@
     <arg name="use_obstacle_segmentation_single_frame_filter" value="$(var use_obstacle_segmentation_single_frame_filter)"/>
     <arg name="use_obstacle_segmentation_time_series_filter" value="$(var use_obstacle_segmentation_time_series_filter)"/>
     <arg name="segmentation_pointcloud_fusion_camera_ids" value="$(var segmentation_pointcloud_fusion_camera_ids)"/>
+    <arg name="use_camera_vru_detector" value="$(var use_camera_vru_detector)"/>
+    <arg name="camera_vru_detector_rois_ids" value="$(var camera_vru_detector_rois_ids)"/>
 
     <arg name="camera_2d_detector/model_path" value="$(var camera_2d_detector/model_path)"/>
     <arg name="camera_2d_detector/label_path" value="$(var camera_2d_detector/label_path)"/>
@@ -149,6 +153,10 @@
     <arg
       name="object_recognition_detection_roi_detected_object_fusion_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/image_projection_based_fusion/roi_detected_object_fusion.param.yaml"
+    />
+    <arg
+      name="object_recognition_detection_near_range_camera_vru_param_path"
+      value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/camera_vru_detection/near_range_camera_vru_detector.param.yaml"
     />
     <arg
       name="object_recognition_detection_pointpainting_fusion_common_param_path"


### PR DESCRIPTION
## Description
This PR will add the image_object_locator to the perception pipeline.

The near range camera VRU pipeline will be enable when

- `use_camera_vru_detector:=true`
- `use_multi_channel_tracker_merger:=true`

, and `perception_mode` contains camera.

This PR must merge with https://github.com/autowarefoundation/autoware_universe/pull/11622

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
