### PR TITLE
feat(crosswalk): add parameter to stop for pedestrians on crosswalk polygon

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/crosswalk.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/crosswalk.param.yaml
@@ -48,7 +48,7 @@
         ego_min_assumed_speed: 2.0 # [m/s] assumed speed to calculate the time to collision point
 
         consider_obj_on_crosswalk_on_red_light: false # consider and do not ignore objects if they are on the crosswalk when the crosswalk pedestrian traffic light is red
-
+        stop_for_pedestrian_on_crosswalk: false # ego will always stop for pedestrians on the crosswalk, regardless of other conditions
         no_stop_decision: # parameters to determine stop cancel. the distance f($min_acc, $min_jerk) is compared against min(distance to stop pose, 0.1).
           enable_no_stop_decision: true
           min_acc: -1.5 # min acceleration [m/ss]


### PR DESCRIPTION
## Description
This PR created to add `stop_for_pedestrian_on_crosswalk` parameter to stop for any pedestrians on crosswalk. Ego will continue to stop until they leave the crosswalk polygon.

It is left as `stop_for_pedestrian_on_crosswalk`: `false` not to change the current system behavior.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
