### PR TITLE
feat(autoware_launch): launch dummy traffic light publisher in simulator

### DIFF
--- a/autoware_launch/launch/components/tier4_simulator_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_simulator_component.launch.xml
@@ -8,6 +8,7 @@
   <arg name="perception/enable_detection_failure"/>
   <arg name="perception/enable_object_recognition"/>
   <arg name="perception/enable_traffic_light"/>
+  <arg name="dummy_traffic_light_mode" default="empty" description="fallback mode of dummy traffic light publisher: 'empty', 'standalone' or 'fixed'"/>
   <arg name="perception/use_base_link_z"/>
   <arg name="sensing/visible_range"/>
   <arg name="vehicle_model"/>
@@ -29,6 +30,7 @@
     <arg name="perception/enable_detection_failure" value="$(var perception/enable_detection_failure)"/>
     <arg name="perception/enable_object_recognition" value="$(var perception/enable_object_recognition)"/>
     <arg name="perception/enable_traffic_light" value="$(var perception/enable_traffic_light)"/>
+    <arg name="dummy_traffic_light_mode" value="$(var dummy_traffic_light_mode)"/>
     <arg name="perception/use_base_link_z" value="$(var perception/use_base_link_z)"/>
     <arg name="sensing/visible_range" value="$(var sensing/visible_range)"/>
     <arg name="vehicle_model" value="$(var vehicle_model)"/>

--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -25,6 +25,7 @@
   <arg name="perception/enable_detection_failure" default="true" description="enable to simulate detection failure when using dummy perception"/>
   <arg name="perception/enable_object_recognition" default="true" description="enable object recognition when using dummy perception"/>
   <arg name="perception/enable_traffic_light" default="false" description="enable traffic light recognition"/>
+  <arg name="dummy_traffic_light_mode" default="empty" description="fallback mode of dummy traffic light publisher when no manual (passthrough) input arrives: 'empty', 'standalone' or 'fixed'"/>
   <arg name="perception/use_base_link_z" default="true" description="dummy perception uses base_link z axis coordinate if it is true"/>
   <arg name="sensing/visible_range" default="300.0" description="visible range when using dummy perception"/>
   <arg name="scenario_simulation" default="false" description="use scenario simulation"/>
@@ -105,6 +106,7 @@
       <arg name="perception/enable_detection_failure" value="$(var perception/enable_detection_failure)"/>
       <arg name="perception/enable_object_recognition" value="$(var perception/enable_object_recognition)"/>
       <arg name="perception/enable_traffic_light" value="$(var perception/enable_traffic_light)"/>
+      <arg name="dummy_traffic_light_mode" value="$(var dummy_traffic_light_mode)"/>
       <arg name="perception/use_base_link_z" value="$(var perception/use_base_link_z)"/>
       <arg name="sensing/visible_range" value="$(var sensing/visible_range)"/>
       <arg name="vehicle_model" value="$(var vehicle_model)"/>

--- a/tier4_universe_launch/tier4_simulator_launch/launch/simulator.launch.xml
+++ b/tier4_universe_launch/tier4_simulator_launch/launch/simulator.launch.xml
@@ -69,6 +69,8 @@
   <arg name="perception/enable_object_recognition" default="false" description="enable object recognition"/>
   <arg name="perception/enable_elevation_map" default="false" description="enable elevation map loader"/>
   <arg name="perception/enable_traffic_light" default="true" description="enable traffic light"/>
+  <arg name="launch_dummy_traffic_light_publisher" default="true" description="launch dummy traffic light publisher when traffic light recognition is disabled"/>
+  <arg name="dummy_traffic_light_mode" default="empty" description="fallback mode of dummy traffic light publisher when no passthrough input arrives: 'empty', 'standalone' or 'fixed'"/>
   <arg name="fusion_only" default="true" description="enable only camera and V2X fusion when enabling traffic light"/>
   <arg name="perception/use_base_link_z" default="true" description="dummy perception uses base_link z axis coordinate if it is true"/>
   <arg name="sensing/visible_range" default="300.0" description="visible range when using dummy perception"/>
@@ -98,6 +100,15 @@
         <arg name="use_base_link_z" value="$(var perception/use_base_link_z)"/>
         <arg name="visible_range" value="$(var sensing/visible_range)"/>
       </include>
+    </group>
+
+    <!-- Dummy Traffic Light Publisher (used when traffic light recognition is disabled, e.g. planning simulator) -->
+    <group if="$(var launch_dummy_traffic_light_publisher)">
+      <group unless="$(var perception/enable_traffic_light)">
+        <include file="$(find-pkg-share autoware_dummy_traffic_light_publisher)/launch/dummy_traffic_light_publisher.launch.xml">
+          <arg name="mode" value="$(var dummy_traffic_light_mode)"/>
+        </include>
+      </group>
     </group>
 
     <group unless="$(var scenario_simulation)">

--- a/tier4_universe_launch/tier4_simulator_launch/package.xml
+++ b/tier4_universe_launch/tier4_simulator_launch/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend>autoware_dummy_perception_publisher</exec_depend>
+  <exec_depend>autoware_dummy_traffic_light_publisher</exec_depend>
   <exec_depend>autoware_elevation_map_loader</exec_depend>
   <exec_depend>autoware_fault_injection</exec_depend>
   <exec_depend>autoware_multi_object_tracker</exec_depend>


### PR DESCRIPTION
## Description

Integrate `autoware_dummy_traffic_light_publisher` into the simulator launch so that dummy traffic signals are published when traffic light recognition is disabled (e.g. the planning simulator).

- Launch the node from `simulator.launch.xml`, gated by `launch_dummy_traffic_light_publisher` and active only when `perception/enable_traffic_light` is `false`.
- Thread `dummy_traffic_light_mode` (`empty` / `standalone` / `fixed`) from `planning_simulator.launch.xml` → `tier4_simulator_component.launch.xml` → `simulator.launch.xml` down to the node.

Depends on autowarefoundation/autoware_universe#12456 (adds the `autoware_dummy_traffic_light_publisher` package). This PR has no effect until that package is available.

## How was this PR tested?

Launched the planning simulator:

```bash
ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
```

Confirmed that the node is launched and publishes onto the traffic-signal topic that the AD pipeline consumes:

```bash
ros2 topic info -v /perception/traffic_light_recognition/traffic_signals
```

The output lists `dummy_traffic_light_publisher` as the publisher of the topic (with the perception/planning side as subscribers), confirming that dummy traffic signals are provided when traffic light recognition is disabled.

## Notes for reviewers

- Depends on autowarefoundation/autoware_universe#12456.
- `fixed` mode is selectable via `dummy_traffic_light_mode:=fixed`, but the color is intentionally **not** exposed as a launch argument to keep the user-facing launch simple; it falls back to the node's parameter-file default (`red`) and can be changed there if needed.

## Effects on system behavior

When traffic light recognition is disabled (e.g. planning simulator), dummy traffic signals are now published on `/perception/traffic_light_recognition/traffic_signals`.
