### PR TITLE
feat(feature_environment_recognizer)!: integrate feature_environment_recognizer into localization component

### DIFF
--- a/autoware_launch/config/localization/feature_environment_recognizer.param.yaml
+++ b/autoware_launch/config/localization/feature_environment_recognizer.param.yaml
@@ -1,0 +1,26 @@
+/**:
+  ros__parameters:
+    # Default environment ID when lanelet is not found in any list
+    # 0: Normal environment (default)
+    default_environment_id: 0
+
+    # Distance threshold for lanelet search [m]
+    search_distance_threshold: 10.0
+
+    # Yaw threshold for lanelet search [rad]
+    search_yaw_threshold: 0.785  # π/4
+
+    # Environment-lanelet ID mappings
+    # Environment ID 1: Uniform road (e.g., tunnel straight sections, uniform shape roads)
+    # 環境ID 1: 均一形状路（トンネル直線部など）
+    environment_id_1:
+      lanelet_ids: []  # Add lanelet IDs for uniform roads here, e.g., [100, 101, 102, 103]
+
+    # Environment ID 2: Feature-poor road (roads with few features for map matching)
+    # 環境ID 2: 特徴が少ない道路（地図マッチングに特徴が少ない道路）
+    environment_id_2:
+      lanelet_ids: []  # Add lanelet IDs for feature-poor roads here, e.g., [200, 201, 202, 203]
+
+    # You can add more environment mappings as needed:
+    # environment_id_3:
+    #   lanelet_ids: [300, 301, 302]

--- a/autoware_launch/config/localization/feature_environment_recognizer.param.yaml
+++ b/autoware_launch/config/localization/feature_environment_recognizer.param.yaml
@@ -1,26 +1,25 @@
 /**:
   ros__parameters:
-    # Default environment ID when lanelet is not found in any list
+    # Default environment ID when area is not found in any list
     # 0: Normal environment (default)
     default_environment_id: 0
 
-    # Distance threshold for lanelet search [m]
-    search_distance_threshold: 10.0
-
-    # Yaw threshold for lanelet search [rad]
-    search_yaw_threshold: 0.785  # π/4
-
-    # Environment-lanelet ID mappings
+    # Area subtype to environment ID mappings
+    # Define areas in the lanelet2 map with:
+    #   - type="feature_environment_specify"
+    #   - subtype=<subtype_name> (e.g., "uniform_road", "feature_poor_road")
+    #   - area="yes"
+    #
     # Environment ID 1: Uniform road (e.g., tunnel straight sections, uniform shape roads)
     # 環境ID 1: 均一形状路（トンネル直線部など）
-    environment_id_1:
-      lanelet_ids: []  # Add lanelet IDs for uniform roads here, e.g., [100, 101, 102, 103]
+    area_subtype_uniform_road:
+      environment_id: 1
 
     # Environment ID 2: Feature-poor road (roads with few features for map matching)
     # 環境ID 2: 特徴が少ない道路（地図マッチングに特徴が少ない道路）
-    environment_id_2:
-      lanelet_ids: []  # Add lanelet IDs for feature-poor roads here, e.g., [200, 201, 202, 203]
+    area_subtype_feature_poor_road:
+      environment_id: 2
 
-    # You can add more environment mappings as needed:
-    # environment_id_3:
-    #   lanelet_ids: [300, 301, 302]
+    # You can add more area subtype mappings as needed:
+    # area_subtype_custom_area:
+    #   environment_id: 3

--- a/autoware_launch/launch/components/tier4_localization_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_localization_component.launch.xml
@@ -42,6 +42,7 @@
 
       <!-- parameter paths for common -->
       <arg name="localization_error_monitor_param_path" value="$(var loc_config_path)/localization_error_monitor.param.yaml"/>
+      <arg name="feature_environment_recognizer_param_path" value="$(var loc_config_path)/feature_environment_recognizer.param.yaml"/>
       <arg name="ekf_localizer_param_path" value="$(var loc_config_path)/ekf_localizer.param.yaml"/>
       <arg name="stop_filter_param_path" value="$(var loc_config_path)/stop_filter.param.yaml"/>
       <arg name="pose_instability_detector_param_path" value="$(var loc_config_path)/pose_instability_detector.param.yaml"/>


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware_universe/pull/11768

Add feature_environment_recognizer to the localization component launch file and provide default parameter configuration.

Changes:
- Add feature_environment_recognizer_param_path argument to tier4_localization_component.launch.xml
- Add default parameter file at config/localization/feature_environment_recognizer.param.yaml

The feature_environment_recognizer node will be automatically launched when starting the localization component, recognizing feature-rich/poor environments based on polygon area of LL2 map

## How was this PR tested?
Please see [the parent PR](https://github.com/autowarefoundation/autoware_universe/pull/11768)

## Notes for reviewers

None.

## Effects on system behavior

None.
