### PR TITLE
fix(tier4_control_launch): add `allow_substs="true"` to control launcher parameter including

### DIFF
--- a/tier4_universe_launch/tier4_control_launch/launch/control.launch.xml
+++ b/tier4_universe_launch/tier4_control_launch/launch/control.launch.xml
@@ -127,7 +127,7 @@
           <remap from="input/engage" to="/autoware/engage"/>
           <remap from="~/service/external_emergency_stop" to="~/external_emergency_stop"/>
           <remap from="~/service/clear_external_emergency_stop" to="~/clear_external_emergency_stop"/>
-          <param from="$(var vehicle_cmd_gate_param_path)"/>
+          <param from="$(var vehicle_cmd_gate_param_path)" allow_substs="true"/>
           <param from="$(var vehicle_param_file)"/>
           <param name="check_external_emergency_heartbeat" value="$(var check_external_emergency_heartbeat)"/>
           <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>

--- a/tier4_universe_launch/tier4_control_launch/launch/control.launch.xml
+++ b/tier4_universe_launch/tier4_control_launch/launch/control.launch.xml
@@ -129,7 +129,6 @@
           <remap from="~/service/clear_external_emergency_stop" to="~/clear_external_emergency_stop"/>
           <param from="$(var vehicle_cmd_gate_param_path)" allow_substs="true"/>
           <param from="$(var vehicle_param_file)"/>
-          <param name="check_external_emergency_heartbeat" value="$(var check_external_emergency_heartbeat)"/>
           <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
         </composable_node>
 


### PR DESCRIPTION
## Description

As `vehicle_cmd_gate.param.yaml` uses substitution:

```
/**:
  ros__parameters:
    update_rate: 10.0
    system_emergency_heartbeat_timeout: 0.5
    use_emergency_handling: true
    check_external_emergency_heartbeat: $(var check_external_emergency_heartbeat)
    # (...)
```

we need `allow_substs="true"` to activate the substitutions inside the parameter file.
We already have many param files for control, so instead of attaching `allow_substs="true"` for every param file reference at once (unlike #1821 , where 2 out of 3 `<param from />` required this) I want to add this attribute for only where it's needed for now, and apply to other files in a separate PR.

Related link: https://github.com/autowarefoundation/autoware_universe/pull/6250
Perception is already using the same `allow_substs="true"` config.

## How was this PR tested?

Not directly.

This issue was revealed when I was working on semantics improvement of my pre-build launcher resolver tool **roscope** ( https://github.com/paulsohn/roscope/pull/46 ) and by the same tool I've confirmed this patch gives the correct parameters.

## Notes for reviewers

None.

## Effects on system behavior

None, or fix `check_external_emergency_heartbeat` substitution skipping.
