### PR TITLE
ci(build-and-test-differential): use require-label

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -12,15 +12,19 @@ on:
       - reopened
       - labeled
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  make-sure-label-is-present:
-    uses: autowarefoundation/autoware-github-actions/.github/workflows/make-sure-label-is-present.yaml@v1
+  require-label:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/require-label.yaml@v1
     with:
       label: run:build-and-test-differential
 
   build-and-test-differential:
-    needs: make-sure-label-is-present
-    if: ${{ needs.make-sure-label-is-present.outputs.result == 'true' }}
+    needs: require-label
+    if: ${{ needs.require-label.outputs.result == 'true' }}
     runs-on: ubuntu-22.04
     container: ${{ matrix.container }}
     strategy:
@@ -28,9 +32,13 @@ jobs:
       matrix:
         rosdistro:
           - humble
+          - jazzy
         include:
           - rosdistro: humble
             container: ros:humble
+            build-depends-repos: build_depends.repos
+          - rosdistro: jazzy
+            container: ros:jazzy
             build-depends-repos: build_depends.repos
     steps:
       - name: Set PR fetch depth


### PR DESCRIPTION
## Description

- testing: https://github.com/autowarefoundation/sync-file-templates/pull/54

Also adds `concurrency` and `jazzy` builds too, can be merged. Will be added in next sync-files sync anyways.

## How was this PR tested?

### It fails without label ❌

https://github.com/autowarefoundation/autoware_launch/actions/runs/20521753946

<img width="1231" height="529" alt="image" src="https://github.com/user-attachments/assets/cc3bb213-424e-4140-972d-06d249c2a478" />

### It succeeds with label ✅

https://github.com/autowarefoundation/autoware_launch/actions/runs/20521778018/job/58958159707?pr=1726

<img width="1236" height="512" alt="image" src="https://github.com/user-attachments/assets/f97a88a1-19e1-44aa-b543-7f27e85606b5" />


## Notes for reviewers

None.

## Effects on system behavior

None.
