### PR TITLE
feat(autoware_launch): make launch of simulator_interface optional for e2e_simulator.launch.xml

### DIFF
--- a/autoware_launch/launch/e2e_simulator.launch.xml
+++ b/autoware_launch/launch/e2e_simulator.launch.xml
@@ -45,7 +45,7 @@
   <group scoped="false" if="$(var launch_simulator_interface)">
     <!-- AWSIM does not require a simulator interface since it publishes autoware_msgs directly -->
     <!-- CARLA -->
-    <group scoped="false" if="$(eval '\'$(var simulator_type)\' == \'carla\'')">
+    <group scoped="false" if="$(equals $(var simulator_type) 'carla')">
       <include file="$(find-pkg-share autoware_carla_interface)/launch/autoware_carla_interface.launch.xml"/>
     </group>
   </group>

--- a/autoware_launch/launch/e2e_simulator.launch.xml
+++ b/autoware_launch/launch/e2e_simulator.launch.xml
@@ -7,6 +7,7 @@
   <arg name="sensor_model" default="sample_sensor_kit" description="sensor model name"/>
   <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
   <arg name="simulator_type" default="awsim" description="select the simulator type ('awsim' or 'carla')"/>
+  <arg name="launch_simulator_interface" default="true" description="launch simulator interface (e.g. autoware_carla_interface when simulator_type is 'carla')"/>
 
   <!-- launch module preset -->
   <arg name="planning_module_preset" default="default" description="planning module preset"/>
@@ -39,8 +40,14 @@
   <arg name="rviz" default="true" description="launch rviz"/>
   <arg name="rviz_config_name" default="autoware.rviz" description="rviz config name"/>
   <arg name="rviz_config" default="$(find-pkg-share autoware_launch)/rviz/$(var rviz_config_name)" description="rviz config path"/>
-  <group scoped="false" if="$(eval '\'$(var simulator_type)\' == \'carla\'')">
-    <include file="$(find-pkg-share autoware_carla_interface)/launch/autoware_carla_interface.launch.xml"/>
+
+  <!-- Simulator interfaces -->
+  <group scoped="false" if="$(var launch_simulator_interface)">
+    <!-- AWSIM does not require a simulator interface since it publishes autoware_msgs directly -->
+    <!-- CARLA -->
+    <group scoped="false" if="$(eval '\'$(var simulator_type)\' == \'carla\'')">
+      <include file="$(find-pkg-share autoware_carla_interface)/launch/autoware_carla_interface.launch.xml"/>
+    </group>
   </group>
 
   <group scoped="false">


### PR DESCRIPTION
## Description
`autoware_carla_interface` not only bridges Autoware and CARLA, but also spawns the world and the ego vehicle inside CARLA as part of its launch. There are use cases where a user wants to relaunch Autoware while leaving the existing CARLA environment (world + ego vehicle) untouched. With this flag set to false, the user can launch autoware_carla_interface individually in other terminal to enable re-running Autoware without re-initializing the CARLA scene.

## Related links

 - https://github.com/autowarefoundation/autoware/issues/7079

## How was this PR tested?
 - Launch with defaults and confirm autoware_carla_interface still starts when simulator_type:=carla
 - Launch with launch_simulator_interface:=false and simulator_type:=carla, verify Autoware comes up without re-initializing the CARLA world/vehicle, and that an already-running CARLA scene continues to work

## Notes for reviewers

I also changed the logics for comparing strings within launch

```
if="$(eval '\'$(var simulator_type)\' == \'carla\'')
```
to
```
if="$(equals $(var simulator_type) 'carla')"
```


## Effects on system behavior

None.
