### PR TITLE
chore: add sync-branch workflow to sync-files target

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -18,6 +18,7 @@
     - source: .github/workflows/semantic-pull-request.yaml
     - source: .github/workflows/spell-check-daily.yaml
     - source: .github/workflows/spell-check-differential.yaml
+    - source: .github/workflows/sync-branches.yaml
     - source: .github/workflows/sync-files.yaml
     - source: .markdown-link-check.json
     - source: .markdownlint.yaml


### PR DESCRIPTION
## Description
This adds sync-branch.yaml as a sync target from sync-file-templates repository.
I would like to use the workflow to sync between main branch and humble branch to automatic release process.

**must be merged after https://github.com/autowarefoundation/sync-file-templates/pull/73**

## How was this PR tested?
sync-branches.yaml is already used in autoware_core https://github.com/autowarefoundation/autoware_core/actions/workflows/sync-branches.yaml

## Notes for reviewers

None.

## Effects on system behavior

None.
