### PR TITLE
feat: add parameters to support get_selected_lanelet2_map interface

### DIFF
--- a/autoware_launch/config/map/lanelet2_map_loader.param.yaml
+++ b/autoware_launch/config/map/lanelet2_map_loader.param.yaml
@@ -4,3 +4,5 @@
     center_line_resolution: 5.0                 # [m]
     use_waypoints: true                         # "centerline" in the Lanelet2 map will be used as a "waypoints" tag.
     lanelet2_map_path: $(var lanelet2_map_path) # The lanelet2 map path
+    enable_selected_map_loading: true          # expose service/get_selected_lanelet2_map and publish cell metadata
+    metadata_file_path: $(var lanelet2_map_metadata_path) # path to lanelet2_map_metadata.yaml; if empty or missing, bboxes are computed from map points

--- a/autoware_launch/config/map/lanelet2_map_loader.param.yaml
+++ b/autoware_launch/config/map/lanelet2_map_loader.param.yaml
@@ -17,5 +17,5 @@
     center_line_resolution: 5.0                 # [m]
     use_waypoints: true                         # "centerline" in the Lanelet2 map will be used as a "waypoints" tag.
     lanelet2_map_path: $(var lanelet2_map_path) # Path to a lanelet2 .osm map file, or a directory containing .osm files
-    enable_selected_map_loading: true           # expose service/get_selected_lanelet2_map and publish cell metadata
+    enable_selected_map_loading: false          # expose service/get_selected_lanelet2_map and publish cell metadata
     lanelet2_map_metadata_path: $(var lanelet2_map_metadata_path) # path to lanelet2_map_metadata.yaml; if empty or missing, bboxes are computed from map points

--- a/autoware_launch/config/map/lanelet2_map_loader.param.yaml
+++ b/autoware_launch/config/map/lanelet2_map_loader.param.yaml
@@ -17,3 +17,5 @@
     center_line_resolution: 5.0                 # [m]
     use_waypoints: true                         # "centerline" in the Lanelet2 map will be used as a "waypoints" tag.
     lanelet2_map_path: $(var lanelet2_map_path) # Path to a lanelet2 .osm map file, or a directory containing .osm files
+    enable_selected_map_loading: true           # expose service/get_selected_lanelet2_map and publish cell metadata
+    metadata_file_path: $(var lanelet2_map_metadata_path) # path to lanelet2_map_metadata.yaml; if empty or missing, bboxes are computed from map points

--- a/autoware_launch/config/map/lanelet2_map_loader.param.yaml
+++ b/autoware_launch/config/map/lanelet2_map_loader.param.yaml
@@ -18,4 +18,4 @@
     use_waypoints: true                         # "centerline" in the Lanelet2 map will be used as a "waypoints" tag.
     lanelet2_map_path: $(var lanelet2_map_path) # Path to a lanelet2 .osm map file, or a directory containing .osm files
     enable_selected_map_loading: true           # expose service/get_selected_lanelet2_map and publish cell metadata
-    metadata_file_path: $(var lanelet2_map_metadata_path) # path to lanelet2_map_metadata.yaml; if empty or missing, bboxes are computed from map points
+    lanelet2_map_metadata_path: $(var lanelet2_map_metadata_path) # path to lanelet2_map_metadata.yaml; if empty or missing, bboxes are computed from map points

--- a/autoware_launch/launch/components/tier4_map_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_map_component.launch.xml
@@ -4,6 +4,7 @@
     <arg name="pointcloud_map_path" value="$(var map_path)/$(var pointcloud_map_file)"/>
     <arg name="pointcloud_map_metadata_path" value="$(var map_path)/pointcloud_map_metadata.yaml"/>
     <arg name="lanelet2_map_path" value="$(var map_path)/$(var lanelet2_map_file)"/>
+    <arg name="lanelet2_map_metadata_path" value="$(var map_path)/lanelet2_map_metadata.yaml"/>
     <arg name="map_projector_info_path" value="$(var map_path)/map_projector_info.yaml"/>
 
     <arg name="pointcloud_map_loader_param_path" value="$(find-pkg-share autoware_launch)/config/map/pointcloud_map_loader.param.yaml"/>

--- a/tier4_universe_launch/tier4_map_launch/launch/map.launch.xml
+++ b/tier4_universe_launch/tier4_map_launch/launch/map.launch.xml
@@ -3,6 +3,7 @@
   <arg name="pointcloud_map_path"/>
   <arg name="pointcloud_map_metadata_path"/>
   <arg name="lanelet2_map_path"/>
+  <arg name="lanelet2_map_metadata_path"/>
   <arg name="map_projector_info_path"/>
 
   <!-- Parameter files -->
@@ -34,7 +35,10 @@
       <composable_node pkg="autoware_map_loader" plugin="autoware::map_loader::Lanelet2MapLoaderNode" name="lanelet2_map_loader">
         <param from="$(var lanelet2_map_loader_param_path)"/>
         <param name="lanelet2_map_path" value="$(var lanelet2_map_path)"/>
+        <param name="lanelet2_map_metadata_path" value="$(var lanelet2_map_metadata_path)"/>
         <remap from="output/lanelet2_map" to="vector_map"/>
+        <remap from="output/lanelet2_map_metadata" to="/map/lanelet2_map_metadata"/>
+        <remap from="service/get_selected_lanelet2_map" to="/map/get_selected_lanelet2_map"/>
       </composable_node>
 
       <composable_node pkg="autoware_lanelet2_map_visualizer" plugin="autoware::lanelet2_map_visualizer::Lanelet2MapVisualizationNode" name="lanelet2_map_visualization">

--- a/tier4_universe_launch/tier4_map_launch/launch/map.launch.xml
+++ b/tier4_universe_launch/tier4_map_launch/launch/map.launch.xml
@@ -3,6 +3,7 @@
   <arg name="pointcloud_map_path"/>
   <arg name="pointcloud_map_metadata_path"/>
   <arg name="lanelet2_map_path"/>
+  <arg name="lanelet2_map_metadata_path"/>
   <arg name="map_projector_info_path"/>
 
   <!-- Parameter files -->
@@ -32,6 +33,8 @@
       <composable_node pkg="autoware_map_loader" plugin="autoware::map_loader::Lanelet2MapLoaderNode" name="lanelet2_map_loader">
         <param from="$(var lanelet2_map_loader_param_path)" allow_substs="true"/>
         <remap from="output/lanelet2_map" to="vector_map"/>
+        <remap from="output/lanelet2_map_metadata" to="/map/lanelet2_map_metadata"/>
+        <remap from="service/get_selected_lanelet2_map" to="/map/get_selected_lanelet2_map"/>
       </composable_node>
 
       <composable_node pkg="autoware_lanelet2_map_visualizer" plugin="autoware::lanelet2_map_visualizer::Lanelet2MapVisualizationNode" name="lanelet2_map_visualization">

--- a/tier4_universe_launch/tier4_map_launch/launch/map.launch.xml
+++ b/tier4_universe_launch/tier4_map_launch/launch/map.launch.xml
@@ -33,8 +33,8 @@
       <composable_node pkg="autoware_map_loader" plugin="autoware::map_loader::Lanelet2MapLoaderNode" name="lanelet2_map_loader">
         <param from="$(var lanelet2_map_loader_param_path)" allow_substs="true"/>
         <remap from="output/lanelet2_map" to="vector_map"/>
-        <remap from="output/lanelet2_map_metadata" to="/map/lanelet2_map_metadata"/>
-        <remap from="service/get_selected_lanelet2_map" to="/map/get_selected_lanelet2_map"/>
+        <remap from="output/lanelet2_map_metadata" to="/map/vector_map_metadata"/>
+        <remap from="service/get_selected_lanelet2_map" to="/map/get_selected_vector_map"/>
       </composable_node>
 
       <composable_node pkg="autoware_lanelet2_map_visualizer" plugin="autoware::lanelet2_map_visualizer::Lanelet2MapVisualizationNode" name="lanelet2_map_visualization">


### PR DESCRIPTION
## Description
This must be merged with https://github.com/autowarefoundation/autoware_core/pull/889

This PR wires up the launcher side for the get_selected_lanelet2_map service introduced in autoware_map_loader. When enable_selected_map_loading is true, the node reads cell bounding box metadata from lanelet2_map_metadata.yaml (or computes them from the map itself) and exposes a service that returns only the map primitives within a requested region — enabling differential map loading for large-scale deployments.

### Notes
lanelet2_map_metadata.yaml is optional; if missing, the node falls back to computing bounding boxes from the map data.
No behavior change when enable_selected_map_loading is set to false.

## Related Link
https://github.com/autowarefoundation/autoware_core/issues/887


## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
