### PR TITLE
fix(simulator launch): add missing paramaters related to TLR

### DIFF
--- a/autoware_launch/launch/components/tier4_simulator_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_simulator_component.launch.xml
@@ -70,8 +70,8 @@
       name="each_traffic_light_map_based_detector_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_map_based_detector/TRAFFIC_LIGHT_RECOGNITION_CAMERA_NAMESPACE_traffic_light_map_based_detector.param.yaml"
     />
-    <arg name="traffic_light_recognition/classification/pedestrian/classifier_type" description="0=HSVFilter, 1=CNN, 2=LampRecognizer"/>
-    <arg name="traffic_light_recognition/classification/car/classifier_type" description="0=HSVFilter, 1=CNN, 2=LampRecognizer"/>
+    <arg name="traffic_light_recognition/classification/pedestrian/classifier_type" default="1" description="0=HSVFilter, 1=CNN, 2=LampRecognizer"/>
+    <arg name="traffic_light_recognition/classification/car/classifier_type" default="1" description="0=HSVFilter, 1=CNN, 2=LampRecognizer"/>
     <arg
       name="traffic_light_fine_detector_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_fine_detector/traffic_light_fine_detector.param.yaml"

--- a/autoware_launch/launch/components/tier4_simulator_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_simulator_component.launch.xml
@@ -16,6 +16,8 @@
   <arg name="raw_vehicle_cmd_converter_param_path"/>
   <arg name="occupancy_grid_map_updater" default="binary_bayes_filter" description="options: binary_bayes_filter"/>
   <arg name="use_pointcloud_container" default="true" description="use point cloud container for simulator perception modules"/>
+  <arg name="traffic_light_recognition/classification/pedestrian/classifier_type" default="1" description="0=HSVFilter, 1=CNN, 2=LampRecognizer"/>
+  <arg name="traffic_light_recognition/classification/car/classifier_type" default="1" description="0=HSVFilter, 1=CNN, 2=LampRecognizer"/>
 
   <include file="$(find-pkg-share tier4_simulator_launch)/launch/simulator.launch.xml">
     <arg name="launch_dummy_perception" value="$(var launch_dummy_perception)"/>
@@ -70,8 +72,8 @@
       name="each_traffic_light_map_based_detector_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_map_based_detector/TRAFFIC_LIGHT_RECOGNITION_CAMERA_NAMESPACE_traffic_light_map_based_detector.param.yaml"
     />
-    <arg name="traffic_light_recognition/classification/pedestrian/classifier_type" default="1" description="0=HSVFilter, 1=CNN, 2=LampRecognizer"/>
-    <arg name="traffic_light_recognition/classification/car/classifier_type" default="1" description="0=HSVFilter, 1=CNN, 2=LampRecognizer"/>
+    <arg name="traffic_light_recognition/classification/pedestrian/classifier_type" value="$(var traffic_light_recognition/classification/pedestrian/classifier_type)"/>
+    <arg name="traffic_light_recognition/classification/car/classifier_type" value="$(var traffic_light_recognition/classification/car/classifier_type)"/>
     <arg
       name="traffic_light_fine_detector_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_fine_detector/traffic_light_fine_detector.param.yaml"

--- a/autoware_launch/launch/components/tier4_simulator_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_simulator_component.launch.xml
@@ -70,6 +70,8 @@
       name="each_traffic_light_map_based_detector_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_map_based_detector/TRAFFIC_LIGHT_RECOGNITION_CAMERA_NAMESPACE_traffic_light_map_based_detector.param.yaml"
     />
+    <arg name="traffic_light_recognition/classification/pedestrian/classifier_type" description="0=HSVFilter, 1=CNN, 2=LampRecognizer"/>
+    <arg name="traffic_light_recognition/classification/car/classifier_type" description="0=HSVFilter, 1=CNN, 2=LampRecognizer"/>
     <arg
       name="traffic_light_fine_detector_param_path"
       value="$(find-pkg-share autoware_launch)/config/perception/traffic_light_recognition/traffic_light_fine_detector/traffic_light_fine_detector.param.yaml"

--- a/tier4_universe_launch/tier4_simulator_launch/launch/simulator.launch.xml
+++ b/tier4_universe_launch/tier4_simulator_launch/launch/simulator.launch.xml
@@ -15,6 +15,28 @@
   <arg name="pose_initializer_param_path"/>
   <arg name="twist2accel_param_path"/>
 
+  <arg name="traffic_light_recognition/classification/pedestrian/classifier_type"/>
+  <arg name="traffic_light_recognition/classification/car/classifier_type"/>
+  <arg
+    name="traffic_light_car_classifier_model"
+    default="traffic_light_classifier_mobilenetv2_batch_6.onnx"
+    if="$(eval &quot;'$(var traffic_light_recognition/classification/car/classifier_type)' == '1'&quot;)"
+  />
+  <arg
+    name="traffic_light_car_classifier_model"
+    default="traffic_light_lamp_recognizer_comlops.onnx"
+    if="$(eval &quot;'$(var traffic_light_recognition/classification/car/classifier_type)' == '2'&quot;)"
+  />
+  <arg
+    name="traffic_light_ped_classifier_model"
+    default="ped_traffic_light_classifier_mobilenetv2_batch_6.onnx"
+    if="$(eval &quot;'$(var traffic_light_recognition/classification/pedestrian/classifier_type)' == '1'&quot;)"
+  />
+  <arg
+    name="traffic_light_ped_classifier_model"
+    default="traffic_light_lamp_recognizer_comlops.onnx"
+    if="$(eval &quot;'$(var traffic_light_recognition/classification/pedestrian/classifier_type)' == '2'&quot;)"
+  />
   <arg name="each_traffic_light_map_based_detector_param_path"/>
   <arg name="traffic_light_fine_detector_param_path"/>
   <arg name="yolox_traffic_light_detector_param_path"/>
@@ -175,10 +197,13 @@
           <arg name="whole_image_detection/yolox_roi_label_remap_path" value="$(var traffic_light_recognition/whole_image_detection/yolox_roi_label_remap_path)"/>
           <arg name="fine_detection/model_path" value="$(env HOME)/autoware_data/traffic_light_fine_detector/tlr_car_ped_yolox_s_batch_6.onnx"/>
           <arg name="fine_detection/label_path" value="$(env HOME)/autoware_data/traffic_light_fine_detector/tlr_labels.txt"/>
-          <arg name="classification/car/model_path" value="$(env HOME)/autoware_data/traffic_light_classifier/traffic_light_classifier_mobilenetv2_batch_6.onnx"/>
+          <arg name="classification/car/model_path" value="$(env HOME)/autoware_data/traffic_light_classifier/$(var traffic_light_car_classifier_model)"/>
           <arg name="classification/car/label_path" value="$(env HOME)/autoware_data/traffic_light_classifier/lamp_labels.txt"/>
-          <arg name="classification/pedestrian/model_path" value="$(env HOME)/autoware_data/traffic_light_classifier/ped_traffic_light_classifier_mobilenetv2_batch_6.onnx"/>
+          <arg name="classification/pedestrian/model_path" value="$(env HOME)/autoware_data/traffic_light_classifier/$(var traffic_light_ped_classifier_model)"/>
           <arg name="classification/pedestrian/label_path" value="$(env HOME)/autoware_data/traffic_light_classifier/lamp_labels_ped.txt"/>
+          <arg name="classification/lamp_recognizer_ml_param_path" value="$(env HOME)/autoware_data/traffic_light_classifier/lamp_recognizer_ml.param.yaml"/>
+          <arg name="classification/pedestrian/classifier_type" value="$(var traffic_light_recognition/classification/pedestrian/classifier_type)"/>
+          <arg name="classification/car/classifier_type" value="$(var traffic_light_recognition/classification/car/classifier_type)"/>
         </include>
       </group>
     </group>

--- a/tier4_universe_launch/tier4_simulator_launch/launch/simulator.launch.xml
+++ b/tier4_universe_launch/tier4_simulator_launch/launch/simulator.launch.xml
@@ -15,8 +15,8 @@
   <arg name="pose_initializer_param_path"/>
   <arg name="twist2accel_param_path"/>
 
-  <arg name="traffic_light_recognition/classification/pedestrian/classifier_type"/>
-  <arg name="traffic_light_recognition/classification/car/classifier_type"/>
+  <arg name="traffic_light_recognition/classification/pedestrian/classifier_type" default="1" description="0=HSVFilter, 1=CNN, 2=LampRecognizer"/>
+  <arg name="traffic_light_recognition/classification/car/classifier_type" default="1" description="0=HSVFilter, 1=CNN, 2=LampRecognizer"/>
   <arg
     name="traffic_light_car_classifier_model"
     default="traffic_light_classifier_mobilenetv2_batch_6.onnx"

--- a/tier4_universe_launch/tier4_simulator_launch/launch/simulator.launch.xml
+++ b/tier4_universe_launch/tier4_simulator_launch/launch/simulator.launch.xml
@@ -1,5 +1,6 @@
 <launch>
   <!-- Parameter files -->
+  <!-- cspell: ignore semseg, comlops -->
   <arg name="launch_fault_injection" default="false"/>
   <arg name="fault_injection_param_path"/>
   <arg name="fault_injection_input_diagnostics" default="/diagnostics"/>


### PR DESCRIPTION
## Description

- Add missing parameters related to `traffic_light_recognition` in `simulator.launch.xml` 
- Related PR: 
  - https://github.com/autowarefoundation/autoware_universe/pull/12302
  - https://github.com/autowarefoundation/autoware_launch/pull/1807

## How was this PR tested?

- Run `planning_simulator.launch.xml` with option enable_traffic_light:=true

```
ros2 launch autoware_launch planning_simulator.launch.xml map_path:=/home/dainguyen/data/maps/odaiba_rinkai_1155-20250507083633622467/ is_simulation:=true vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit perception/enable_object_recognition:=false perception/enable_traffic_light:=true scenario_simulation:=true
```
- Confirm traffic_light related nodes are executed together with autoware without error from launch side:

```
~/autoware$ ros2 node list | grep traffic
WARNING: Be aware that are nodes in the graph that share an exact name, this can have unintended side effects.
/perception/traffic_light_recognition/camera6/classification/traffic_light_occlusion_predictor
/perception/traffic_light_recognition/camera6/classification/traffic_light_occlusion_predictor
/perception/traffic_light_recognition/camera6/classification/transform_listener_impl_5f3bf753fc88
/perception/traffic_light_recognition/camera6/classification/transform_listener_impl_61acdef90c88
/perception/traffic_light_recognition/camera7/classification/traffic_light_occlusion_predictor
/perception/traffic_light_recognition/camera7/classification/traffic_light_occlusion_predictor
/perception/traffic_light_recognition/camera7/classification/transform_listener_impl_5a6ad2acfc88
/perception/traffic_light_recognition/camera7/classification/transform_listener_impl_608d285e4c88
/perception/traffic_light_recognition/crosswalk_traffic_light_estimator
/perception/traffic_light_recognition/crosswalk_traffic_light_estimator
/perception/traffic_light_recognition/traffic_light_arbiter
/perception/traffic_light_recognition/traffic_light_arbiter
/perception/traffic_light_recognition/traffic_light_map_visualizer
/perception/traffic_light_recognition/traffic_light_map_visualizer
/perception/traffic_light_recognition/traffic_light_multi_camera_fusion
/perception/traffic_light_recognition/traffic_light_multi_camera_fusion

```

## Notes for reviewers

None.

## Effects on system behavior

None.
