### PR TITLE
feat(perception): update tracker assignments to use general_vehicle_tracker for bounding box and polygon types

### DIFF
--- a/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/data_association_matrix.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/data_association_matrix.param.yaml
@@ -15,22 +15,22 @@
     # Omitted entries — implicitly not accepted: a throttled error is emitted at runtime.
     tracker_assignment:
       bounding_box:
-        unknown:    {create: multi_vehicle_tracker,          match: [multi_vehicle_tracker, pedestrian_and_bicycle_tracker]}
-        car:        {create: multi_vehicle_tracker,          match: [multi_vehicle_tracker]}
-        truck:      {create: multi_vehicle_tracker,          match: [multi_vehicle_tracker]}
-        bus:        {create: multi_vehicle_tracker,          match: [multi_vehicle_tracker]}
-        trailer:    {create: multi_vehicle_tracker,          match: [multi_vehicle_tracker]}
+        unknown:    {create: general_vehicle_tracker,          match: [general_vehicle_tracker, pedestrian_and_bicycle_tracker]}
+        car:        {create: general_vehicle_tracker,          match: [general_vehicle_tracker]}
+        truck:      {create: general_vehicle_tracker,          match: [general_vehicle_tracker]}
+        bus:        {create: general_vehicle_tracker,          match: [general_vehicle_tracker]}
+        trailer:    {create: general_vehicle_tracker,          match: [general_vehicle_tracker]}
         motorcycle: {create: pedestrian_and_bicycle_tracker, match: [pedestrian_and_bicycle_tracker]}
         bicycle:    {create: pedestrian_and_bicycle_tracker, match: [pedestrian_and_bicycle_tracker]}
         pedestrian: {create: pedestrian_and_bicycle_tracker, match: [pedestrian_and_bicycle_tracker]}
         animal:     {create: "null"}
         hazard:     {create: static_tracker,                 match: [static_tracker]}
       polygon:
-        unknown:    {create: polygon_tracker,                match: [polygon_tracker, static_tracker, multi_vehicle_tracker, pedestrian_and_bicycle_tracker]}
-        car:        {create: polygon_tracker,                match: [polygon_tracker, multi_vehicle_tracker]}
-        truck:      {create: polygon_tracker,                match: [polygon_tracker, multi_vehicle_tracker]}
-        bus:        {create: polygon_tracker,                match: [polygon_tracker, multi_vehicle_tracker]}
-        trailer:    {create: polygon_tracker,                match: [polygon_tracker, multi_vehicle_tracker]}
+        unknown:    {create: polygon_tracker,                match: [polygon_tracker, static_tracker, general_vehicle_tracker, pedestrian_and_bicycle_tracker]}
+        car:        {create: polygon_tracker,                match: [polygon_tracker, general_vehicle_tracker]}
+        truck:      {create: polygon_tracker,                match: [polygon_tracker, general_vehicle_tracker]}
+        bus:        {create: polygon_tracker,                match: [polygon_tracker, general_vehicle_tracker]}
+        trailer:    {create: polygon_tracker,                match: [polygon_tracker, general_vehicle_tracker]}
         motorcycle: {create: pedestrian_and_bicycle_tracker, match: [pedestrian_and_bicycle_tracker]}
         bicycle:    {create: pedestrian_and_bicycle_tracker, match: [pedestrian_and_bicycle_tracker]}
         pedestrian: {create: pedestrian_and_bicycle_tracker, match: [pedestrian_and_bicycle_tracker]}
@@ -51,7 +51,7 @@
     # Tracker profiles: each tracker type defines its association thresholds per label.
     # Only labels where the tracker is actually used are listed.
     tracker_profiles:
-      multi_vehicle_tracker:
+      general_vehicle_tracker:
         bounding_box:
           unknown:  {max_dist: 4.0, max_area: 60.0,  min_area: 3.6,   min_iou: 0.0001}
           car:      {max_dist: 5.0, max_area: 12.10, min_area: 3.6,   min_iou: 0.0001}

--- a/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/tracking/multi_object_tracker/input_channels.param.yaml
@@ -21,7 +21,7 @@
           can_spawn_new_tracker: true
           can_trust_existence_probability: false
           can_trust_extension: false
-          can_trust_classification: false
+          can_trust_classification: true
           can_trust_orientation: false
         optional:
           name: "clustering"


### PR DESCRIPTION
## Description
Replace multi_vehicle_tracker to general_vehicle_tracker

- multi_vehicle_tracker: double tracker that has normal vehicle tracker and git vehicle tracker. double work
- general_vehicle_tracker: single vehicle tracker having general parameters


Double tracker approach may taken to cover sudden size changes, when detector confused.
Sudden size change is absorbed by [UnstableShapeFilter](https://github.com/autowarefoundation/autoware_universe/pull/10864), so this kind of high-cost algorithm is not necessary anymore.

## How was this PR tested?

Tested by logging simulator, using sample rosbag file and TIER IV INTERNAL recordings.
This configuration is tested under [new PR](https://github.com/autowarefoundation/autoware_universe/pull/12728)

## Notes for reviewers

None.

## Effects on system behavior

None.
