### PR TITLE
feat: add launch params and configs for direction_change module

### DIFF
--- a/autoware_launch/config/planning/preset/default_preset.yaml
+++ b/autoware_launch/config/planning/preset/default_preset.yaml
@@ -42,6 +42,9 @@ launch:
   - arg:
       name: launch_bidirectional_traffic_module
       default: "true"
+  - arg:
+      name: launch_direction_change_module
+      default: "false"
 
   # behavior velocity modules
   - arg:

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_direction_change_module/direction_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_direction_change_module/direction_change.param.yaml
@@ -1,0 +1,43 @@
+/**:
+  ros__parameters:
+    direction_change:
+      # ========================================
+      # General parameters
+      # Module-level feature toggles and settings
+      # ========================================
+      enable_cusp_detection: true  # Enable cusp point detection
+      enable_reverse_following: true  # Enable reverse lane following
+      publish_debug_marker: false  # Publish debug markers for visualization
+      print_debug_info: true # When true, log debug info (segment state, cusps, path analysis, etc.)
+      th_arrived_distance: 0.5  # [m] If ego within this distance of route goal, do not activate (align with arrival_check / th_arrived_distance)
+
+      # ========================================
+      # Cusp detection parameters
+      # Detection of direction change points in path
+      # ========================================
+      cusp_detection_angle_threshold_deg: 90.0  # [deg] Angle threshold to detect cusp point
+      cusp_detection_distance_threshold: 0.2  # [m] Distance threshold to detect approaching cusp
+      cusp_detection_distance_start_approaching: 10.0  # [m] Distance to start approaching cusp (transition to APPROACHING_CUSP)
+
+      # ========================================
+      # State transition parameters
+      # Vehicle stop detection and state transitions
+      # ========================================
+      stop_velocity_threshold: 0.5  # [m/s] Velocity threshold to determine vehicle has stopped
+      th_stopped_time: 0.090  # [s] Duration velocity must stay below stop_velocity_threshold before direction switch at cusp
+
+      # ========================================
+      # Reverse behavior parameters
+      # Speed limits and path generation for reverse motion
+      # ========================================
+      reverse_initial_speed: 0.5  # [m/s] Upper speed limit for backward_slow_speed
+      reverse_speed_limit: 2.0  # [m/s] Upper speed limit for backward_cruise_speed (clamped by reference path speed)
+      reverse_path_densify_max_yaw_step_deg: 5.0  # [deg] Maximum yaw angle step for reverse path densification
+      reverse_path_densify_max_distance_step: 0.5  # [m] Maximum distance step for reverse path densification
+
+      # ========================================
+      # Goal lateral shift parameters
+      # Cubic polynomial blend from centerline to route goal pose
+      # ========================================
+      enable_goal_lateral_shift: true  # Enable cubic lateral shift toward goal on terminal approach
+      max_allowed_yaw_deg: 20.0  # [deg] Max heading change rate for maneuver length (nominal: 20, aggressive: 30)

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/scene_module_manager.param.yaml
@@ -21,6 +21,7 @@
       - "external_request_lane_change_left"
       - "external_request_lane_change_right"
       - "bidirectional_traffic"
+      - "direction_change"
     slot3:
       - "goal_planner"
     slot4:
@@ -86,3 +87,8 @@
       enable_rtc: false
       enable_simultaneous_execution_as_approved_module: true
       enable_simultaneous_execution_as_candidate_module: true
+
+    direction_change:
+      enable_rtc: false
+      enable_simultaneous_execution_as_approved_module: false
+      enable_simultaneous_execution_as_candidate_module: false

--- a/autoware_launch/launch/components/tier4_planning_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_planning_component.launch.xml
@@ -66,6 +66,7 @@
     <arg name="behavior_path_planner_goal_planner_module_param_path" value="$(var behavior_path_config_path)/goal_planner/goal_planner.param.yaml"/>
     <arg name="behavior_path_planner_start_planner_module_param_path" value="$(var behavior_path_config_path)/start_planner/start_planner.param.yaml"/>
     <arg name="behavior_path_bidirectional_traffic_module_param_path" value="$(var behavior_path_config_path)/autoware_behavior_path_bidirectional_traffic_module/bidirectional_traffic.param.yaml"/>
+    <arg name="behavior_path_planner_direction_change_module_param_path" value="$(var behavior_path_config_path)/autoware_behavior_path_direction_change_module/direction_change.param.yaml"/>
     <arg name="behavior_path_planner_drivable_area_expansion_param_path" value="$(var behavior_path_config_path)/drivable_area_expansion.param.yaml"/>
 
     <!-- path generator -->

--- a/tier4_universe_launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/tier4_universe_launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -27,6 +27,7 @@
   <arg name="launch_sampling_planner_module" default="true"/>
   <arg name="launch_side_shift_module" default="true"/>
   <arg name="launch_bidirectional_traffic_module" default="true"/>
+  <arg name="launch_direction_change_module" default="false"/>
 
   <arg name="launch_crosswalk_module" default="true"/>
   <arg name="launch_walkway_module" default="true"/>
@@ -66,6 +67,11 @@
     name="behavior_path_planner_launch_modules"
     value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'autoware::behavior_path_planner::BidirectionalTrafficModuleManager, '&quot;)"
     if="$(var launch_bidirectional_traffic_module)"
+  />
+  <let
+    name="behavior_path_planner_launch_modules"
+    value="$(eval &quot;'$(var behavior_path_planner_launch_modules)' + 'autoware::behavior_path_planner::DirectionChangeModuleManager, '&quot;)"
+    if="$(var launch_direction_change_module)"
   />
   <let
     name="behavior_path_planner_launch_modules"
@@ -259,6 +265,7 @@
         <param from="$(var behavior_path_planner_static_obstacle_avoidance_module_param_path)"/>
         <param from="$(var behavior_path_planner_avoidance_by_lc_module_param_path)"/>
         <param from="$(var behavior_path_bidirectional_traffic_module_param_path)"/>
+        <param from="$(var behavior_path_planner_direction_change_module_param_path)"/>
         <param from="$(var behavior_path_planner_dynamic_obstacle_avoidance_module_param_path)"/>
         <param from="$(var behavior_path_planner_lane_change_module_param_path)"/>
         <param from="$(var behavior_path_planner_goal_planner_module_param_path)"/>


### PR DESCRIPTION
## Description

This PR includes the changes related to `direction_change` module. `direction_module` is for reverse, cusp maneuvers in a narrow spaces. To enable this module, set the `launch_direction_change_module` param to `true` in `default_preset.yaml` or in the launch file being used. 

## Related Links
- Related [universe PR](https://github.com/autowarefoundation/autoware_universe/pull/12638)  --> This PR has `direction_change` module actual implementation.

## How was this PR tested?

- colcon build to check if everything is built properly
- PSim tests to check if the respective node is launched. Results as expected.

## Notes for reviewers

None.

## Effects on system behavior

None.
