### PR TITLE
refactor(vehicle): delegate vehicle interface launch to vehicle_launch pkg

### DIFF
--- a/tier4_universe_launch/tier4_vehicle_launch/launch/vehicle.launch.xml
+++ b/tier4_universe_launch/tier4_vehicle_launch/launch/vehicle.launch.xml
@@ -21,12 +21,11 @@
     </node>
   </group>
 
-  <!-- vehicle interface -->
-  <group if="$(var launch_vehicle_interface)">
-    <include file="$(var vehicle_launch_pkg)/launch/vehicle_interface.launch.xml">
-      <arg name="vehicle_id" value="$(var vehicle_id)"/>
-      <arg name="raw_vehicle_cmd_converter_param_path" value="$(var raw_vehicle_cmd_converter_param_path)"/>
-      <arg name="initial_engage_state" value="$(var initial_engage_state)"/>
-    </include>
-  </group>
+  <!-- vehicle -->
+  <include file="$(var vehicle_launch_pkg)/launch/vehicle.launch.xml">
+    <arg name="vehicle_id" value="$(var vehicle_id)"/>
+    <arg name="raw_vehicle_cmd_converter_param_path" value="$(var raw_vehicle_cmd_converter_param_path)"/>
+    <arg name="initial_engage_state" value="$(var initial_engage_state)"/>
+    <arg name="launch_vehicle_interface" value="$(var launch_vehicle_interface)"/>
+  </include>
 </launch>

--- a/tier4_universe_launch/tier4_vehicle_launch/launch/vehicle.launch.xml
+++ b/tier4_universe_launch/tier4_vehicle_launch/launch/vehicle.launch.xml
@@ -2,6 +2,7 @@
 <launch>
   <arg name="use_sim_time" default="false"/>
   <arg name="launch_vehicle_interface"/>
+  <arg name="vehicle_launch_mode" default="vehicle_interface" description="vehicle: delegate to vehicle package's vehicle.launch.xml. vehicle_interface: include vehicle_interface.launch.xml here (legacy)."/>
   <arg name="vehicle_model" description="vehicle model name"/>
   <arg name="sensor_model" description="sensor model name"/>
   <arg name="vehicle_id" default="$(env VEHICLE_ID default)" description="vehicle specific ID"/>
@@ -21,11 +22,23 @@
     </node>
   </group>
 
-  <!-- vehicle -->
-  <include file="$(var vehicle_launch_pkg)/launch/vehicle.launch.xml">
-    <arg name="vehicle_id" value="$(var vehicle_id)"/>
-    <arg name="raw_vehicle_cmd_converter_param_path" value="$(var raw_vehicle_cmd_converter_param_path)"/>
-    <arg name="initial_engage_state" value="$(var initial_engage_state)"/>
-    <arg name="launch_vehicle_interface" value="$(var launch_vehicle_interface)"/>
-  </include>
+  <!-- vehicle: delegate to vehicle package's vehicle.launch.xml -->
+  <group if="$(eval '&quot;$(var vehicle_launch_mode)&quot;==&quot;vehicle&quot;')">
+    <include file="$(var vehicle_launch_pkg)/launch/vehicle.launch.xml">
+      <arg name="vehicle_id" value="$(var vehicle_id)"/>
+      <arg name="raw_vehicle_cmd_converter_param_path" value="$(var raw_vehicle_cmd_converter_param_path)"/>
+      <arg name="initial_engage_state" value="$(var initial_engage_state)"/>
+      <arg name="launch_vehicle_interface" value="$(var launch_vehicle_interface)"/>
+    </include>
+  </group>
+  <!-- vehicle_interface: legacy behavior (include vehicle_interface.launch.xml here) -->
+  <group if="$(eval '&quot;$(var vehicle_launch_mode)&quot;==&quot;vehicle_interface&quot;')">
+    <group if="$(var launch_vehicle_interface)">
+      <include file="$(var vehicle_launch_pkg)/launch/vehicle_interface.launch.xml">
+        <arg name="vehicle_id" value="$(var vehicle_id)"/>
+        <arg name="raw_vehicle_cmd_converter_param_path" value="$(var raw_vehicle_cmd_converter_param_path)"/>
+        <arg name="initial_engage_state" value="$(var initial_engage_state)"/>
+      </include>
+    </group>
+  </group>
 </launch>


### PR DESCRIPTION
## Description

Adds a string argument **`vehicle_launch_mode`** to `tier4_vehicle_launch`'s `vehicle.launch.xml` to choose how vehicle-related launch is done.

| Value | Behavior |
|-------|----------|
| **`vehicle_interface`** (default) | Legacy: this launch file includes `vehicle_interface.launch.xml` when `launch_vehicle_interface` is true. |
| **`vehicle`** | Includes the vehicle package's `vehicle.launch.xml` and passes `launch_vehicle_interface` (and other args). The vehicle package decides whether to start vehicle_interface and can run vehicle-specific logic (e.g. SteeringReport → JointState for articulated vehicles) with or without it. |

This enables **launching vehicle-specific functionality without vehicle_interface**, which is useful for articulated vehicles and especially for **simulation**, where vehicle_interface is usually not needed.

![launch_structure](https://github.com/user-attachments/assets/823cad58-4f8a-403e-9829-eb006705afba)

## How was this PR tested?

- `vehicle_launch_mode="vehicle_interface"`: behavior matches the previous implementation.
- `vehicle_launch_mode="vehicle"`: vehicle package's `vehicle.launch.xml` is included and receives the intended arguments.

## Notes for reviewers

None.

## Effects on system behavior

- **Backward compatible:** Default is `vehicle_interface`; existing callers and vehicle packages require no change.
- **Opt-in:** Set `vehicle_launch_mode="vehicle"` to use a vehicle package's `vehicle.launch.xml`. That package must provide `launch/vehicle.launch.xml` and handle `launch_vehicle_interface` as needed.
