### PR TITLE
feat(autoware_launch): add dbt camera cross validation

### DIFF
--- a/autoware_launch/config/perception/object_recognition/detection/image_projection_based_fusion/roi_detected_object_fusion_dbt.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/image_projection_based_fusion/roi_detected_object_fusion_dbt.param.yaml
@@ -1,0 +1,21 @@
+/**:
+  ros__parameters:
+    # UNKNOWN, CAR, TRUCK, BUS, TRAILER, MOTORBIKE, BICYCLE, PEDESTRIAN
+    # For detection_by_tracker objects: existence_probability = 2D IoU (not NN confidence).
+    # Set PEDESTRIAN to 1.0 so ALL dbt pedestrians must pass camera ROI validation (no passthrough).
+    passthrough_lower_bound_probability_thresholds: [0.35, 0.35, 0.35, 0.35, 0.35, 0.35, 0.35, 1.0]
+    trust_distances: [50.0, 100.0, 100.0, 100.0, 100.0, 50.0, 50.0, 70.0]
+    min_iou_threshold: 0.5
+    use_roi_probability: false
+    roi_probability_threshold: 0.5
+
+    can_assign_matrix:
+      #UNKNOWN, CAR, TRUCK, BUS, TRAILER, MOTORBIKE, BICYCLE, PEDESTRIAN <-roi_msg
+      [1,       0,   0,     0,   0,       0,         0,       0,         # UNKNOWN <-detected_objects
+       0,       1,   1,     1,   1,       0,         0,       0,         # CAR
+       0,       1,   1,     1,   1,       0,         0,       0,         # TRUCK
+       0,       1,   1,     1,   1,       0,         0,       0,         # BUS
+       0,       1,   1,     1,   1,       0,         0,       0,         # TRAILER
+       0,       0,   0,     0,   0,       1,         1,       1,         # MOTORBIKE
+       0,       0,   0,     0,   0,       1,         1,       1,         # BICYCLE
+       0,       0,   0,     0,   0,       1,         1,       1]         # PEDESTRIAN

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -156,6 +156,10 @@
       value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/image_projection_based_fusion/roi_detected_object_fusion.param.yaml"
     />
     <arg
+      name="object_recognition_detection_roi_detected_object_fusion_dbt_param_path"
+      value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/image_projection_based_fusion/roi_detected_object_fusion_dbt.param.yaml"
+    />
+    <arg
       name="object_recognition_detection_near_range_camera_vru_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/object_recognition/detection/camera_vru_detection/near_range_camera_vru_detector.param.yaml"
     />

--- a/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
+++ b/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
@@ -102,7 +102,7 @@
   <let name="camera_lidar_rule_detector/output/objects" value="$(var ns)/clustering/camera_lidar_fusion/objects"/>
   <let name="camera_lidar_rule_detector/output/cluster_objects" value="$(var ns)/clustering/objects_with_feature"/>
   <let name="tracker_based_detector/input/clusters" value="$(var ns)/clustering/objects_with_feature"/>
-  <let name="tracker_based_detector/output/objects_raw" value="$(var ns)/detection_by_tracker/unfiltered/objects"/>
+  <let name="tracker_based_detector/output/objects_raw" value="$(var ns)/detection_by_tracker/objects"/>
   <let name="tracker_based_detector/output/objects" value="$(var ns)/detection_by_tracker/objects"/>
   <let name="lidar_object_filter/output/objects" value="$(var ns)/$(var lidar_detection_model_type)/validation/objects"/>
   <let name="camera_lidar_object_filter/output/objects" value="$(var ns)/clustering/camera_lidar_fusion/filtered/objects"/>
@@ -142,6 +142,7 @@
   <group scoped="false" if="$(eval '&quot;$(var mode)&quot;==&quot;camera_lidar_radar_fusion&quot;')">
     <let name="switch/filter/pointcloud" value="true"/>
     <let name="switch/detector/camera_lidar" value="true"/>
+    <let name="tracker_based_detector/output/objects_raw" value="$(var ns)/detection_by_tracker/unfiltered/objects"/>
     <let name="switch/detector/lidar_dnn" value="true"/>
     <let name="switch/detector/radar" value="true" unless="$(var use_radar_tracking_fusion)"/>
     <let name="switch/merger/camera_lidar_radar" value="true" unless="$(var use_multi_channel_tracker_merger)"/>
@@ -156,6 +157,7 @@
   <group scoped="false" if="$(eval '&quot;$(var mode)&quot;==&quot;camera_lidar_fusion&quot;')">
     <let name="switch/filter/pointcloud" value="true"/>
     <let name="switch/detector/camera_lidar" value="true"/>
+    <let name="tracker_based_detector/output/objects_raw" value="$(var ns)/detection_by_tracker/unfiltered/objects"/>
     <let name="switch/detector/lidar_dnn" value="true"/>
     <let name="switch/merger/camera_lidar" value="true" unless="$(var use_multi_channel_tracker_merger)"/>
     <group scoped="false" if="$(var use_multi_channel_tracker_merger)">
@@ -345,6 +347,7 @@
 
   <!-- ROI filter for DetectionByTracker: cross-validate tracker-based detections against camera ROIs -->
   <group if="$(var switch/detector/tracker_based)">
+  <group if="$(var switch/detector/camera_lidar)">
     <push-ros-namespace namespace="detection_by_tracker"/>
     <include file="$(find-pkg-share autoware_image_projection_based_fusion)/launch/roi_detected_object_fusion.launch.xml">
       <arg name="input/rois_number" value="$(var number_of_cameras)"/>
@@ -380,6 +383,7 @@
       <arg name="output/objects" value="$(var tracker_based_detector/output/objects)"/>
       <arg name="param_path" value="$(var roi_detected_object_fusion_dbt_param_path)"/>
     </include>
+  </group>
   </group>
 
   <group if="$(var switch/detector/camera_vru_detector)">

--- a/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
+++ b/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
@@ -102,6 +102,7 @@
   <let name="camera_lidar_rule_detector/output/objects" value="$(var ns)/clustering/camera_lidar_fusion/objects"/>
   <let name="camera_lidar_rule_detector/output/cluster_objects" value="$(var ns)/clustering/objects_with_feature"/>
   <let name="tracker_based_detector/input/clusters" value="$(var ns)/clustering/objects_with_feature"/>
+  <let name="tracker_based_detector/output/objects_raw" value="$(var ns)/detection_by_tracker/unfiltered/objects"/>
   <let name="tracker_based_detector/output/objects" value="$(var ns)/detection_by_tracker/objects"/>
   <let name="lidar_object_filter/output/objects" value="$(var ns)/$(var lidar_detection_model_type)/validation/objects"/>
   <let name="camera_lidar_object_filter/output/objects" value="$(var ns)/clustering/camera_lidar_fusion/filtered/objects"/>
@@ -337,8 +338,47 @@
     <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/detection/detector/tracker_based_detector.launch.xml">
       <arg name="input/clusters" value="$(var tracker_based_detector/input/clusters)"/>
       <arg name="input/tracked_objects" value="$(var input/tracked_objects)"/>
-      <arg name="output/objects" value="$(var tracker_based_detector/output/objects)"/>
+      <arg name="output/objects" value="$(var tracker_based_detector/output/objects_raw)"/>
       <arg name="detection_by_tracker_param_path" value="$(var object_recognition_detection_detection_by_tracker_param)"/>
+    </include>
+  </group>
+
+  <!-- ROI filter for DetectionByTracker: cross-validate tracker-based detections against camera ROIs -->
+  <group if="$(var switch/detector/tracker_based)">
+    <push-ros-namespace namespace="detection_by_tracker"/>
+    <include file="$(find-pkg-share autoware_image_projection_based_fusion)/launch/roi_detected_object_fusion.launch.xml">
+      <arg name="input/rois_number" value="$(var number_of_cameras)"/>
+      <arg name="input/rois0" value="$(var input/camera0/rois)"/>
+      <arg name="input/rois1" value="$(var input/camera1/rois)"/>
+      <arg name="input/rois2" value="$(var input/camera2/rois)"/>
+      <arg name="input/rois3" value="$(var input/camera3/rois)"/>
+      <arg name="input/rois4" value="$(var input/camera4/rois)"/>
+      <arg name="input/rois5" value="$(var input/camera5/rois)"/>
+      <arg name="input/rois6" value="$(var input/camera6/rois)"/>
+      <arg name="input/rois7" value="$(var input/camera7/rois)"/>
+      <arg name="input/rois8" value="$(var input/camera8/rois)"/>
+      <arg name="input/camera_info0" value="$(var input/camera0/info)"/>
+      <arg name="input/camera_info1" value="$(var input/camera1/info)"/>
+      <arg name="input/camera_info2" value="$(var input/camera2/info)"/>
+      <arg name="input/camera_info3" value="$(var input/camera3/info)"/>
+      <arg name="input/camera_info4" value="$(var input/camera4/info)"/>
+      <arg name="input/camera_info5" value="$(var input/camera5/info)"/>
+      <arg name="input/camera_info6" value="$(var input/camera6/info)"/>
+      <arg name="input/camera_info7" value="$(var input/camera7/info)"/>
+      <arg name="input/camera_info8" value="$(var input/camera8/info)"/>
+      <arg name="input/image0" value="$(var input/camera0/image)"/>
+      <arg name="input/image1" value="$(var input/camera1/image)"/>
+      <arg name="input/image2" value="$(var input/camera2/image)"/>
+      <arg name="input/image3" value="$(var input/camera3/image)"/>
+      <arg name="input/image4" value="$(var input/camera4/image)"/>
+      <arg name="input/image5" value="$(var input/camera5/image)"/>
+      <arg name="input/image6" value="$(var input/camera6/image)"/>
+      <arg name="input/image7" value="$(var input/camera7/image)"/>
+      <arg name="input/image8" value="$(var input/camera8/image)"/>
+      <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
+      <arg name="input/objects" value="$(var tracker_based_detector/output/objects_raw)"/>
+      <arg name="output/objects" value="$(var tracker_based_detector/output/objects)"/>
+      <arg name="param_path" value="$(var roi_detected_object_fusion_dbt_param_path)"/>
     </include>
   </group>
 

--- a/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
+++ b/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
@@ -347,43 +347,43 @@
 
   <!-- ROI filter for DetectionByTracker: cross-validate tracker-based detections against camera ROIs -->
   <group if="$(var switch/detector/tracker_based)">
-  <group if="$(var switch/detector/camera_lidar)">
-    <push-ros-namespace namespace="detection_by_tracker"/>
-    <include file="$(find-pkg-share autoware_image_projection_based_fusion)/launch/roi_detected_object_fusion.launch.xml">
-      <arg name="input/rois_number" value="$(var number_of_cameras)"/>
-      <arg name="input/rois0" value="$(var input/camera0/rois)"/>
-      <arg name="input/rois1" value="$(var input/camera1/rois)"/>
-      <arg name="input/rois2" value="$(var input/camera2/rois)"/>
-      <arg name="input/rois3" value="$(var input/camera3/rois)"/>
-      <arg name="input/rois4" value="$(var input/camera4/rois)"/>
-      <arg name="input/rois5" value="$(var input/camera5/rois)"/>
-      <arg name="input/rois6" value="$(var input/camera6/rois)"/>
-      <arg name="input/rois7" value="$(var input/camera7/rois)"/>
-      <arg name="input/rois8" value="$(var input/camera8/rois)"/>
-      <arg name="input/camera_info0" value="$(var input/camera0/info)"/>
-      <arg name="input/camera_info1" value="$(var input/camera1/info)"/>
-      <arg name="input/camera_info2" value="$(var input/camera2/info)"/>
-      <arg name="input/camera_info3" value="$(var input/camera3/info)"/>
-      <arg name="input/camera_info4" value="$(var input/camera4/info)"/>
-      <arg name="input/camera_info5" value="$(var input/camera5/info)"/>
-      <arg name="input/camera_info6" value="$(var input/camera6/info)"/>
-      <arg name="input/camera_info7" value="$(var input/camera7/info)"/>
-      <arg name="input/camera_info8" value="$(var input/camera8/info)"/>
-      <arg name="input/image0" value="$(var input/camera0/image)"/>
-      <arg name="input/image1" value="$(var input/camera1/image)"/>
-      <arg name="input/image2" value="$(var input/camera2/image)"/>
-      <arg name="input/image3" value="$(var input/camera3/image)"/>
-      <arg name="input/image4" value="$(var input/camera4/image)"/>
-      <arg name="input/image5" value="$(var input/camera5/image)"/>
-      <arg name="input/image6" value="$(var input/camera6/image)"/>
-      <arg name="input/image7" value="$(var input/camera7/image)"/>
-      <arg name="input/image8" value="$(var input/camera8/image)"/>
-      <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
-      <arg name="input/objects" value="$(var tracker_based_detector/output/objects_raw)"/>
-      <arg name="output/objects" value="$(var tracker_based_detector/output/objects)"/>
-      <arg name="param_path" value="$(var roi_detected_object_fusion_dbt_param_path)"/>
-    </include>
-  </group>
+    <group if="$(var switch/detector/camera_lidar)">
+      <push-ros-namespace namespace="detection_by_tracker"/>
+      <include file="$(find-pkg-share autoware_image_projection_based_fusion)/launch/roi_detected_object_fusion.launch.xml">
+        <arg name="input/rois_number" value="$(var number_of_cameras)"/>
+        <arg name="input/rois0" value="$(var input/camera0/rois)"/>
+        <arg name="input/rois1" value="$(var input/camera1/rois)"/>
+        <arg name="input/rois2" value="$(var input/camera2/rois)"/>
+        <arg name="input/rois3" value="$(var input/camera3/rois)"/>
+        <arg name="input/rois4" value="$(var input/camera4/rois)"/>
+        <arg name="input/rois5" value="$(var input/camera5/rois)"/>
+        <arg name="input/rois6" value="$(var input/camera6/rois)"/>
+        <arg name="input/rois7" value="$(var input/camera7/rois)"/>
+        <arg name="input/rois8" value="$(var input/camera8/rois)"/>
+        <arg name="input/camera_info0" value="$(var input/camera0/info)"/>
+        <arg name="input/camera_info1" value="$(var input/camera1/info)"/>
+        <arg name="input/camera_info2" value="$(var input/camera2/info)"/>
+        <arg name="input/camera_info3" value="$(var input/camera3/info)"/>
+        <arg name="input/camera_info4" value="$(var input/camera4/info)"/>
+        <arg name="input/camera_info5" value="$(var input/camera5/info)"/>
+        <arg name="input/camera_info6" value="$(var input/camera6/info)"/>
+        <arg name="input/camera_info7" value="$(var input/camera7/info)"/>
+        <arg name="input/camera_info8" value="$(var input/camera8/info)"/>
+        <arg name="input/image0" value="$(var input/camera0/image)"/>
+        <arg name="input/image1" value="$(var input/camera1/image)"/>
+        <arg name="input/image2" value="$(var input/camera2/image)"/>
+        <arg name="input/image3" value="$(var input/camera3/image)"/>
+        <arg name="input/image4" value="$(var input/camera4/image)"/>
+        <arg name="input/image5" value="$(var input/camera5/image)"/>
+        <arg name="input/image6" value="$(var input/camera6/image)"/>
+        <arg name="input/image7" value="$(var input/camera7/image)"/>
+        <arg name="input/image8" value="$(var input/camera8/image)"/>
+        <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
+        <arg name="input/objects" value="$(var tracker_based_detector/output/objects_raw)"/>
+        <arg name="output/objects" value="$(var tracker_based_detector/output/objects)"/>
+        <arg name="param_path" value="$(var roi_detected_object_fusion_dbt_param_path)"/>
+      </include>
+    </group>
   </group>
 
   <group if="$(var switch/detector/camera_vru_detector)">

--- a/tier4_universe_launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/tier4_universe_launch/tier4_perception_launch/launch/perception.launch.xml
@@ -14,6 +14,7 @@
   <arg name="object_recognition_detection_roi_cluster_fusion_param_path"/>
   <arg name="object_recognition_detection_irregular_object_detector_param_path"/>
   <arg name="object_recognition_detection_roi_detected_object_fusion_param_path"/>
+  <arg name="object_recognition_detection_roi_detected_object_fusion_dbt_param_path" default=""/>
   <arg name="object_recognition_detection_near_range_camera_vru_param_path"/>
   <arg name="object_recognition_detection_pointpainting_fusion_common_param_path"/>
   <arg name="object_recognition_detection_lidar_model_param_path"/>
@@ -309,6 +310,7 @@
           <arg name="roi_cluster_fusion_param_path" value="$(var object_recognition_detection_roi_cluster_fusion_param_path)"/>
           <arg name="irregular_object_detector_param_path" value="$(var object_recognition_detection_irregular_object_detector_param_path)"/>
           <arg name="roi_detected_object_fusion_param_path" value="$(var object_recognition_detection_roi_detected_object_fusion_param_path)"/>
+          <arg name="roi_detected_object_fusion_dbt_param_path" value="$(var object_recognition_detection_roi_detected_object_fusion_dbt_param_path)"/>
           <arg name="pointpainting_fusion_common_param_path" value="$(var object_recognition_detection_pointpainting_fusion_common_param_path)"/>
           <arg name="lidar_model_param_path" value="$(var object_recognition_detection_lidar_model_param_path)"/>
           <arg name="euclidean_param_path" value="$(var object_recognition_detection_euclidean_cluster_param_path)"/>


### PR DESCRIPTION
## Description

Add a separate `roi_detected_object_fusion` step for `detection_by_tracker` (DBT) objects in the detection pipeline. This filters phantom detections, particularly pedestrians that originate from the tracker feedback loop.

### Problem

In the existing pipeline, the output of `detection_by_tracker` was fed directly into the merger/tracker without any camera validation.Once a momentary false-positive tracker was created for a static object misclassified as a pedestrian, `detection_by_tracker` would continuously find the point cloud cluster at that position and re-publish it as a pedestrian detection. Then `detection_by_tracker` would find the point cloud cluster at that position and re-publish it as a pedestrian detection. Since the DBT channel's `can_spawn_new_tracker`([link](https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml#L97)) is `false` but it can still update existing trackers with a default existence probability of 0.75, the tracker's total existence probability stays above the expiry threshold indefinitely, effectively living forever through the feedback mechanism.

https://github.com/user-attachments/assets/6dca0cdd-c6fb-4ed2-b683-8784febf8953

### Solution

A `roi_detected_object_fusion` node is inserted in detection.launch.xml between the `detection_by_tracker` node output and all downstream consumers (both multi-channel tracker and merged-mode merger). The DBT node now outputs to an intermediate topic (detection_by_tracker/unfiltered/objects), which is validated against camera ROIs before being published to the original topic (detection_by_tracker/objects).

A dedicated parameter file (roi_detected_object_fusion_dbt.param.yaml) is used with stricter thresholds for PEDESTRIAN:

- passthrough_lower_bound_probability_threshold: 1.0 → all DBT pedestrians must be confirmed by camera ROI (no passthrough)
- trust_distance: 70.0m validation range

https://github.com/user-attachments/assets/6b7b02b1-7273-40c1-b0f4-5318617887c9

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
