### PR TITLE
feat(launch): default data_path to ~/autoware_data/ml_models

### DIFF
--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -5,7 +5,7 @@
   <arg name="vehicle_model" default="sample_vehicle" description="vehicle model name"/>
   <arg name="sensor_model" default="sample_sensor_kit" description="sensor model name"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
 
   <!-- launch module preset -->
   <arg name="planning_setting" default="rule_based" description="planning setting diffusion_planner / rule_based"/>

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -52,7 +52,7 @@
   <arg name="occupancy_grid_map_updater" default="binary_bayes_filter" description="options: binary_bayes_filter"/>
   <arg name="detected_objects_filter_method" default="lanelet_filter" description="options: lanelet_filter, position_filter"/>
   <arg name="detected_objects_validation_method" default="obstacle_pointcloud" description="options: obstacle_pointcloud, occupancy_grid (must be used with laserscan_based_occupancy_grid_map)"/>
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
   <arg name="lidar_detection_model" default="centerpoint" description="If the model name is not declared, the default model in perception.launch.xml will be used"/>
   <arg name="ml_camera_lidar_merger_priority_mode" default="0" description="priority mode for ml and camera_lidar merger, options: `0: Object0`, `1: Object1`, `2: ConfidenceBased`, `3: ClassBased`"/>
   <arg name="input_pointcloud_for_traffic_light_occlusion_predictor" default="/sensing/lidar/top/pointcloud_raw_ex" description="input pointcloud topic for traffic_light_occlusion_predictor"/>

--- a/autoware_launch/launch/components/tier4_planning_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_planning_component.launch.xml
@@ -7,7 +7,7 @@
   <arg name="use_sim_time" default="false"/>
   <arg name="vehicle_model" default="sample_vehicle"/>
   <arg name="planning_setting" default="rule_based" description="planning setting diffusion_planner / rule_based"/>
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
 
   <!-- Input topic parameters for planning modules -->
   <arg name="planning_input_objects_topic_name" default="/perception/object_recognition/objects"/>

--- a/autoware_launch/launch/components/tier4_simulator_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_simulator_component.launch.xml
@@ -14,6 +14,7 @@
   <arg name="initial_engage_state"/>
   <arg name="vehicle_info_param_file"/>
   <arg name="raw_vehicle_cmd_converter_param_path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
   <arg name="occupancy_grid_map_updater" default="binary_bayes_filter" description="options: binary_bayes_filter"/>
   <arg name="use_pointcloud_container" default="true" description="use point cloud container for simulator perception modules"/>
   <arg name="traffic_light_recognition/classification/pedestrian/classifier_type" default="1" description="0=HSVFilter, 1=CNN, 2=LampRecognizer"/>
@@ -35,6 +36,7 @@
     <arg name="vehicle_info_param_file" value="$(var vehicle_info_param_file)"/>
     <arg name="raw_vehicle_cmd_converter_param_path" value="$(var raw_vehicle_cmd_converter_param_path)"/>
     <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
+    <arg name="data_path" value="$(var data_path)"/>
 
     <arg name="fault_injection_param_path" value="$(find-pkg-share autoware_launch)/config/simulator/fault_injection.param.yaml"/>
     <arg

--- a/autoware_launch/launch/e2e_simulator.launch.xml
+++ b/autoware_launch/launch/e2e_simulator.launch.xml
@@ -5,7 +5,7 @@
   <arg name="map_path" description="point cloud and lanelet2 map directory path"/>
   <arg name="vehicle_model" default="sample_vehicle" description="vehicle model name"/>
   <arg name="sensor_model" default="sample_sensor_kit" description="sensor model name"/>
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
   <arg name="simulator_type" default="awsim" description="select the simulator type ('awsim' or 'carla')"/>
 
   <!-- launch module preset -->

--- a/autoware_launch/launch/logging_simulator.launch.xml
+++ b/autoware_launch/launch/logging_simulator.launch.xml
@@ -5,7 +5,7 @@
   <arg name="vehicle_model" default="sample_vehicle" description="vehicle model name"/>
   <arg name="sensor_model" default="sample_sensor_kit" description="sensor model name"/>
   <arg name="vehicle_id" default="$(env VEHICLE_ID default)" description="vehicle specific ID"/>
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
 
   <!-- launch module preset -->
   <arg name="planning_module_preset" default="default" description="planning module preset"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -4,7 +4,7 @@
   <arg name="map_path" description="point cloud and lanelet2 map directory path"/>
   <arg name="vehicle_model" default="sample_vehicle" description="vehicle model name"/>
   <arg name="sensor_model" default="sample_sensor_kit" description="sensor model name"/>
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
 
   <!-- launch module preset -->
   <arg name="planning_module_preset" default="default" description="planning module preset"/>
@@ -111,6 +111,7 @@
       <arg name="initial_engage_state" value="$(var initial_engage_state)"/>
       <arg name="vehicle_info_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
       <arg name="raw_vehicle_cmd_converter_param_path" value="$(find-pkg-share autoware_launch)/config/vehicle/raw_vehicle_cmd_converter/raw_vehicle_cmd_converter.param.yaml"/>
+      <arg name="data_path" value="$(var data_path)"/>
     </include>
   </group>
 </launch>

--- a/autoware_sample_designs/design/system/AutowareSample.system.yaml
+++ b/autoware_sample_designs/design/system/AutowareSample.system.yaml
@@ -9,7 +9,7 @@ variables:
   - name: vehicle_model
     value: sample_vehicle
   - name: data_path
-    value: $(env HOME)/autoware_data
+    value: $(env HOME)/autoware_data/ml_models
   - name: lanelet2_map_file
     value: lanelet2_map.osm
   - name: pointcloud_map_file
@@ -19,7 +19,7 @@ variables:
     value: $(find-pkg-share sample_sensor_kit_description)/config
   # environment variables
   - name: map_path
-    value: $(env HOME)/autoware_map/sample-map-rosbag
+    value: $(env HOME)/autoware_data/maps/sample-map-rosbag
 
 variable_files:
   - name: vehicle_info
@@ -218,7 +218,7 @@ E2ESimulation:
   override:
     variables:
       - name: map_path
-        value: $(env HOME)/autoware_map/nishishinjuku_autoware_map
+        value: $(env HOME)/autoware_data/maps/nishishinjuku_autoware_map
     parameter_sets:
       - e2e_simulation.parameter_set
     components:

--- a/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_bev_detector.launch.xml
+++ b/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_bev_detector.launch.xml
@@ -21,7 +21,7 @@
   <arg name="number_of_cameras"/>
 
   <!-- Model parameters -->
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
   <arg name="bevdet_model_name" default="bevdet_one_lt_d"/>
   <arg name="bevdet_model_path" default="$(var data_path)/tensorrt_bevdet"/>
   <!-- BEVDet -->

--- a/tier4_universe_launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/tier4_universe_launch/tier4_perception_launch/launch/perception.launch.xml
@@ -78,7 +78,7 @@
     <choice value="lidar_radar_fusion"/>
     <choice value="lidar"/>
   </arg>
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
   <arg name="image_raw0" default="/sensing/camera/camera0/image_rect_color" description="image raw topic name"/>
   <arg name="camera_info0" default="/sensing/camera/camera0/camera_info" description="camera info topic name"/>
   <arg name="detection_rois0" default="/perception/object_recognition/detection/rois0" description="detection rois output topic name"/>

--- a/tier4_universe_launch/tier4_simulator_launch/launch/simulator.launch.xml
+++ b/tier4_universe_launch/tier4_simulator_launch/launch/simulator.launch.xml
@@ -5,6 +5,7 @@
   <arg name="fault_injection_param_path"/>
   <arg name="fault_injection_input_diagnostics" default="/diagnostics"/>
   <arg name="fault_injection_output_diagnostics" default="/diagnostics/fault_injection"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
   <arg name="obstacle_segmentation_ground_segmentation_elevation_map_param_path"/>
   <arg name="laserscan_based_occupancy_grid_map_param_path"/>
   <arg name="occupancy_grid_map_updater"/>
@@ -193,16 +194,16 @@
           <arg name="traffic_light_multi_camera_fusion_param_path" value="$(var traffic_light_multi_camera_fusion_param_path)"/>
           <arg name="traffic_light_arbiter_param_path" value="$(var traffic_light_arbiter_param_path)"/>
           <arg name="crosswalk_traffic_light_estimator_param_path" value="$(var crosswalk_traffic_light_estimator_param_path)"/>
-          <arg name="whole_image_detection/model_path" value="$(env HOME)/autoware_data/tensorrt_yolox/yolox_s_car_ped_tl_detector_960_960_batch_1.onnx"/>
-          <arg name="whole_image_detection/label_path" value="$(env HOME)/autoware_data/tensorrt_yolox/car_ped_tl_detector_labels.txt"/>
+          <arg name="whole_image_detection/model_path" value="$(var data_path)/tensorrt_yolox/yolox_s_car_ped_tl_detector_960_960_batch_1.onnx"/>
+          <arg name="whole_image_detection/label_path" value="$(var data_path)/tensorrt_yolox/car_ped_tl_detector_labels.txt"/>
           <arg name="whole_image_detection/yolox_roi_label_remap_path" value="$(var traffic_light_recognition/whole_image_detection/yolox_roi_label_remap_path)"/>
-          <arg name="fine_detection/model_path" value="$(env HOME)/autoware_data/traffic_light_fine_detector/tlr_car_ped_yolox_s_batch_6.onnx"/>
-          <arg name="fine_detection/label_path" value="$(env HOME)/autoware_data/traffic_light_fine_detector/tlr_labels.txt"/>
-          <arg name="classification/car/model_path" value="$(env HOME)/autoware_data/traffic_light_classifier/$(var traffic_light_car_classifier_model)"/>
-          <arg name="classification/car/label_path" value="$(env HOME)/autoware_data/traffic_light_classifier/lamp_labels.txt"/>
-          <arg name="classification/pedestrian/model_path" value="$(env HOME)/autoware_data/traffic_light_classifier/$(var traffic_light_ped_classifier_model)"/>
-          <arg name="classification/pedestrian/label_path" value="$(env HOME)/autoware_data/traffic_light_classifier/lamp_labels_ped.txt"/>
-          <arg name="classification/lamp_recognizer_ml_param_path" value="$(env HOME)/autoware_data/traffic_light_classifier/lamp_recognizer_ml.param.yaml"/>
+          <arg name="fine_detection/model_path" value="$(var data_path)/traffic_light_fine_detector/tlr_car_ped_yolox_s_batch_6.onnx"/>
+          <arg name="fine_detection/label_path" value="$(var data_path)/traffic_light_fine_detector/tlr_labels.txt"/>
+          <arg name="classification/car/model_path" value="$(var data_path)/traffic_light_classifier/$(var traffic_light_car_classifier_model)"/>
+          <arg name="classification/car/label_path" value="$(var data_path)/traffic_light_classifier/lamp_labels.txt"/>
+          <arg name="classification/pedestrian/model_path" value="$(var data_path)/traffic_light_classifier/$(var traffic_light_ped_classifier_model)"/>
+          <arg name="classification/pedestrian/label_path" value="$(var data_path)/traffic_light_classifier/lamp_labels_ped.txt"/>
+          <arg name="classification/lamp_recognizer_ml_param_path" value="$(var data_path)/traffic_light_classifier/lamp_recognizer_ml.param.yaml"/>
           <arg name="classification/pedestrian/classifier_type" value="$(var traffic_light_recognition/classification/pedestrian/classifier_type)"/>
           <arg name="classification/car/classifier_type" value="$(var traffic_light_recognition/classification/car/classifier_type)"/>
         </include>


### PR DESCRIPTION
- **Parent Issue:** autowarefoundation/autoware#7068
- Roll the `data_path` arg defaults from `$(env HOME)/autoware_data` to `$(env HOME)/autoware_data/ml_models` in every top-level launch (`autoware`, `e2e_simulator`, `logging_simulator`, `planning_simulator`) and component (`tier4_perception_component`, `tier4_planning_component`, `tier4_simulator_component`).
- Plumb `data_path` through the simulator chain (`planning_simulator` -> `tier4_simulator_component` -> `tier4_simulator_launch/simulator.launch.xml`) and rewrite the nine hardcoded `$(env HOME)/autoware_data/{tensorrt_yolox,traffic_light_fine_detector,traffic_light_classifier}/...` strings in `simulator.launch.xml` to use `$(var data_path)/<package>/...`, matching the perception convention.
- Migrate `autoware_sample_designs/design/system/AutowareSample.system.yaml`: `data_path` value to `~/autoware_data/ml_models`, and both `map_path` values (Runtime mode, E2ESimulation override) from `~/autoware_map/<map>` to `~/autoware_data/maps[/demos]/<map>`.

## Why

The umbrella issue (autowarefoundation/autoware#7068) restructures the host-side data folder into asset-typed subdirectories (`assets/`, `maps/`, `ml_models/`, `recordings/`, `scenarios/`). `ml_models/` is now the home for everything the `artifacts` ansible role downloads, and `maps/` replaces the legacy `~/autoware_map/` directory. Every launch arg that points at "ML model artifacts" needs to default under `ml_models/`, and every map reference needs to drop off `~/autoware_map/`. The simulator-chain plumbing closes a gap where the planning-simulator's traffic-light models bypassed the launch arg entirely.

Users on the legacy layout can pin the old paths with `data_path:=$HOME/autoware_data` and `map_path:=$HOME/autoware_map/<map>` on the command line.

---

- Pairs with autowarefoundation/autoware#7077 (this repo's `artifacts` role default, docker compose mounts and `map_path` defaults).
- Pairs with autowarefoundation/autoware_universe#12523 (per-package launch defaults and READMEs).
- Pairs with autowarefoundation/autoware_tools#417 (tools-repo README map_path examples).
- Pairs with autowarefoundation/autoware_system_designer#53 (`vehicle_x.system.yaml`).
- Builds on autowarefoundation/autoware_universe#12521 (already merged) which removed the hardcoded `$(env HOME)/autoware_data/...` strings from the universe param YAMLs.
- Builds on autowarefoundation/autoware_launch#1834 (already merged) which plumbed `data_path` through the planning chain.

## Test plan

- [ ] Build the affected packages from the workspace root and confirm they build clean:

  ```bash
  source /opt/ros/jazzy/setup.bash
  colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release \
    --packages-select autoware_launch tier4_perception_launch tier4_planning_launch tier4_simulator_launch
  ```

- [ ] New default cascades through the perception and planning chains:

  ```bash
  source install/setup.bash
  ros2 launch autoware_launch planning_simulator.launch.xml --show-args | grep data_path
  ```

  Expect every `data_path` (top-level, perception, planning, simulator) to default to `$HOME/autoware_data/ml_models`.

- [ ] Legacy override still works for users on the old layout:

  ```bash
  ros2 launch autoware_launch planning_simulator.launch.xml \
    data_path:=$HOME/autoware_data --show-args | grep data_path
  ```

  Expect every resolved path to drop back under `$HOME/autoware_data/...`.

- [ ] Simulator-chain traffic-light artifacts resolve via the launch arg, not via hardcoded strings:

  ```bash
  ros2 launch tier4_simulator_launch simulator.launch.xml --show-args | grep -E '(tensorrt_yolox|traffic_light_(fine_detector|classifier))'
  ```

  Expect every path to be prefixed with `$HOME/autoware_data/ml_models/`.

- [ ] No leftover `$HOME/autoware_map` references in either repo (autoware_launch + tier4_universe_launch):

  ```bash
  grep -rnE '\$\(env HOME\)/autoware_map|\$HOME/autoware_map' --include='*.yaml' --include='*.yml' --include='*.xml' .
  ```

  Expect no output.
