### PR TITLE
fix: assign acados-prepended `LD_LIBRARY_PATH` for motion planning container

### DIFF
--- a/tier4_universe_launch/tier4_planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml
+++ b/tier4_universe_launch/tier4_planning_launch/launch/scenario_planning/lane_driving/motion_planning/motion_planning.launch.xml
@@ -71,7 +71,10 @@
   <let name="container_executable" value="$(var container_type)" unless="$(eval &quot;'$(var use_agnocast)' == '1'&quot;)"/>
   <let name="container_executable" value="agnocast_component_container_cie" if="$(eval &quot;'$(var use_agnocast)' == '1'&quot;)"/>
 
-  <node_container pkg="$(var container_package)" exec="$(var container_executable)" name="motion_planning_container" namespace="" args="" output="screen"/>
+  <node_container pkg="$(var container_package)" exec="$(var container_executable)" name="motion_planning_container" namespace="" args="" output="screen">
+    <!-- for acados-based path optimizer -->
+    <env name="LD_LIBRARY_PATH" value="/opt/acados/lib:$(env LD_LIBRARY_PATH)"/>
+  </node_container>
 
   <!-- path smoothing -->
   <group>


### PR DESCRIPTION
## Description

Acados-based path optimizer requires `LD_LIBRARY_PATH` containing `/opt/acados/lib`, for dynamic linking to acados-related libraries, assuming that acados is installed by the ansible role introduced in https://github.com/autowarefoundation/autoware/pull/6835 .

While the role registers `LD_LIBRARY_PATH` in the bashrc, it is not always that the launch is executed on bashrc sourced environment. (e.g. registering onto systemctl) This PR explicitly adds `LD_LIBRARY_PATH` when launching the container of path optimizer.

## How was this PR tested?

In TIER IV product bench. [Relevant Slack (TIER IV internal)](https://star4.slack.com/archives/C07K1PPNPTR/p1776244438028089)

## Notes for reviewers

None.

## Effects on system behavior

None.
