### PR TITLE
feat(perception, proximity_hazard_object_checker): enable new module

### DIFF
--- a/autoware_launch/config/perception/proximity_hazard_object_checker.param.yaml
+++ b/autoware_launch/config/perception/proximity_hazard_object_checker.param.yaml
@@ -1,0 +1,19 @@
+/**:
+  ros__parameters:
+    node_hz: 5.0
+
+    max_detection_range_m: 2.0
+
+    include_unknown_objects: true
+
+    sector_range:
+      front: [-10.0, 10.0]
+      front_left: [10.0, 30.0]
+      left: [30.0, 150.0]
+      rear_left: [150.0, 170.0]
+      rear: [170.0, -170.0]
+      rear_right: [-170.0, -150.0]
+      right: [-150.0, -30.0]
+      front_right: [-30.0, -10.0]
+
+    sector_boundary_tolerance_deg: 1.0

--- a/tier4_universe_launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/tier4_universe_launch/tier4_perception_launch/launch/perception.launch.xml
@@ -173,6 +173,13 @@
   <!-- Object merger method: whether to enable multi-channel tracker merger -->
   <arg name="use_multi_channel_tracker_merger" default="false" description="if it is true, replace the multi step merger to multi-channel tracker merger."/>
   <arg name="output/tracker_merged_objects" default="/perception/object_recognition/detection/objects"/>
+
+  <!-- Proximity Hazard publisher -->
+  <arg name="launch_proximity_hazard_object_checker" default="true"/>
+  <arg name="proximity_hazard_object_checker_param_path" default="$(find-pkg-share autoware_launch)/config/perception/proximity_hazard_object_checker.param.yaml"/>
+  <arg name="proximity_hazard_object_checker_input_odometry" default="/localization/kinematic_state"/>
+  <arg name="proximity_hazard_object_checker_output_hazards" default="/hmi/proximity_hazards"/>
+
   <!-- Downsample pointcloud for perception usage -->
   <arg name="downsample_perception_common_pointcloud" default="false"/>
   <arg name="cuda_pointcloud_preprocessing" default="false"/>
@@ -382,6 +389,15 @@
       <node pkg="autoware_dummy_perception_publisher" exec="empty_objects_publisher" name="empty_objects_publisher" output="screen">
         <remap from="~/output/objects" to="/perception/object_recognition/objects"/>
       </node>
+    </group>
+
+    <!-- Proximity Hazard publisher -->
+    <group if="$(var launch_proximity_hazard_object_checker)">
+      <include file="$(find-pkg-share autoware_proximity_hazard_object_checker)/launch/proximity_hazard_object_checker.launch.xml">
+        <arg name="input_odometry" value="$(var proximity_hazard_object_checker_input_odometry)"/>
+        <arg name="output_hazards" value="$(var proximity_hazard_object_checker_output_hazards)"/>
+        <arg name="param_path" value="$(var proximity_hazard_object_checker_param_path)"/>
+      </include>
     </group>
 
     <!-- Traffic light module -->

--- a/tier4_universe_launch/tier4_perception_launch/package.xml
+++ b/tier4_universe_launch/tier4_perception_launch/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend>autoware_agnocast_wrapper</exec_depend>
+  <exec_depend>autoware_proximity_hazard_object_checker</exec_depend>
   <exec_depend>autoware_bevfusion</exec_depend>
   <exec_depend>autoware_bytetrack</exec_depend>
   <exec_depend>autoware_cluster_merger</exec_depend>


### PR DESCRIPTION
## Description
Integrates `autoware_proximity_hazard_object_checker` into the perception launch stack.

Three changes:

1. **`autoware_launch/config/perception/proximity_hazard_object_checker.param.yaml`** (new) — vehicle-level parameter file for the checker node. Sets the detection range to 2.0 m, timer rate to 5 Hz, includes UNKNOWN-classified objects, sector boundary tolerance of 1.0°, and eight configurable sector ranges that cover 360° with default wedges of ±10° (fore/aft), ±10–30° (shoulder), and ±30–150° (sides).

2. **`tier4_universe_launch/tier4_perception_launch/launch/perception.launch.xml`** — adds the checker into the perception launch graph. The node is **enabled by default** (`launch_proximity_hazard_object_checker` defaults to `true`). Four launch arguments are exposed:
   - `launch_proximity_hazard_object_checker` (`true`) — on/off switch
   - `proximity_hazard_object_checker_param_path` — defaults to the new param file above
   - `proximity_hazard_object_checker_input_odometry` — defaults to `/localization/kinematic_state`
   - `proximity_hazard_object_checker_output_hazards` — defaults to `/hmi/proximity_hazards`

   The objects input (`/perception/object_recognition/objects`) is not overridden here; the checker's own launch file default is used, which already matches the standard output of the object recognition pipeline.

3. **`tier4_universe_launch/tier4_perception_launch/package.xml`** — adds `<exec_depend>autoware_proximity_hazard_object_checker</exec_depend>` so the launch package declares the runtime dependency correctly.

## How was this PR tested?
<!-- TODO: fill in -->

## Notes for reviewers
- The node is **on by default**. Any deployment using `perception.launch.xml` will start publishing `/hmi/proximity_hazards` at 5 Hz unless `launch_proximity_hazard_object_checker:=false` is passed at launch time. Verify this is the desired default for all vehicle configs that share this launch file.
- `input_objects` is intentionally not exposed as a launch argument in `perception.launch.xml`. The checker's own launch file hardcodes the default to `/perception/object_recognition/objects`, which is the standard tracker output in this pipeline. If a vehicle config needs a different source, the `input_objects` arg would need to be added here.
- The param file values are identical to the package's own `config/proximity_hazard.yaml` defaults. This file exists to allow per-vehicle tuning without modifying the upstream package.

## Effects on system behavior
- `/hmi/proximity_hazards` (`tier4_external_api_msgs/ProximityHazardObjects`) begins publishing at 5 Hz in all deployments that use `perception.launch.xml`, unless the node is explicitly disabled at launch time.
- A 5 Hz TF lookup (objects frame → base_link) is added to the perception process. If the TF tree is incomplete or stale on a given tick, the checker emits a throttled warning and skips that publish cycle; it does not affect other nodes in the pipeline.
- No existing topics, parameters, or node graphs are modified.

