### PR TITLE
fix(tier4_perception_launch): add missing dependency

### DIFF
--- a/tier4_universe_launch/tier4_perception_launch/package.xml
+++ b/tier4_universe_launch/tier4_perception_launch/package.xml
@@ -26,6 +26,7 @@
   <exec_depend>autoware_elevation_map_loader</exec_depend>
   <exec_depend>autoware_euclidean_cluster</exec_depend>
   <exec_depend>autoware_ground_segmentation</exec_depend>
+  <exec_depend>autoware_ground_segmentation_cuda</exec_depend>
   <exec_depend>autoware_image_object_locator</exec_depend>
   <exec_depend>autoware_image_projection_based_fusion</exec_depend>
   <exec_depend>autoware_image_transport_decompressor</exec_depend>


### PR DESCRIPTION
## Description
- This PR added missing `autoware_ground_segmentation_cuda` dependency to the `package.xml` file, ensuring that the package will correctly depend on the CUDA-accelerated ground segmentation component.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
