### PR TITLE
feat(planning): wire data_path through to diffusion_planner

### DIFF
--- a/autoware_launch/config/planning/neural_net_planner/diffusion_planner.param.yaml
+++ b/autoware_launch/config/planning/neural_net_planner/diffusion_planner.param.yaml
@@ -1,8 +1,8 @@
 /**:
   ros__parameters:
     plugins_path: $(find-pkg-share autoware_tensorrt_plugins)/plugins/libautoware_tensorrt_plugins.so
-    onnx_model_path: $(env HOME)/autoware_data/diffusion_planner/v4.0/diffusion_planner.onnx
-    args_path: $(env HOME)/autoware_data/diffusion_planner/v4.0/diffusion_planner.param.json
+    onnx_model_path: $(var data_path)/diffusion_planner/v4.0/diffusion_planner.onnx
+    args_path: $(var data_path)/diffusion_planner/v4.0/diffusion_planner.param.json
     planning_frequency_hz: 10.0
     ignore_neighbors: false
     ignore_unknown_neighbors: true

--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -115,6 +115,7 @@
       <arg name="is_simulation" value="$(var is_simulation)"/>
       <arg name="use_sim_time" value="$(var use_sim_time)"/>
       <arg name="vehicle_model" value="$(var vehicle_model)"/>
+      <arg name="data_path" value="$(var data_path)"/>
     </include>
 
     <!-- Relay node for trajectory topic -->

--- a/autoware_launch/launch/components/tier4_planning_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_planning_component.launch.xml
@@ -7,6 +7,7 @@
   <arg name="use_sim_time" default="false"/>
   <arg name="vehicle_model" default="sample_vehicle"/>
   <arg name="planning_setting" default="rule_based" description="planning setting diffusion_planner / rule_based"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
 
   <!-- Input topic parameters for planning modules -->
   <arg name="planning_input_objects_topic_name" default="/perception/object_recognition/objects"/>
@@ -31,6 +32,7 @@
     <arg name="pointcloud_container_name" value="$(var pointcloud_container_name)"/>
     <arg name="enable_all_modules_auto_mode" value="$(var enable_all_modules_auto_mode)"/>
     <arg name="is_simulation" value="$(var is_simulation)"/>
+    <arg name="data_path" value="$(var data_path)"/>
 
     <!-- Input topic parameters -->
     <arg name="input_objects_topic_name" value="$(var planning_input_objects_topic_name)"/>

--- a/tier4_universe_launch/tier4_planning_launch/launch/learning_based_planning/diffusion_planner.launch.xml
+++ b/tier4_universe_launch/tier4_planning_launch/launch/learning_based_planning/diffusion_planner.launch.xml
@@ -1,6 +1,7 @@
 <launch>
   <!-- planning module -->
   <!-- diffusion planner -->
+  <arg name="data_path"/>
   <arg name="diffusion_planner_param_path"/>
 
   <!-- trajectory modifier -->
@@ -30,6 +31,7 @@
     <group>
       <push-ros-namespace namespace="neural_network_based_planner"/>
       <include file="$(find-pkg-share autoware_diffusion_planner)/launch/diffusion_planner.launch.xml">
+        <arg name="data_path" value="$(var data_path)"/>
         <arg name="diffusion_planner_param_path" value="$(var diffusion_planner_param_path)"/>
         <arg name="input_odometry" value="/localization/kinematic_state"/>
         <arg name="input_acceleration" value="/localization/acceleration"/>

--- a/tier4_universe_launch/tier4_planning_launch/launch/planning.launch.xml
+++ b/tier4_universe_launch/tier4_planning_launch/launch/planning.launch.xml
@@ -18,6 +18,8 @@
   <!-- Input topic parameters -->
   <arg name="input_objects_topic_name"/>
   <arg name="input_pointcloud_topic_name"/>
+  <!-- Artifacts -->
+  <arg name="data_path"/>
 
   <group>
     <push-ros-namespace namespace="planning"/>
@@ -53,6 +55,7 @@
         <arg name="is_simulation" value="$(var is_simulation)"/>
         <arg name="input_objects_topic_name" value="$(var input_objects_topic_name)"/>
         <arg name="input_pointcloud_topic_name" value="$(var input_pointcloud_topic_name)"/>
+        <arg name="data_path" value="$(var data_path)"/>
         <arg name="diffusion_planner_param_path" value="$(var diffusion_planner_param_path)"/>
         <arg name="trajectory_modifier_param_path" value="$(var trajectory_modifier_param_path)"/>
         <arg name="trajectory_optimizer_param_path" value="$(var trajectory_optimizer_param_path)"/>


### PR DESCRIPTION
- **Parent Issue:** autowarefoundation/autoware#7068
- Pass `data_path` from `autoware.launch.xml` through `tier4_planning_component` -> `tier4_planning_launch/planning.launch.xml` -> `learning_based_planning/diffusion_planner.launch.xml` -> `autoware_diffusion_planner/launch/diffusion_planner.launch.xml`, mirroring how perception already plumbs it.
- Replace the hardcoded `$(env HOME)/autoware_data/diffusion_planner/v4.0/...` literals in [diffusion_planner.param.yaml](https://github.com/autowarefoundation/autoware_launch/blob/6b71b90f3a1fd07c08defe974c7caff917759108/autoware_launch/config/planning/neural_net_planner/diffusion_planner.param.yaml) with `$(var data_path)/diffusion_planner/v4.0/...`, matching the perception convention (literal package subdir under `data_path`).

## Why

The integrated diffusion planner stack currently hardcodes its model paths in `autoware_launch/config/planning/neural_net_planner/diffusion_planner.param.yaml`. Without `data_path` propagated to the planning chain, every artifact-root change (e.g. the `~/autoware_data/` to `~/autoware_data/ml_models/` move tracked in autowarefoundation/autoware#7068) requires re-editing this file. After this PR, flipping `data_path` once at the root controls the diffusion planner artifact path end-to-end, the same way it already does for perception.

Pure refactor; no behavior change at default values.

---

- Counterpart on universe side: autowarefoundation/autoware_universe#12521. Addresses @go-sakayori's review question on that PR about whether the related `autoware_launch` files would be updated.
- Follow-up flip of `data_path` default to `~/autoware_data/ml_models` will land separately to match autowarefoundation/autoware#7068.

## Test plan

- [ ] Build:

  ```bash
  source /opt/ros/jazzy/setup.bash
  colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release \
    --packages-select autoware_launch tier4_planning_launch
  ```

  Expect: clean build, no schema/yaml errors.

- [ ] Default-path resolution unchanged. Launch the integrated stack with `planning_setting:=diffusion_planner` and confirm:

  ```bash
  ros2 param get /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node onnx_model_path
  ```

  Expect: `$HOME/autoware_data/diffusion_planner/v4.0/diffusion_planner.onnx`.

- [ ] Override resolves end-to-end. Same launch with `data_path:=/tmp/foo`:

  ```bash
  ros2 param get /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node onnx_model_path
  ```

  Expect: `/tmp/foo/diffusion_planner/v4.0/diffusion_planner.onnx`.

- [ ] Confirm node starts cleanly and produces trajectories with default args (smoke test).
