### PR TITLE
ci: register map param files for sync-params workflow + sync-params bugfix

### DIFF
--- a/.github/scripts/sync_params.py
+++ b/.github/scripts/sync_params.py
@@ -1237,7 +1237,13 @@ def extract_override_values(
                 f"Override path {_format_path(path)} in '{variant_path}' must be a leaf "
                 "scalar or array of scalars."
             )
-        overrides[path] = copy.deepcopy(value)
+        # Values loaded via ruamel can be CommentedSeq with attached inline comment
+        # metadata. Strip that metadata by materialising plain Python containers,
+        # otherwise comment text can be re-emitted into scalar dumps repeatedly.
+        if isinstance(value, list):
+            overrides[path] = [copy.deepcopy(item) for item in value]
+        else:
+            overrides[path] = copy.deepcopy(value)
     return overrides, override_comments
 
 

--- a/.github/scripts/test_sync_params.py
+++ b/.github/scripts/test_sync_params.py
@@ -626,6 +626,60 @@ perception: []
         )
         self.assertEqual(source_line.index("#"), patched_line.index("#"))
 
+    def test_list_override_comments_do_not_accumulate_across_sync_runs(self) -> None:
+        """List overrides must not carry ruamel comment metadata into dumped values.
+
+        This regression covers a real map-sync case where repeated runs appended
+        another "# Path ..." fragment on each execution.
+        """
+        source_text = dedent(
+            """\
+            /**:
+              ros__parameters:
+                pcd_paths_or_directory: [$(var pcd_paths_or_directory)] # Path to the pointcloud map file or directory
+            """
+        )
+        variant_text = dedent(
+            """\
+            /**:
+              ros__parameters:
+                pcd_paths_or_directory: [$(var pointcloud_map_path)] # {OVERRIDE} Path to the pointcloud map file or directory
+            """
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            variant_path = Path(tmpdir) / "variant.yaml"
+            variant_path.write_text(variant_text, encoding="utf-8")
+
+            overrides, override_comments = extract_override_values(variant_path)
+            override_comment_columns = parse_override_comment_columns_from_variant_text(
+                variant_text
+            )
+
+            once = apply_overrides_to_source_text(source_text, overrides)
+            once = ensure_override_markers_in_text(
+                once, override_comments, override_comment_columns
+            )
+            line_once = next(line for line in once.splitlines() if "pcd_paths_or_directory" in line)
+
+            # Simulate another sync run by extracting from the regenerated variant.
+            variant_path.write_text(once, encoding="utf-8")
+            overrides2, override_comments2 = extract_override_values(variant_path)
+            cols2 = parse_override_comment_columns_from_variant_text(once)
+            twice = apply_overrides_to_source_text(source_text, overrides2)
+            twice = ensure_override_markers_in_text(twice, override_comments2, cols2)
+            line_twice = next(
+                line for line in twice.splitlines() if "pcd_paths_or_directory" in line
+            )
+
+            expected = (
+                "pcd_paths_or_directory: [$(var pointcloud_map_path)] # {OVERRIDE} "
+                "Path to the pointcloud map file or directory"
+            )
+            self.assertIn(expected, line_once)
+            self.assertIn(expected, line_twice)
+            self.assertEqual(line_once, line_twice)
+
     def test_multiple_overrides_applied_correctly_when_earlier_override_changes_line_count(
         self,
     ) -> None:

--- a/.github/sync-params.yaml
+++ b/.github/sync-params.yaml
@@ -124,7 +124,26 @@ perception:
       # Perception/traffic_light_recognition
 
 localization: []
-map: []
+map:
+  - repository: autowarefoundation/autoware_core
+    ref: main
+    files:
+      - source: map/autoware_map_loader/config/lanelet2_map_loader.param.yaml
+        variants:
+          - path: autoware_launch/config/map/lanelet2_map_loader.param.yaml
+      - source: map/autoware_map_loader/config/pointcloud_map_loader.param.yaml
+        variants:
+          - path: autoware_launch/config/map/pointcloud_map_loader.param.yaml
+      - source: map/autoware_map_projection_loader/config/map_projection_loader.param.yaml
+        variants:
+          - path: autoware_launch/config/map/map_projection_loader.param.yaml
+  - repository: autowarefoundation/autoware_universe
+    ref: main
+    files:
+      - source: map/autoware_map_tf_generator/config/map_tf_generator.param.yaml
+        variants:
+          - path: autoware_launch/config/map/map_tf_generator.param.yaml
+
 planning: []
 control: []
 system: []

--- a/autoware_launch/config/map/lanelet2_map_loader.param.yaml
+++ b/autoware_launch/config/map/lanelet2_map_loader.param.yaml
@@ -1,3 +1,10 @@
+# This file is managed by sync-params workflow.
+# Keys marked with '{OVERRIDE}' or '# {OVERRIDE: reason}' are persisted as variant overrides.
+# 'reason' can be any single-line text without braces.
+# To keep local changes, annotate fields with '# {OVERRIDE}' or '# {OVERRIDE: reason}'.
+#
+# Source: https://github.com/autowarefoundation/autoware_core/blob/588765440f691cd06db9e552007a0771f2b7e5f2/map/autoware_map_loader/config/lanelet2_map_loader.param.yaml
+
 /**:
   ros__parameters:
     allow_unsupported_version: true             # flag to load unsupported format_version anyway. If true, just prints warning.

--- a/autoware_launch/config/map/map_projection_loader.param.yaml
+++ b/autoware_launch/config/map/map_projection_loader.param.yaml
@@ -1,3 +1,10 @@
+# This file is managed by sync-params workflow.
+# Keys marked with '{OVERRIDE}' or '# {OVERRIDE: reason}' are persisted as variant overrides.
+# 'reason' can be any single-line text without braces.
+# To keep local changes, annotate fields with '# {OVERRIDE}' or '# {OVERRIDE: reason}'.
+#
+# Source: https://github.com/autowarefoundation/autoware_core/blob/a5563e24e31361e6a8f87a07e34cd2df3290f166/map/autoware_map_projection_loader/config/map_projection_loader.param.yaml
+
 /**:
   ros__parameters:
     map_projector_info_path: $(var map_projector_info_path)

--- a/autoware_launch/config/map/map_tf_generator.param.yaml
+++ b/autoware_launch/config/map/map_tf_generator.param.yaml
@@ -1,3 +1,10 @@
+# This file is managed by sync-params workflow.
+# Keys marked with '{OVERRIDE}' or '# {OVERRIDE: reason}' are persisted as variant overrides.
+# 'reason' can be any single-line text without braces.
+# To keep local changes, annotate fields with '# {OVERRIDE}' or '# {OVERRIDE: reason}'.
+#
+# Source: https://github.com/autowarefoundation/autoware_universe/blob/35615358eb936aab3520bdb8a233b5b52c8529b8/map/autoware_map_tf_generator/config/map_tf_generator.param.yaml
+
 /**:
   ros__parameters:
     map_frame: map

--- a/autoware_launch/config/map/pointcloud_map_loader.param.yaml
+++ b/autoware_launch/config/map/pointcloud_map_loader.param.yaml
@@ -1,3 +1,10 @@
+# This file is managed by sync-params workflow.
+# Keys marked with '{OVERRIDE}' or '# {OVERRIDE: reason}' are persisted as variant overrides.
+# 'reason' can be any single-line text without braces.
+# To keep local changes, annotate fields with '# {OVERRIDE}' or '# {OVERRIDE: reason}'.
+#
+# Source: https://github.com/autowarefoundation/autoware_core/blob/588765440f691cd06db9e552007a0771f2b7e5f2/map/autoware_map_loader/config/pointcloud_map_loader.param.yaml
+
 /**:
   ros__parameters:
     enable_whole_load: true
@@ -7,5 +14,5 @@
 
     # only used when downsample_whole_load enabled
     leaf_size: 3.0 # downsample leaf size [m]
-    pcd_paths_or_directory: [$(var pointcloud_map_path)] # Path to the pointcloud map file or directory
-    pcd_metadata_path: $(var pointcloud_map_metadata_path) # Path to pointcloud metadata file
+    pcd_paths_or_directory: [$(var pointcloud_map_path)] # {OVERRIDE} Path to the pointcloud map file or directory
+    pcd_metadata_path: $(var pointcloud_map_metadata_path) # {OVERRIDE} Path to pointcloud metadata file


### PR DESCRIPTION
## Description

Tracking issue: https://github.com/autowarefoundation/autoware/issues/7048

Sync-params workflow: #1812 

Register map param files with their upstream sources so that param files can be synced (via PR) periodically or by a manual trigger, excluding fields with `{OVERRIDE}` comment marker.

<img width="2062" height="607" alt="image" src="https://github.com/user-attachments/assets/7cd3c1b3-ea27-4912-b3c7-60d558e67c02" />

So sync-params script itself has been patched because of an error. No regression is detected.

## How was this PR tested?

Not available.

## Notes for reviewers

While I briefly identified the corresponding nodes for each param file, I need the reviewer's help to cross-check whether the mapping from the upstream and downstream files (`.github/sync-params.yaml`, under `map` section) are set correctly.

## Effects on system behavior

None expected. Active parameters remain same.
