### PR TITLE
fix: remove unnecessary dependency

### DIFF
--- a/tier4_universe_launch/tier4_perception_launch/package.xml
+++ b/tier4_universe_launch/tier4_perception_launch/package.xml
@@ -41,7 +41,6 @@
   <exec_depend>autoware_perception_online_evaluator</exec_depend>
   <exec_depend>autoware_pointcloud_preprocessor</exec_depend>
   <exec_depend>autoware_probabilistic_occupancy_grid_map</exec_depend>
-  <exec_depend>autoware_proximity_hazard_object_checker</exec_depend>
   <exec_depend>autoware_ptv3</exec_depend>
   <exec_depend>autoware_radar_fusion_to_detected_object</exec_depend>
   <exec_depend>autoware_radar_object_tracker</exec_depend>


### PR DESCRIPTION
## Description
This is a fix for removing unnecessary dependency to autoware_proximity_hazard_object_checker which does not exist in autoware_universe yet.

The error wasn't caught in the CI since exec_depends are skipped. 
## How was this PR tested?
run rosdep install command and made sure that no error occurs.

## Notes for reviewers

None.

## Effects on system behavior

None.
