### PR TITLE
feat(autoware_launch): remove MrmSummaryoverlayPlugins 

### DIFF
--- a/autoware_launch/rviz/autoware_test_utils.rviz
+++ b/autoware_launch/rviz/autoware_test_utils.rviz
@@ -283,22 +283,6 @@ Visualization Manager:
               Width: 550
           Enabled: true
           Name: Vehicle
-        - Class: rviz_plugins/MrmSummaryOverlayDisplay
-          Enabled: false
-          Font Size: 10
-          Left: 512
-          Max Letter Num: 100
-          Name: MRM Summary
-          Text Color: 25; 255; 240
-          Top: 64
-          Topic:
-            Depth: 5
-            Durability Policy: Volatile
-            History Policy: Keep Last
-            Reliability Policy: Reliable
-            Value: /system/emergency/hazard_status
-          Value: false
-          Value height offset: 0
       Enabled: true
       Name: System
     - Class: rviz_common/Group
@@ -3326,7 +3310,6 @@ Visualization Manager:
                   Value: true
                 System:
                   Grid: true
-                  MRM Summary: true
                   TF: true
                   Value: false
                   Vehicle:

--- a/autoware_launch/rviz/perception.rviz
+++ b/autoware_launch/rviz/perception.rviz
@@ -3184,7 +3184,6 @@ Visualization Manager:
                   Lanelet2VectorMap: true
                   PointCloudMap: true
                   Value: false
-                MrmSummaryOverlayDisplay: true
                 Perception:
                   ObjectRecognition:
                     Detection:
@@ -3352,7 +3351,6 @@ Visualization Manager:
                 StringStampedOverlayDisplay: true
                 System:
                   Grid: true
-                  MRM Summary: true
                   TF: true
                   Value: false
                   Vehicle:

--- a/autoware_launch/rviz/planning_bev.rviz
+++ b/autoware_launch/rviz/planning_bev.rviz
@@ -39,7 +39,6 @@ Panels:
         - /Debug1/Perception1/RadarFarObjects(white)1/UNKNOWN1
         - /Debug1/Perception1/Detection(yellow)1/UNKNOWN1
         - /Debug1/Planning1
-        - /MrmSummaryOverlayDisplay1
       Splitter Ratio: 0.7641357183456421
     Tree Height: 378
   - Class: rviz_common/Selection


### PR DESCRIPTION
## Description
This removes MRM summary overlay plugins from rviz configs as the plugin was deleted in https://github.com/autowarefoundation/autoware_universe/pull/11376.

## How was this PR tested?

* `ros2 run rviz2 rviz2 -d $(ros2 pkg prefix --share autoware_launch)/rviz/autoware_test_utils.rviz`
* `ros2 run rviz2 rviz2 -d $(ros2 pkg prefix --share autoware_launch)/rviz/perception.rviz`
* `ros2 run rviz2 rviz2 -d $(ros2 pkg prefix --share autoware_launch)/rviz/planning_bev.rviz`

perception.rviz and planning_bev.rviz still fails due to other plugins that are missing regardless of this PR. I would create the follow up PR to fix them. 

## Notes for reviewers

None.

## Effects on system behavior

None.
