### PR TITLE
fix(tier4_perception_launch): occupancy_grid_map input topic when ptv3 used

### DIFF
--- a/tier4_universe_launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/tier4_universe_launch/tier4_perception_launch/launch/perception.launch.xml
@@ -254,8 +254,16 @@
     <group>
       <push-ros-namespace namespace="occupancy_grid_map"/>
       <let name="unfiltered_obstacle_pointcloud" value="/perception/obstacle_segmentation/pointcloud"/>
-      <let name="unfiltered_obstacle_pointcloud" value="/perception/obstacle_segmentation/single_frame/pointcloud" if="$(eval &quot;'$(var use_semantic_segmentation_ptv3)' == 'false' and '$(var use_obstacle_segmentation_single_frame_filter)' == 'true'&quot;)"/>
-      <let name="unfiltered_obstacle_pointcloud" value="/perception/obstacle_segmentation/single_frame/pointcloud" if="$(eval &quot;'$(var use_semantic_segmentation_ptv3)' == 'false' and '$(var use_obstacle_segmentation_time_series_filter)' == 'true'&quot;)"/>
+      <let
+        name="unfiltered_obstacle_pointcloud"
+        value="/perception/obstacle_segmentation/single_frame/pointcloud"
+        if="$(eval &quot;'$(var use_semantic_segmentation_ptv3)' == 'false' and '$(var use_obstacle_segmentation_single_frame_filter)' == 'true'&quot;)"
+      />
+      <let
+        name="unfiltered_obstacle_pointcloud"
+        value="/perception/obstacle_segmentation/single_frame/pointcloud"
+        if="$(eval &quot;'$(var use_semantic_segmentation_ptv3)' == 'false' and '$(var use_obstacle_segmentation_time_series_filter)' == 'true'&quot;)"
+      />
       <include file="$(find-pkg-share tier4_perception_launch)/launch/occupancy_grid_map/probabilistic_occupancy_grid_map.launch.xml">
         <arg name="input/obstacle_pointcloud" value="$(var unfiltered_obstacle_pointcloud)"/>
         <arg name="input/raw_pointcloud" value="$(var perception_pointcloud)"/>

--- a/tier4_universe_launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/tier4_universe_launch/tier4_perception_launch/launch/perception.launch.xml
@@ -254,8 +254,8 @@
     <group>
       <push-ros-namespace namespace="occupancy_grid_map"/>
       <let name="unfiltered_obstacle_pointcloud" value="/perception/obstacle_segmentation/pointcloud"/>
-      <let name="unfiltered_obstacle_pointcloud" value="/perception/obstacle_segmentation/single_frame/pointcloud" if="$(var use_obstacle_segmentation_single_frame_filter)"/>
-      <let name="unfiltered_obstacle_pointcloud" value="/perception/obstacle_segmentation/single_frame/pointcloud" if="$(var use_obstacle_segmentation_time_series_filter)"/>
+      <let name="unfiltered_obstacle_pointcloud" value="/perception/obstacle_segmentation/single_frame/pointcloud" if="$(eval &quot;'$(var use_semantic_segmentation_ptv3)' == 'false' and '$(var use_obstacle_segmentation_single_frame_filter)' == 'true'&quot;)"/>
+      <let name="unfiltered_obstacle_pointcloud" value="/perception/obstacle_segmentation/single_frame/pointcloud" if="$(eval &quot;'$(var use_semantic_segmentation_ptv3)' == 'false' and '$(var use_obstacle_segmentation_time_series_filter)' == 'true'&quot;)"/>
       <include file="$(find-pkg-share tier4_perception_launch)/launch/occupancy_grid_map/probabilistic_occupancy_grid_map.launch.xml">
         <arg name="input/obstacle_pointcloud" value="$(var unfiltered_obstacle_pointcloud)"/>
         <arg name="input/raw_pointcloud" value="$(var perception_pointcloud)"/>


### PR DESCRIPTION
## Description
- To fix missing switching related to `occupancy_grid_map` regarding https://github.com/autowarefoundation/autoware_launch/pull/1865
## How was this PR tested?
- Run logging_simulator with ptv3: 

``` 
ros2 launch autoware_launch logging_simulator.launch.xml map_path:=/mnt/data/maps/ vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit use_semantic_segmentation_ptv3:=true
```

- Confirmed by logging_simulator that `/perception/occupancy_grid_map/occupancy_grid_map_node` using `/perception/obstacle_segmentation/pointcloud` if pointcloud semantic segmentation is used. 

```
ros2 node info /perception/occupancy_grid_map/occupancy_grid_map_node
/perception/occupancy_grid_map/occupancy_grid_map_node
  Subscribers:
    /clock: rosgraph_msgs/msg/Clock
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /perception/obstacle_segmentation/pointcloud: sensor_msgs/msg/PointCloud2
    /sensing/lidar/concatenated/pointcloud: sensor_msgs/msg/PointCloud2
  Publishers:
    /diagnostics: diagnostic_msgs/msg/DiagnosticArray
    /parameter_events: rcl_interfaces/msg/ParameterEvent
    /perception/occupancy_grid_map/map: nav_msgs/msg/OccupancyGrid
    /rosout: rcl_interfaces/msg/Log
  ...
```

## Notes for reviewers

None.

## Effects on system behavior

None.
