### PR TITLE
fix(neural_net_planner): add temporal MPT optimizer config for trajec…

### DIFF
--- a/autoware_launch/config/planning/neural_net_planner/trajectory_optimizer.param.yaml
+++ b/autoware_launch/config/planning/neural_net_planner/trajectory_optimizer.param.yaml
@@ -21,3 +21,4 @@
     use_trajectory_extender: false
     use_kinematic_feasibility_enforcer: true
     use_mpt_optimizer: false
+    use_temporal_mpt_optimizer: false

--- a/autoware_launch/config/planning/neural_net_planner/trajectory_optimizer_plugins/trajectory_temporal_mpt_optimizer.param.yaml
+++ b/autoware_launch/config/planning/neural_net_planner/trajectory_optimizer_plugins/trajectory_temporal_mpt_optimizer.param.yaml
@@ -1,0 +1,12 @@
+/**:
+  ros__parameters:
+    trajectory_temporal_mpt_optimizer:
+      # lr = cg_distance_from_rear_axle_ratio * wheel_base (from vehicle_info); lf = wheel_base - lr
+      # Same 0.8 default as spatial MPT optimization_center_offset / wheel_base.
+      cg_distance_from_rear_axle_ratio: 0.8
+      min_points_for_optimization: 2
+      enable_debug_info: false
+      publish_debug_topics: false
+      write_replay_fixture: false
+      replay_fixture_directory: "~/.ros/autoware_temporal_mpt_replay"
+      log_replay_fixture_to_console: false

--- a/autoware_launch/launch/components/tier4_planning_component.launch.xml
+++ b/autoware_launch/launch/components/tier4_planning_component.launch.xml
@@ -145,5 +145,6 @@
     <arg name="trajectory_velocity_optimizer_param_path" value="$(var optimizer_plugins_config_path)/trajectory_velocity_optimizer.param.yaml"/>
     <arg name="trajectory_kinematic_feasibility_enforcer_param_path" value="$(var optimizer_plugins_config_path)/trajectory_kinematic_feasibility_enforcer.param.yaml"/>
     <arg name="trajectory_mpt_optimizer_param_path" value="$(var optimizer_plugins_config_path)/trajectory_mpt_optimizer.param.yaml"/>
+    <arg name="trajectory_temporal_mpt_optimizer_param_path" value="$(var optimizer_plugins_config_path)/trajectory_temporal_mpt_optimizer.param.yaml"/>
   </include>
 </launch>

--- a/tier4_universe_launch/tier4_planning_launch/launch/learning_based_planning/diffusion_planner.launch.xml
+++ b/tier4_universe_launch/tier4_planning_launch/launch/learning_based_planning/diffusion_planner.launch.xml
@@ -19,6 +19,7 @@
   <arg name="trajectory_velocity_optimizer_param_path"/>
   <arg name="trajectory_kinematic_feasibility_enforcer_param_path"/>
   <arg name="trajectory_mpt_optimizer_param_path"/>
+  <arg name="trajectory_temporal_mpt_optimizer_param_path"/>
 
   <node pkg="demo_nodes_cpp" exec="parameter_blackboard" name="velocity_smoother" namespace="/planning/scenario_planning" output="screen">
     <param name="max_velocity" value="16.6"/>
@@ -69,6 +70,7 @@
         <arg name="trajectory_velocity_optimizer_param_path" value="$(var trajectory_velocity_optimizer_param_path)"/>
         <arg name="trajectory_kinematic_feasibility_enforcer_param_path" value="$(var trajectory_kinematic_feasibility_enforcer_param_path)"/>
         <arg name="trajectory_mpt_optimizer_param_path" value="$(var trajectory_mpt_optimizer_param_path)"/>
+        <arg name="trajectory_temporal_mpt_optimizer_param_path" value="$(var trajectory_temporal_mpt_optimizer_param_path)"/>
       </include>
     </group>
   </group>

--- a/tier4_universe_launch/tier4_planning_launch/launch/planning.launch.xml
+++ b/tier4_universe_launch/tier4_planning_launch/launch/planning.launch.xml
@@ -70,6 +70,7 @@
         <arg name="trajectory_velocity_optimizer_param_path" value="$(var trajectory_velocity_optimizer_param_path)"/>
         <arg name="trajectory_kinematic_feasibility_enforcer_param_path" value="$(var trajectory_kinematic_feasibility_enforcer_param_path)"/>
         <arg name="trajectory_mpt_optimizer_param_path" value="$(var trajectory_mpt_optimizer_param_path)"/>
+        <arg name="trajectory_temporal_mpt_optimizer_param_path" value="$(var trajectory_temporal_mpt_optimizer_param_path)"/>
       </include>
     </group>
 


### PR DESCRIPTION
## Description
The autoware_trajectory_optimizer node now declares use_temporal_mpt_optimizer as a statically typed parameter, so it crashes on startup (UninitializedStaticallyTypedParameterException) when launched with the autoware_launch config, which did not provide it.

- Add use_temporal_mpt_optimizer: false to trajectory_optimizer.param.yaml
- Add trajectory_temporal_mpt_optimizer.param.yaml plugin config
- Wire trajectory_temporal_mpt_optimizer_param_path through the launch chain

## How was this PR tested?
Planning Simulator
[Uploading Screencast from 2026年06月12日 12時24分38秒.webm…]()


## Notes for reviewers
Related PR
https://github.com/autowarefoundation/autoware_universe/pull/12394

## Effects on system behavior
None.
