### PR TITLE
fix(e2e_simulator): fix path to carla launch file

### DIFF
--- a/autoware_launch/launch/e2e_simulator.launch.xml
+++ b/autoware_launch/launch/e2e_simulator.launch.xml
@@ -40,7 +40,7 @@
   <arg name="rviz_config_name" default="autoware.rviz" description="rviz config name"/>
   <arg name="rviz_config" default="$(find-pkg-share autoware_launch)/rviz/$(var rviz_config_name)" description="rviz config path"/>
   <group scoped="false" if="$(eval '\'$(var simulator_type)\' == \'carla\'')">
-    <include file="$(find-pkg-share autoware_carla_interface)/autoware_carla_interface.launch.xml"/>
+    <include file="$(find-pkg-share autoware_carla_interface)/launch/autoware_carla_interface.launch.xml"/>
   </group>
 
   <group scoped="false">


### PR DESCRIPTION
## Description

A recent PR (https://github.com/autowarefoundation/autoware_universe/pull/11706) changed the location of the launch file for the `autoware_carla_interface`, causing the launch of the `e2e_simulator.xml` to fail with option `simulator_type:=carla`.

This PR simply sets the correct path.

## How was this PR tested?

Launch `e2e_simulator.xml` with option `simulator_type:=carla`.

## Notes for reviewers

None.

## Effects on system behavior

None.
