### PR TITLE
chore(autoware_launch): remove comment referencing to outdated COMPILE_WITH_OLD_ARCHITECTURE

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
@@ -1,5 +1,3 @@
-# USE ONLY WHEN THE OPTION COMPILE_WITH_OLD_ARCHITECTURE IS SET TO FALSE.
-# https://github.com/autowarefoundation/autoware.universe/blob/main/planning/behavior_path_planner/CMakeLists.txt
 # NOTE: The smaller the priority number is, the higher the module priority is.
 /**:
   ros__parameters:


### PR DESCRIPTION
COMPILE_WITH_OLD_ARCHITECTURE no longer exist.

## Description

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
