### PR TITLE
feat(behavior_path_side_shift): add drivable area check parameters to prevent lane departure

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/side_shift/side_shift.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/side_shift/side_shift.param.yaml
@@ -7,4 +7,6 @@
       min_shifting_distance: 5.0
       min_shifting_speed: 5.56
       shift_request_time_limit: 1.0
+      drivable_area_check_mode: 1 # 0 = No check, 1 = Only current lane, 2 = Adjacent lanes included
+      min_drivable_area_margin: 0.3
       publish_debug_marker: false


### PR DESCRIPTION
## Description

This PR adds the configuration parameters for the drivable area check (lane departure prevention) feature in the `behavior_path_side_shift` module. This corresponds to the newly implemented feature in the autoware.universe repository. 

Added parameters:
- `drivable_area_check_mode`: 1 # 0 = No check, 1 = Only current lane, 2 = Adjacent lanes included
- `min_drivable_area_margin`: 0.3

## Related Links
- autoware.universe PR: https://github.com/autowarefoundation/autoware.universe/pull/12504