### PR TITLE
refactor(component_state_monitor): replace topic state monitor by control_exe_node timeout

### DIFF
--- a/autoware_launch/config/system/component_state_monitor/topics.yaml
+++ b/autoware_launch/config/system/component_state_monitor/topics.yaml
@@ -89,19 +89,6 @@
     error_rate: 0.0
     timeout: 0.0
 
-- module: planning
-  mode: [online, logging_simulation, planning_simulation]
-  type: autonomous
-  args:
-    node_name_suffix: scenario_planning_trajectory
-    topic: /planning/trajectory
-    topic_type: autoware_planning_msgs/msg/Trajectory
-    best_effort: false
-    transient_local: false
-    warn_rate: 5.0
-    error_rate: 1.0
-    timeout: 1.0
-
 - module: control
   mode: [online, logging_simulation, planning_simulation]
   type: autonomous

--- a/autoware_launch/config/system/diagnostics/autoware-carla.yaml
+++ b/autoware_launch/config/system/diagnostics/autoware-carla.yaml
@@ -130,17 +130,11 @@ units:
       - type: and
         list:
           - { type: link, link: /autoware/planning/topic_rate_check/route }
-          - { type: link, link: /autoware/planning/topic_rate_check/trajectory }
           - { type: link, link: /autoware/planning/trajectory_validation }
 
   - path: /autoware/planning/topic_rate_check/route
     type: diag
     node: topic_state_monitor_mission_planning_route
-    name: planning_topic_status
-
-  - path: /autoware/planning/topic_rate_check/trajectory
-    type: diag
-    node: topic_state_monitor_scenario_planning_trajectory
     name: planning_topic_status
 
   - path: /autoware/planning/trajectory_validation

--- a/autoware_launch/config/system/diagnostics/control.yaml
+++ b/autoware_launch/config/system/diagnostics/control.yaml
@@ -8,6 +8,7 @@ units:
       - { type: link, link: /autoware/control/emergency_braking }
       - { type: link, link: /autoware/control/performance_monitoring/lane_departure }
       - { type: link, link: /autoware/control/performance_monitoring/control_state }
+      - { type: link, link: /autoware/control/incoming_message_timeout }
 
   - path: /autoware/control/node_alive_monitoring/command_gate
     type: or
@@ -71,3 +72,8 @@ units:
     type: diag
     node: external_cmd_converter
     name: remote_control_topic_status
+
+  - path: /autoware/control/incoming_message_timeout
+    type: diag
+    node: controller_node_exe
+    name: incoming_message_timeout

--- a/autoware_launch/config/system/diagnostics/planning.yaml
+++ b/autoware_launch/config/system/diagnostics/planning.yaml
@@ -7,7 +7,6 @@ units:
       - type: and
         list:
           - { type: link, link: /autoware/planning/topic_rate_check/route }
-          - { type: link, link: /autoware/planning/topic_rate_check/trajectory }
           - { type: link, link: /autoware/planning/trajectory_validation }
 
   - path: /autoware/planning/trajectory_validation
@@ -33,11 +32,6 @@ units:
   - path: /autoware/planning/topic_rate_check/route
     type: diag
     node: topic_state_monitor_mission_planning_route
-    name: planning_topic_status
-
-  - path: /autoware/planning/topic_rate_check/trajectory
-    type: diag
-    node: topic_state_monitor_scenario_planning_trajectory
     name: planning_topic_status
 
   - path: /autoware/planning/trajectory_validation/finite


### PR DESCRIPTION
## Description

Remove `topic_state_monitor`-based diagnostic entries that are now redundant, because `trajectory_follower_node` internally monitors its input message timeouts (see autowarefoundation/autoware_universe#12082).

The following `topic_state_monitor` entries are removed from `tier4_diagnostics` config:

| Domain | Removed topic_state_monitor | Reason |
|---|---|---|
| planning | `trajectory` | Monitored as trajectory input by trajectory_follower_node |

A new diagnostic entry `/autoware/control//incoming_message_timeout` is added to `control.yaml`, which aggregates the `trajectory_follower_node`'s `incoming_message_timeout` diagnostics.


## How was this PR tested?

Setup before launch
```bash
cd /path/to/autoware
source install/setup.bash

cd /path/to/autoware/src/launcher/autoware_launch
gh pr checkout 1784 --repo autowarefoundation/autoware_launch
```

Launch Autoware with PSim.
```bash
source ~/autoware/install/setup.bash
ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=autoware_sample_vehicle sensor_model:=autoware_sample_sensor_kit
```

Run `converter_node` from `diagnostic_graph_utils` package.
```bash
ros2 run autoware_diagnostic_graph_utils converter_node
```

Run `rqt_runtime_monitor`
```
 ros2 run rqt_runtime_monitor rqt_runtime_monitor --ros-args -r diagnostics:=diagnostics_array
```

You'll find that `/autoware/control//incoming_message_timeout` is defined.
<img width="1282" height="359" alt="image" src="https://github.com/user-attachments/assets/ec726a2a-2510-4964-a445-14bb72520ac8" />


## Notes for reviewers

Evaluator worked fine after merging this change.
https://evaluation.tier4.jp/evaluation/reports/f4b62541-3aef-5f8f-a3c0-824090a5d513?project_id=autoware_dev

## Effects on system behavior

Some `topic_state_monitor` will not run after this changes.