### PR TITLE
chore(yolox): remove param named preprocess_on_gpu

### DIFF
--- a/autoware_launch/config/perception/traffic_light_recognition/tensorrt_yolox/yolox_traffic_light_detector.param.yaml
+++ b/autoware_launch/config/perception/traffic_light_recognition/tensorrt_yolox/yolox_traffic_light_detector.param.yaml
@@ -12,7 +12,6 @@
     quantize_last_layer: false # If true, set the operating precision for the last (output) layer to be fp16. This option is valid only when precision==int8.
     profile_per_layer: false # If true, profiler function will be enabled. Since the profile function may affect execution speed, it is recommended to set this flag true only for development purpose.
     clip_value: 6.0 # If positive value is specified, the value of each layer output will be clipped between [0.0, clip_value]. This option is valid only when precision==int8 and used to manually specify the dynamic range instead of using any calibration.
-    preprocess_on_gpu: true # If true, pre-processing is performed on GPU.
     gpu_id: 0 # GPU ID to select CUDA Device
     calibration_image_list_path: "" # Path to a file which contains path to images. Those images will be used for int8 quantization.
 


### PR DESCRIPTION
## Description

As of https://github.com/autowarefoundation/autoware_universe/pull/12803, a parameter called `preprocess_on_gpu` is removed.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
