### PR TITLE
fix(lane_change): extended polygon policy along_path

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -60,7 +60,7 @@
           lateral_distance_max_threshold: 0.5           # [m]
           longitudinal_distance_min_threshold: 1.0      # [m]
           longitudinal_velocity_delta_time: 0.0         # [s]
-          extended_polygon_policy: "along-path"         # [-] available options are `rectangle` or `along-path`
+          extended_polygon_policy: "along_path"         # [-] available options are `rectangle` or `along_path`
         execution:
           expected_front_deceleration: -1.0
           expected_rear_deceleration: -1.0


### PR DESCRIPTION
## Description

Fix incorrect parameter set to `extended_polygon_policy`.

| Before | After |
|:-:|:-:|
|hyphen `along-path` | underscore `along_path` | 

## How was this PR tested?

[TIER IV Internal Link - ControlDLR Test](https://evaluation.tier4.jp/evaluation/reports/4183d199-d90e-59fc-bb98-684fb61597e4?project_id=prd_jt)
[TIER IV Internal Link - FuncVerification Test](https://evaluation.tier4.jp/evaluation/reports/49239ede-2918-5fc6-9a68-cc76897c7ece?project_id=prd_jt)
[TIER IV Internal Link - CommonScenario_Basic Test](https://evaluation.tier4.jp/evaluation/reports/2738227d-3d02-5379-ae21-959953afd695?project_id=prd_jt)

## Notes for reviewers

None.

## Effects on system behavior

None.
