### PR TITLE
fix(tier4_map_launch): add `allow_substs="true"` to map launcher parameter including

### DIFF
--- a/tier4_universe_launch/tier4_map_launch/launch/map.launch.xml
+++ b/tier4_universe_launch/tier4_map_launch/launch/map.launch.xml
@@ -21,7 +21,7 @@
 
     <node_container pkg="rclcpp_components" exec="$(var container_type)" name="map_container" namespace="" output="both">
       <composable_node pkg="autoware_map_loader" plugin="autoware::map_loader::PointCloudMapLoaderNode" name="pointcloud_map_loader">
-        <param from="$(var pointcloud_map_loader_param_path)"/>
+        <param from="$(var pointcloud_map_loader_param_path)" allow_substs="true"/>
         <param name="pcd_paths_or_directory" value="[$(var pointcloud_map_path)]"/>
         <param name="pcd_metadata_path" value="$(var pointcloud_map_metadata_path)"/>
         <remap from="output/pointcloud_map" to="pointcloud_map"/>
@@ -32,7 +32,7 @@
       </composable_node>
 
       <composable_node pkg="autoware_map_loader" plugin="autoware::map_loader::Lanelet2MapLoaderNode" name="lanelet2_map_loader">
-        <param from="$(var lanelet2_map_loader_param_path)"/>
+        <param from="$(var lanelet2_map_loader_param_path)" allow_substs="true"/>
         <param name="lanelet2_map_path" value="$(var lanelet2_map_path)"/>
         <remap from="output/lanelet2_map" to="vector_map"/>
       </composable_node>
@@ -43,7 +43,7 @@
       </composable_node>
 
       <composable_node pkg="autoware_map_tf_generator" plugin="autoware::map_tf_generator::VectorMapTFGeneratorNode" name="vector_map_tf_generator">
-        <param from="$(var map_tf_generator_param_path)"/>
+        <param from="$(var map_tf_generator_param_path)" allow_substs="true"/>
       </composable_node>
     </node_container>
 

--- a/tier4_universe_launch/tier4_map_launch/launch/map.launch.xml
+++ b/tier4_universe_launch/tier4_map_launch/launch/map.launch.xml
@@ -22,8 +22,6 @@
     <node_container pkg="rclcpp_components" exec="$(var container_type)" name="map_container" namespace="" output="both">
       <composable_node pkg="autoware_map_loader" plugin="autoware::map_loader::PointCloudMapLoaderNode" name="pointcloud_map_loader">
         <param from="$(var pointcloud_map_loader_param_path)" allow_substs="true"/>
-        <param name="pcd_paths_or_directory" value="[$(var pointcloud_map_path)]"/>
-        <param name="pcd_metadata_path" value="$(var pointcloud_map_metadata_path)"/>
         <remap from="output/pointcloud_map" to="pointcloud_map"/>
         <remap from="output/pointcloud_map_metadata" to="pointcloud_map_metadata"/>
         <remap from="service/get_partial_pcd_map" to="/map/get_partial_pointcloud_map"/>
@@ -33,7 +31,6 @@
 
       <composable_node pkg="autoware_map_loader" plugin="autoware::map_loader::Lanelet2MapLoaderNode" name="lanelet2_map_loader">
         <param from="$(var lanelet2_map_loader_param_path)" allow_substs="true"/>
-        <param name="lanelet2_map_path" value="$(var lanelet2_map_path)"/>
         <remap from="output/lanelet2_map" to="vector_map"/>
       </composable_node>
 
@@ -43,7 +40,7 @@
       </composable_node>
 
       <composable_node pkg="autoware_map_tf_generator" plugin="autoware::map_tf_generator::VectorMapTFGeneratorNode" name="vector_map_tf_generator">
-        <param from="$(var map_tf_generator_param_path)" allow_substs="true"/>
+        <param from="$(var map_tf_generator_param_path)"/>
       </composable_node>
     </node_container>
 


### PR DESCRIPTION
## Description

As `pointcloud_map_loader.param.yaml` (substitutions for `$(var pointcloud_map_loader_param_path)`) itself uses substitutions:

```
/**:
  ros__parameters:
    enable_whole_load: true
    enable_downsampled_whole_load: false
    enable_partial_load: true
    enable_selected_load: false

    # only used when downsample_whole_load enabled
    leaf_size: 3.0 # downsample leaf size [m]
    pcd_paths_or_directory: [$(var pointcloud_map_path)] # Path to the pointcloud map file or directory
    pcd_metadata_path: $(var pointcloud_map_metadata_path) # Path to pointcloud metadata file
```

we need `allow_substs="true"` to activate the substitutions inside the parameter file.
Similar to `lanelet2_map_loader.param.yaml`.

Related link: https://github.com/autowarefoundation/autoware_universe/pull/6250
Perception is already using the same `allow_substs="true"` config.

## How was this PR tested?

Not directly.

This issue was revealed when I was working on semantics improvement of my pre-build launcher resolver tool **roscope** ( https://github.com/paulsohn/roscope/pull/46 ) and by the same tool I've confirmed this patch gives the correct parameters.

## Notes for reviewers

None.

## Effects on system behavior

None, or fix the PCD map loading issue.
