### PR TITLE
feat(perception): update perception pipeline to remove shape estimation

### DIFF
--- a/autoware_launch/config/perception/object_recognition/detection/clustering/voxel_grid_based_euclidean_cluster.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/clustering/voxel_grid_based_euclidean_cluster.param.yaml
@@ -16,7 +16,7 @@
     min_x: -200.0
     max_y: 200.0
     min_y: -200.0
-    max_z: 2.0
+    max_z: 4.0
     min_z: -10.0
     negative: false
     processing_time_threshold_sec: 0.01

--- a/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
@@ -3,7 +3,7 @@
 # 'reason' can be any single-line text without braces.
 # To keep local changes, annotate fields with '# {OVERRIDE}' or '# {OVERRIDE: reason}'.
 #
-# Source: https://github.com/autowarefoundation/autoware_universe/blob/682bd2ea2df48d232d8243400c7e1f24583aaef1/perception/autoware_multi_object_tracker/config/input_channels.param.yaml
+# Source: https://github.com/autowarefoundation/autoware_universe/blob/78d01cb28c9c30707b3683415ee72ad1224d9ef1/perception/autoware_multi_object_tracker/config/input_channels.param.yaml
 
 /**:
   ros__parameters:

--- a/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
@@ -16,7 +16,7 @@
           short_name: "all"
       # LIDAR - rule-based
       lidar_clustering:
-        associator_type: bev
+        associator_type: polar
         flags:
           can_spawn_new_tracker: true
           can_trust_existence_probability: false
@@ -87,7 +87,7 @@
           short_name: "Csp"
       # CAMERA-LIDAR
       camera_lidar_fusion:
-        associator_type: bev
+        associator_type: polar
         flags:
           can_spawn_new_tracker: true
           can_trust_existence_probability: false
@@ -99,7 +99,7 @@
           short_name: "CLf"
       # CAMERA-LIDAR-IRREGULAR
       camera_lidar_fusion_irregular:
-        associator_type: bev
+        associator_type: polar
         flags:
           can_spawn_new_tracker: true
           can_trust_existence_probability: false
@@ -135,7 +135,7 @@
           short_name: "Rad"
       # CAMERA VRU
       camera_vru:
-        associator_type: bev
+        associator_type: polar
         flags:
           can_spawn_new_tracker: true
           can_trust_existence_probability: true

--- a/autoware_launch/config/perception/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml
+++ b/autoware_launch/config/perception/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml
@@ -9,7 +9,7 @@
         max_x: 150.0
         min_y: -70.0
         max_y: 70.0
-        margin_max_z: 1.0  # to extend the crop box max_z from vehicle_height
+        margin_max_z: 2.5  # to extend the crop box max_z from vehicle_height
         margin_min_z: -2.5 # to extend the crop box min_z from ground
         negative: False
         processing_time_threshold_sec: 0.01

--- a/autoware_launch/config/perception/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml
+++ b/autoware_launch/config/perception/obstacle_segmentation/ground_segmentation/ground_segmentation.param.yaml
@@ -9,7 +9,7 @@
         max_x: 150.0
         min_y: -70.0
         max_y: 70.0
-        margin_max_z: 0.0  # to extend the crop box max_z from vehicle_height
+        margin_max_z: 1.0  # to extend the crop box max_z from vehicle_height
         margin_min_z: -2.5 # to extend the crop box min_z from ground
         negative: False
         processing_time_threshold_sec: 0.01
@@ -25,7 +25,7 @@
         non_ground_height_threshold: 0.20
         grid_size_m: 0.5
         gnd_grid_buffer_size: 4
-        detection_range_z_max: 2.5
+        detection_range_z_max: 3.5
         elevation_grid_mode: true
         use_recheck_ground_cluster: true
         recheck_start_distance: 20.0

--- a/autoware_launch/launch/components/tier4_perception_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_perception_component.launch.xml
@@ -37,7 +37,7 @@
   <arg name="use_image_segmentation_based_filter" default="false" description="launch image_segmentation_based_filter in clustering"/>
   <arg name="use_perception_online_evaluator" default="false" description="launch perception online evaluator"/>
   <arg name="use_perception_analytics_publisher" default="true" description="launch perception analytics publisher"/>
-  <arg name="use_detection_by_tracker" default="true" description="launch detection_by_tracker function"/>
+  <arg name="use_detection_by_tracker" default="false" description="launch detection_by_tracker function"/>
   <arg name="use_radar_tracking_fusion" default="true" description="if true, radar objects are merged in tracking module. Otherwise, radar objects are merged in detection module."/>
   <arg name="use_object_filter" default="true" description="launch object filter to filter-out detected object"/>
   <arg name="use_obstacle_segmentation_single_frame_filter" default="false" description="use single frame filter at the ground segmentation"/>

--- a/autoware_sample_designs/config/perception/obstacle_segmentation/crop_box_filter.param.yaml
+++ b/autoware_sample_designs/config/perception/obstacle_segmentation/crop_box_filter.param.yaml
@@ -6,7 +6,5 @@
     max_y: 70.0
     min_z: -10.0
     max_z: 4.0
-    margin_max_z: 2.5  # to extend the crop box max_z from vehicle_height
-    margin_min_z: -2.5 # to extend the crop box min_z from ground
     negative: false
     processing_time_threshold_sec: 0.01

--- a/autoware_sample_designs/config/perception/obstacle_segmentation/crop_box_filter.param.yaml
+++ b/autoware_sample_designs/config/perception/obstacle_segmentation/crop_box_filter.param.yaml
@@ -4,7 +4,9 @@
     max_x: 150.0
     min_y: -70.0
     max_y: 70.0
-    margin_max_z: 0.0  # to extend the crop box max_z from vehicle_height
+    min_z: -10.0
+    max_z: 4.0
+    margin_max_z: 2.5  # to extend the crop box max_z from vehicle_height
     margin_min_z: -2.5 # to extend the crop box min_z from ground
     negative: false
     processing_time_threshold_sec: 0.01

--- a/autoware_sample_designs/design/module/perception/ObjectRecognition.module.yaml
+++ b/autoware_sample_designs/design/module/perception/ObjectRecognition.module.yaml
@@ -46,10 +46,6 @@ connections:
     - tracking.subscriber.lidar_ml_objects
   - - detection.publisher.lidar_clustering_objects
     - tracking.subscriber.lidar_rule_detector_objects
-  - - detection.publisher.tracker_based_detector_objects
-    - tracking.subscriber.tracker_based_detector_objects
-  - - tracking.publisher.objects
-    - detection.subscriber.tracked_objects
 
   # prediction
   - - tracking.publisher.objects

--- a/autoware_sample_designs/design/module/perception/object_recongition/ObjectDetection.module.yaml
+++ b/autoware_sample_designs/design/module/perception/object_recongition/ObjectDetection.module.yaml
@@ -16,10 +16,6 @@ instances:
   - name: object_lanelet_filter
     entity: ObjectLaneletFilter.node
 
-  # tracker based detection
-  - name: detection_by_tracker
-    entity: DetectionByTracker.node
-
 subscribers:
   - name: pointcloud_map
   - name: vector_map
@@ -27,10 +23,8 @@ subscribers:
   - name: kinematic_state
   - name: pointcloud
   - name: obstacle_pointcloud
-  - name: tracked_objects
 publishers:
   - name: lidar_clustering_objects
-  - name: tracker_based_detector_objects
   - name: lidar_ml_objects
 
 connections:
@@ -63,11 +57,3 @@ connections:
     - centerpoint.subscriber.obstacle_pointcloud
   - - centerpoint.publisher.detected_objects
     - publisher.lidar_ml_objects
-
-  # detection by tracker
-  - - subscriber.tracked_objects
-    - detection_by_tracker.subscriber.tracked_objects
-  - - clustering.publisher.cluster_objects
-    - detection_by_tracker.subscriber.initial_objects
-  - - detection_by_tracker.publisher.objects
-    - publisher.tracker_based_detector_objects

--- a/autoware_sample_designs/design/module/perception/object_recongition/detection/clustering/LidarClustering.module.yaml
+++ b/autoware_sample_designs/design/module/perception/object_recongition/detection/clustering/LidarClustering.module.yaml
@@ -5,8 +5,6 @@ name: LidarClustering.module
 instances:
   - name: euclidean_cluster
     entity: VoxelGridBasedEuclideanCluster.node
-  - name: shape_estimation
-    entity: ShapeEstimation.node
   - name: detected_object_feature_remover
     entity: DetectedObjectFeatureRemover.node
 
@@ -14,18 +12,12 @@ subscribers:
   - name: pointcloud
 publishers:
   - name: detected_objects
-  - name: cluster_objects
 
 connections:
   - - subscriber.pointcloud
     - euclidean_cluster.subscriber.input_pointcloud
 
   - - euclidean_cluster.publisher.output_clusters
-    - shape_estimation.subscriber.objects
-  - - shape_estimation.publisher.objects
-    - publisher.cluster_objects
-
-  - - shape_estimation.publisher.objects
     - detected_object_feature_remover.subscriber.input
   - - detected_object_feature_remover.publisher.output
     - publisher.detected_objects

--- a/autoware_sample_designs/design/parameter_set/sample_system_perception.parameter_set.yaml
+++ b/autoware_sample_designs/design/parameter_set/sample_system_perception.parameter_set.yaml
@@ -71,9 +71,6 @@ parameters:
         value: false
       - name: processing_time_threshold_sec
         value: 0.01
-  - node: /perception/object_recognition/detection/clustering/shape_estimation
-    param_files: []
-    param_values: []
   - node: /perception/object_recognition/detection/clustering/camera_lidar_fusion/roi_cluster_fusion
     param_files: []
     param_values:
@@ -88,17 +85,11 @@ parameters:
   - node: /perception/object_recognition/detection/clustering/camera_lidar_fusion/low_intensity_cluster_filter
     param_files: []
     param_values: []
-  - node: /perception/object_recognition/detection/clustering/camera_lidar_fusion/shape_estimation
-    param_files: []
-    param_values: []
-  - node: /perception/object_recognition/detection/clustering/camera_lidar_fusion/detected_object_feature_remover
+  - node: /perception/object_recognition/detection/clustering/detected_object_feature_remover
     param_files: []
     param_values:
       - name: run_convex_hull_conversion
         value: true
-  - node: /perception/object_recognition/detection/detection_by_tracker
-    param_files: []
-    param_values: []
   - node: /perception/object_recognition/detection/roi_detected_object_fusion
     param_files: []
     param_values:
@@ -113,8 +104,6 @@ parameters:
         value: lidar_centerpoint
       - name: input/detection03/channel
         value: lidar_clustering
-      - name: input/detection05/channel
-        value: detection_by_tracker
       - name: publish_merged_objects
         value: false
       - name: enable_delay_compensation

--- a/autoware_sample_designs/design/parameter_set/sample_system_perception.parameter_set.yaml
+++ b/autoware_sample_designs/design/parameter_set/sample_system_perception.parameter_set.yaml
@@ -52,25 +52,7 @@ parameters:
         value: 1000.0
   - node: /perception/object_recognition/detection/clustering/voxel_grid_based_euclidean_cluster
     param_files: []
-    param_values:
-      - name: input_frame
-        value: base_link
-      - name: max_x
-        value: 200.0
-      - name: min_x
-        value: -200.0
-      - name: max_y
-        value: 200.0
-      - name: min_y
-        value: -200.0
-      - name: max_z
-        value: 2.0
-      - name: min_z
-        value: -10.0
-      - name: negative
-        value: false
-      - name: processing_time_threshold_sec
-        value: 0.01
+    param_values: []
   - node: /perception/object_recognition/detection/clustering/camera_lidar_fusion/roi_cluster_fusion
     param_files: []
     param_values:

--- a/autoware_sample_designs/design/system/AutowareSample.system.yaml
+++ b/autoware_sample_designs/design/system/AutowareSample.system.yaml
@@ -97,7 +97,7 @@ node_groups:
     nodes:
       - /sensing/lidar/concatenate_and_time_sync
       - /perception/obstacle_segmentation/*
-      - /perception/object_recognition/detection/pointcloud_map_filter/voxel_grid_downsample_filter
+      - /perception/object_recognition/detection/pointcloud_map_filter/*
       - /perception/object_recognition/detection/clustering/euclidean_cluster
       - /perception/occupancy_grid_map/occupancy_grid_map_node
   - name: lidar_top_container

--- a/autoware_sample_designs/design/system/AutowareSample.system.yaml
+++ b/autoware_sample_designs/design/system/AutowareSample.system.yaml
@@ -97,7 +97,7 @@ node_groups:
     nodes:
       - /sensing/lidar/concatenate_and_time_sync
       - /perception/obstacle_segmentation/*
-      - /perception/object_recognition/detection/pointcloud_map_filter/*
+      - /perception/object_recognition/detection/pointcloud_map_filter/voxel_grid_downsample_filter
       - /perception/object_recognition/detection/clustering/euclidean_cluster
       - /perception/occupancy_grid_map/occupancy_grid_map_node
   - name: lidar_top_container

--- a/autoware_sample_designs/design/wrapper/Tier4PlanningWrapper.node.yaml
+++ b/autoware_sample_designs/design/wrapper/Tier4PlanningWrapper.node.yaml
@@ -32,6 +32,8 @@ publishers:
 param_files: []
 
 param_values:
+  - name: data_path
+    default: $(var data_path)
   - name: planning_setting
     default: rule_based
   - name: enable_all_modules_auto_mode

--- a/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_detector.launch.xml
+++ b/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_detector.launch.xml
@@ -63,7 +63,6 @@
 
   <arg name="output/ml_detector/objects"/>
   <arg name="output/rule_detector/objects"/>
-  <arg name="output/clustering/cluster_objects"/>
 
   <arg name="camera_2d_detector/model_path"/>
   <arg name="camera_2d_detector/label_path"/>
@@ -81,18 +80,14 @@
   <let name="euclidean_cluster/input/pointcloud" value="$(var segmentation_based_filtered/output/pointcloud)" if="$(var use_image_segmentation_based_filter)"/>
   <let name="euclidean_cluster/input/pointcloud" value="$(var input/pointcloud_map/pointcloud)" unless="$(var use_image_segmentation_based_filter)"/>
   <let name="euclidean_cluster/output/clusters" value="$(var ns)/clustering/clusters"/>
-  <let name="shape_estimation1/input/clusters" value="$(var euclidean_cluster/output/clusters)"/>
-  <let name="shape_estimation1/output/objects" value="$(var output/clustering/cluster_objects)"/>
 
   <let name="roi_cluster_fusion/input/clusters" value="$(var euclidean_cluster/output/clusters)"/>
   <let name="roi_cluster_fusion/output/clusters" value="$(var ns)/clustering/camera_lidar_fusion/clusters"/>
   <let name="low_intensity_cluster_filter/input/clusters" value="$(var roi_cluster_fusion/output/clusters)"/>
   <let name="low_intensity_cluster_filter/output/clusters" value="$(var ns)/clustering/camera_lidar_fusion/filtered/clusters"/>
 
-  <let name="shape_estimation2/input/clusters" value="$(var roi_cluster_fusion/output/clusters)" unless="$(var use_low_intensity_cluster_filter)"/>
-  <let name="shape_estimation2/input/clusters" value="$(var low_intensity_cluster_filter/output/clusters)" if="$(var use_low_intensity_cluster_filter)"/>
-  <let name="shape_estimation2/output/objects" value="$(var ns)/clustering/camera_lidar_fusion/objects_with_feature"/>
-  <let name="detected_object_feature_remover/input/objects_with_feature" value="$(var shape_estimation2/output/objects)"/>
+  <let name="detected_object_feature_remover/input/objects_with_feature" value="$(var roi_cluster_fusion/output/clusters)" unless="$(var use_low_intensity_cluster_filter)"/>
+  <let name="detected_object_feature_remover/input/objects_with_feature" value="$(var low_intensity_cluster_filter/output/clusters)" if="$(var use_low_intensity_cluster_filter)"/>
   <let name="detected_object_feature_remover/output/objects" value="$(var output/rule_detector/objects)"/>
 
   <arg name="enable_2d_detection" default="false" description="true: when 2d detection yolox model run the same machine, false: when it run in separate machine"/>
@@ -186,14 +181,6 @@
       </include>
     </group>
 
-    <!-- shape_estimation 1 -->
-    <group>
-      <include file="$(find-pkg-share autoware_shape_estimation)/launch/shape_estimation.launch.xml">
-        <arg name="input/objects" value="$(var shape_estimation1/input/clusters)"/>
-        <arg name="output/objects" value="$(var shape_estimation1/output/objects)"/>
-      </include>
-    </group>
-
     <group>
       <push-ros-namespace namespace="camera_lidar_fusion"/>
       <!-- Fusion camera-lidar to classify -->
@@ -244,17 +231,12 @@
         </include>
       </group>
 
-      <group>
-        <include file="$(find-pkg-share autoware_shape_estimation)/launch/shape_estimation.launch.xml">
-          <arg name="input/objects" value="$(var shape_estimation2/input/clusters)"/>
-          <arg name="output/objects" value="$(var shape_estimation2/output/objects)"/>
-        </include>
-      </group>
       <!-- convert DynamicObjectsWithFeatureArray to DynamicObjects -->
       <group>
         <include file="$(find-pkg-share autoware_detected_object_feature_remover)/launch/detected_object_feature_remover.launch.xml">
           <arg name="input" value="$(var detected_object_feature_remover/input/objects_with_feature)"/>
           <arg name="output" value="$(var detected_object_feature_remover/output/objects)"/>
+          <arg name="run_convex_hull_conversion" value="true"/>
         </include>
       </group>
     </group>

--- a/tier4_universe_launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/tier4_universe_launch/tier4_perception_launch/launch/perception.launch.xml
@@ -160,7 +160,7 @@
   <arg name="traffic_light_recognition/classification/car/classifier_type"/>
 
   <!-- Whether to use detection by tracker -->
-  <arg name="use_detection_by_tracker" default="true"/>
+  <arg name="use_detection_by_tracker" default="false"/>
 
   <!-- Radar parameters -->
   <arg


### PR DESCRIPTION
## Description

* update perception pipeline
  - remove shape estimation from lidar cluster detection and export polygon object
  - multi object tracker accepts the polygon object
  - remove detection by tracker, which also uses shape estimation
  - adjust cluster pipeline parameters (euclidean cluster, ground segmentation) to properly detect cluster height
* update association method
  - use [polar association](https://github.com/autowarefoundation/autoware_universe/pull/12475) for polygon object detection
* minor update
  - for system designer: update planning wrapper to follow current planning ros launcher

pipeline has been update for both autoware_launch and autoware_sample_designs


before

<img width="2652" height="740" alt="Screenshot from 2026-05-22 15-54-36" src="https://github.com/user-attachments/assets/fe510f43-2bba-4cf7-84ee-fb606577513a" />



after

<img width="2652" height="740" alt="Screenshot from 2026-05-22 15-55-13" src="https://github.com/user-attachments/assets/102cd0b0-c8cc-432e-9ea6-edd137b50cfd" />



## How was this PR tested?
tested by logging simulation and sample rosbag


https://github.com/user-attachments/assets/4956a272-84dc-4b23-9e37-0228bb510abe



## Notes for reviewers
https://github.com/autowarefoundation/autoware_universe/pull/12475 will prior this PR

## Effects on system behavior

* remove instability caused by the detection by tracker
* remove faulty object orientation caused by the shape estimation
* improved latency due to shorten perception process
