### PR TITLE
feat: remove deprecated planning interface

### DIFF
--- a/.github/scripts/test_sync_params.py
+++ b/.github/scripts/test_sync_params.py
@@ -626,20 +626,16 @@ perception: []
         This regression covers a real map-sync case where repeated runs appended
         another "# Path ..." fragment on each execution.
         """
-        source_text = dedent(
-            """\
+        source_text = dedent("""\
             /**:
               ros__parameters:
                 pcd_paths_or_directory: [$(var pcd_paths_or_directory)] # Path to the pointcloud map file or directory
-            """
-        )
-        variant_text = dedent(
-            """\
+            """)
+        variant_text = dedent("""\
             /**:
               ros__parameters:
                 pcd_paths_or_directory: [$(var pointcloud_map_path)] # {OVERRIDE} Path to the pointcloud map file or directory
-            """
-        )
+            """)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             variant_path = Path(tmpdir) / "variant.yaml"

--- a/autoware_launch/launch/autoware.launch.xml
+++ b/autoware_launch/launch/autoware.launch.xml
@@ -117,14 +117,6 @@
       <arg name="vehicle_model" value="$(var vehicle_model)"/>
       <arg name="data_path" value="$(var data_path)"/>
     </include>
-
-    <!-- Relay node for trajectory topic -->
-    <!-- This is a temporary addition for migration purposes. -->
-    <!-- https://github.com/orgs/autowarefoundation/discussions/5033#discussioncomment-13704802 -->
-    <node pkg="topic_tools" exec="relay" name="trajectory_relay">
-      <param name="input_topic" value="/planning/trajectory"/>
-      <param name="output_topic" value="/planning/scenario_planning/trajectory"/>
-    </node>
   </group>
 
   <!-- Control -->


### PR DESCRIPTION
## Description

Removal of deprecated interfaces.
Please refer to the background information here.
https://github.com/orgs/autowarefoundation/discussions/5033#discussioncomment-13704802

## How was this PR tested?

The tutorial PSim test was conducted.
Additionally, it has been confirmed that there are no matches when searching for /planning/scenario_planning/trajectory.
<img width="1314" height="915" alt="Peek 2026-05-26 11-39" src="https://github.com/user-attachments/assets/1affa276-6338-4e4c-be31-21b2bb01a232" />


## Notes for reviewers

None.

## Effects on system behavior

None.
