### PR TITLE
fix(merger_topic): mis-aligning topic when using semantic_segmentation without multi_channel_tracker

### DIFF
--- a/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
+++ b/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
@@ -405,6 +405,8 @@
   <!-- Merger -->
   <group if="$(var switch/merger/camera_lidar_radar)">
     <!-- Camera-Lidar-Radar merger -->
+    <let name="input/lidar_rule/objects" value="$(var camera_lidar_rule_detector/output/objects)" unless="$(var use_semantic_segmentation_ptv3)"/>
+    <let name="input/lidar_rule/objects" value="$(var lidar_cluster/output/objects)" if="$(var use_semantic_segmentation_ptv3)"/>
     <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/detection/merger/camera_lidar_radar_merger.launch.xml">
       <arg name="number_of_cameras" value="$(var number_of_cameras)"/>
       <arg name="input/camera0/image" value="$(var input/camera0/image)"/>
@@ -435,7 +437,7 @@
       <arg name="input/camera8/info" value="$(var input/camera8/info)"/>
       <arg name="input/camera8/rois" value="$(var input/camera8/rois)"/>
       <arg name="input/lidar_ml/objects" value="$(var object_merger/input/ml_detected_objects)"/>
-      <arg name="input/lidar_rule/objects" value="$(var camera_lidar_rule_detector/output/objects)"/>
+      <arg name="input/lidar_rule/objects" value="$(var input/lidar_rule/objects)"/>
       <arg name="input/detection_by_tracker/objects" value="$(var tracker_based_detector/output/objects)"/>
       <arg name="input/radar/objects" value="radar/noise_filtered_objects"/>
       <arg name="input/radar_far/objects" value="$(var radar_pipeline/output/objects)"/>
@@ -457,6 +459,8 @@
 
   <group if="$(var switch/merger/camera_lidar)">
     <!-- Camera-Lidar merger -->
+    <let name="input/lidar_rule/objects" value="$(var camera_lidar_rule_detector/output/objects)" unless="$(var use_semantic_segmentation_ptv3)"/>
+    <let name="input/lidar_rule/objects" value="$(var lidar_cluster/output/objects)" if="$(var use_semantic_segmentation_ptv3)"/>
     <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/detection/merger/camera_lidar_merger.launch.xml">
       <arg name="number_of_cameras" value="$(var number_of_cameras)"/>
       <arg name="input/camera0/image" value="$(var input/camera0/image)"/>
@@ -487,7 +491,7 @@
       <arg name="input/camera8/info" value="$(var input/camera8/info)"/>
       <arg name="input/camera8/rois" value="$(var input/camera8/rois)"/>
       <arg name="input/lidar_ml/objects" value="$(var object_merger/input/ml_detected_objects)"/>
-      <arg name="input/lidar_rule/objects" value="$(var camera_lidar_rule_detector/output/objects)"/>
+      <arg name="input/lidar_rule/objects" value="$(var input/lidar_rule/objects)"/>
       <arg name="input/detection_by_tracker/objects" value="$(var tracker_based_detector/output/objects)"/>
       <arg name="detected_irregular_object/output/objects" value="$(var irregular_object_pipeline/output/objects)"/>
       <arg name="output/objects" value="$(var output/objects)"/>
@@ -505,10 +509,12 @@
 
   <group if="$(var switch/merger/lidar_radar)">
     <!-- Lidar object merger-->
+    <let name="input/lidar_rule/objects" value="$(var lidar_rule_detector/output/objects)" unless="$(var use_semantic_segmentation_ptv3)"/>
+    <let name="input/lidar_rule/objects" value="$(var lidar_cluster/output/objects)" if="$(var use_semantic_segmentation_ptv3)"/>
     <group>
       <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/detection/merger/lidar_merger.launch.xml">
         <arg name="input/lidar_ml/objects" value="$(var object_merger/input/ml_detected_objects)"/>
-        <arg name="input/lidar_rule/objects" value="$(var lidar_rule_detector/output/objects)"/>
+        <arg name="input/lidar_rule/objects" value="$(var input/lidar_rule/objects)"/>
         <arg name="output/objects" value="lidar/objects"/>
         <arg name="lidar_detection_model_type" value="$(var lidar_detection_model_type)"/>
         <arg name="use_detection_by_tracker" value="$(var use_detection_by_tracker)"/>
@@ -529,9 +535,11 @@
 
   <group if="$(var switch/merger/lidar)">
     <!-- Lidar object merger-->
+    <let name="input/lidar_rule/objects" value="$(var lidar_rule_detector/output/objects)" unless="$(var use_semantic_segmentation_ptv3)"/>
+    <let name="input/lidar_rule/objects" value="$(var lidar_cluster/output/objects)" if="$(var use_semantic_segmentation_ptv3)"/>
     <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/detection/merger/lidar_merger.launch.xml">
       <arg name="input/lidar_ml/objects " value="$(var object_merger/input/ml_detected_objects)"/>
-      <arg name="input/lidar_rule/objects" value="$(var lidar_rule_detector/output/objects)"/>
+      <arg name="input/lidar_rule/objects" value="$(var input/lidar_rule/objects)"/>
       <arg name="input/detection_by_tracker/objects" value="$(var tracker_based_detector/output/objects)"/>
       <arg name="output/objects" value="$(var output/objects)"/>
       <arg name="lidar_detection_model_type" value="$(var lidar_detection_model_type)"/>

--- a/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
+++ b/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
@@ -405,8 +405,8 @@
   <!-- Merger -->
   <group if="$(var switch/merger/camera_lidar_radar)">
     <!-- Camera-Lidar-Radar merger -->
-    <let name="input/lidar_rule/objects" value="$(var camera_lidar_rule_detector/output/objects)" unless="$(var use_semantic_segmentation_ptv3)"/>
-    <let name="input/lidar_rule/objects" value="$(var lidar_cluster/output/objects)" if="$(var use_semantic_segmentation_ptv3)"/>
+    <let name="input/lidar_cluster/objects" value="$(var camera_lidar_rule_detector/output/objects)" unless="$(var use_semantic_segmentation_ptv3)"/>
+    <let name="input/lidar_cluster/objects" value="$(var lidar_cluster/output/objects)" if="$(var use_semantic_segmentation_ptv3)"/>
     <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/detection/merger/camera_lidar_radar_merger.launch.xml">
       <arg name="number_of_cameras" value="$(var number_of_cameras)"/>
       <arg name="input/camera0/image" value="$(var input/camera0/image)"/>
@@ -437,7 +437,7 @@
       <arg name="input/camera8/info" value="$(var input/camera8/info)"/>
       <arg name="input/camera8/rois" value="$(var input/camera8/rois)"/>
       <arg name="input/lidar_ml/objects" value="$(var object_merger/input/ml_detected_objects)"/>
-      <arg name="input/lidar_rule/objects" value="$(var input/lidar_rule/objects)"/>
+      <arg name="input/lidar_cluster/objects" value="$(var input/lidar_cluster/objects)"/>
       <arg name="input/detection_by_tracker/objects" value="$(var tracker_based_detector/output/objects)"/>
       <arg name="input/radar/objects" value="radar/noise_filtered_objects"/>
       <arg name="input/radar_far/objects" value="$(var radar_pipeline/output/objects)"/>
@@ -459,8 +459,8 @@
 
   <group if="$(var switch/merger/camera_lidar)">
     <!-- Camera-Lidar merger -->
-    <let name="input/lidar_rule/objects" value="$(var camera_lidar_rule_detector/output/objects)" unless="$(var use_semantic_segmentation_ptv3)"/>
-    <let name="input/lidar_rule/objects" value="$(var lidar_cluster/output/objects)" if="$(var use_semantic_segmentation_ptv3)"/>
+    <let name="input/lidar_cluster/objects" value="$(var camera_lidar_rule_detector/output/objects)" unless="$(var use_semantic_segmentation_ptv3)"/>
+    <let name="input/lidar_cluster/objects" value="$(var lidar_cluster/output/objects)" if="$(var use_semantic_segmentation_ptv3)"/>
     <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/detection/merger/camera_lidar_merger.launch.xml">
       <arg name="number_of_cameras" value="$(var number_of_cameras)"/>
       <arg name="input/camera0/image" value="$(var input/camera0/image)"/>
@@ -491,7 +491,7 @@
       <arg name="input/camera8/info" value="$(var input/camera8/info)"/>
       <arg name="input/camera8/rois" value="$(var input/camera8/rois)"/>
       <arg name="input/lidar_ml/objects" value="$(var object_merger/input/ml_detected_objects)"/>
-      <arg name="input/lidar_rule/objects" value="$(var input/lidar_rule/objects)"/>
+      <arg name="input/lidar_cluster/objects" value="$(var input/lidar_cluster/objects)"/>
       <arg name="input/detection_by_tracker/objects" value="$(var tracker_based_detector/output/objects)"/>
       <arg name="detected_irregular_object/output/objects" value="$(var irregular_object_pipeline/output/objects)"/>
       <arg name="output/objects" value="$(var output/objects)"/>
@@ -509,12 +509,12 @@
 
   <group if="$(var switch/merger/lidar_radar)">
     <!-- Lidar object merger-->
-    <let name="input/lidar_rule/objects" value="$(var lidar_rule_detector/output/objects)" unless="$(var use_semantic_segmentation_ptv3)"/>
-    <let name="input/lidar_rule/objects" value="$(var lidar_cluster/output/objects)" if="$(var use_semantic_segmentation_ptv3)"/>
+    <let name="input/lidar_cluster/objects" value="$(var lidar_rule_detector/output/objects)" unless="$(var use_semantic_segmentation_ptv3)"/>
+    <let name="input/lidar_cluster/objects" value="$(var lidar_cluster/output/objects)" if="$(var use_semantic_segmentation_ptv3)"/>
     <group>
       <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/detection/merger/lidar_merger.launch.xml">
         <arg name="input/lidar_ml/objects" value="$(var object_merger/input/ml_detected_objects)"/>
-        <arg name="input/lidar_rule/objects" value="$(var input/lidar_rule/objects)"/>
+        <arg name="input/lidar_cluster/objects" value="$(var input/lidar_cluster/objects)"/>
         <arg name="output/objects" value="lidar/objects"/>
         <arg name="lidar_detection_model_type" value="$(var lidar_detection_model_type)"/>
         <arg name="use_detection_by_tracker" value="$(var use_detection_by_tracker)"/>
@@ -535,11 +535,11 @@
 
   <group if="$(var switch/merger/lidar)">
     <!-- Lidar object merger-->
-    <let name="input/lidar_rule/objects" value="$(var lidar_rule_detector/output/objects)" unless="$(var use_semantic_segmentation_ptv3)"/>
-    <let name="input/lidar_rule/objects" value="$(var lidar_cluster/output/objects)" if="$(var use_semantic_segmentation_ptv3)"/>
+    <let name="input/lidar_cluster/objects" value="$(var lidar_rule_detector/output/objects)" unless="$(var use_semantic_segmentation_ptv3)"/>
+    <let name="input/lidar_cluster/objects" value="$(var lidar_cluster/output/objects)" if="$(var use_semantic_segmentation_ptv3)"/>
     <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/detection/merger/lidar_merger.launch.xml">
       <arg name="input/lidar_ml/objects " value="$(var object_merger/input/ml_detected_objects)"/>
-      <arg name="input/lidar_rule/objects" value="$(var input/lidar_rule/objects)"/>
+      <arg name="input/lidar_cluster/objects" value="$(var input/lidar_cluster/objects)"/>
       <arg name="input/detection_by_tracker/objects" value="$(var tracker_based_detector/output/objects)"/>
       <arg name="output/objects" value="$(var output/objects)"/>
       <arg name="lidar_detection_model_type" value="$(var lidar_detection_model_type)"/>

--- a/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/merger/camera_lidar_merger.launch.xml
+++ b/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/merger/camera_lidar_merger.launch.xml
@@ -45,7 +45,7 @@
   <arg name="input/camera8/info"/>
   <arg name="input/camera8/rois"/>
   <arg name="input/lidar_ml/objects"/>
-  <arg name="input/lidar_rule/objects"/>
+  <arg name="input/lidar_cluster/objects"/>
   <arg name="input/detection_by_tracker/objects"/>
   <arg name="output/objects" default="objects"/>
   <arg name="alpha_merger_priority_mode" default="0"/>
@@ -71,7 +71,7 @@
     value="$(var input/lidar_ml/objects)"
     if="$(eval &quot;'$(var use_irregular_object_detector)'=='false' and '$(var use_roi_detected_object_validator)'=='false' &quot;)"
   />
-  <let name="merger1/input/objects1" value="$(var input/lidar_rule/objects)"/>
+  <let name="merger1/input/objects1" value="$(var input/lidar_cluster/objects)"/>
   <let name="merger1/output/objects" value="$(var output/objects)" if="$(var without_dbt_and_filter)"/>
   <let name="merger1/output/objects" value="$(var lidar_detection_model_type)_roi_cluster_fusion/objects" unless="$(var without_dbt_and_filter)"/>
 

--- a/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/merger/camera_lidar_radar_merger.launch.xml
+++ b/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/merger/camera_lidar_radar_merger.launch.xml
@@ -48,7 +48,7 @@
   <arg name="input/camera8/info"/>
   <arg name="input/camera8/rois"/>
   <arg name="input/lidar_ml/objects"/>
-  <arg name="input/lidar_rule/objects"/>
+  <arg name="input/lidar_cluster/objects"/>
   <arg name="input/radar/objects"/>
   <arg name="input/radar_far/objects"/>
   <arg name="input/detection_by_tracker/objects"/>
@@ -79,7 +79,7 @@
     value="$(var input/lidar_ml/objects)"
     if="$(eval &quot;'$(var use_irregular_object_detector)'=='false' and '$(var use_roi_detected_object_validator)'=='false' &quot;)"
   />
-  <let name="merger1/input/objects1" value="$(var input/lidar_rule/objects)"/>
+  <let name="merger1/input/objects1" value="$(var input/lidar_cluster/objects)"/>
   <let name="merger1/output/objects" value="$(var output/objects)" if="$(var without_dbt_and_filter)"/>
   <let name="merger1/output/objects" value="$(var lidar_detection_model_type)_roi_cluster_fusion/objects" unless="$(var without_dbt_and_filter)"/>
 

--- a/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/merger/lidar_merger.launch.xml
+++ b/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/merger/lidar_merger.launch.xml
@@ -14,13 +14,13 @@
 
   <!-- external interfaces -->
   <arg name="input/lidar_ml/objects" default="$(var lidar_detection_model_type)/objects"/>
-  <arg name="input/lidar_rule/objects" default="clustering/objects"/>
+  <arg name="input/lidar_cluster/objects" default="clustering/objects"/>
   <arg name="input/detection_by_tracker/objects" default="detection_by_tracker/objects"/>
   <arg name="output/objects"/>
 
   <!-- internal interfaces -->
   <let name="merger1/input/objects0" value="$(var input/lidar_ml/objects)"/>
-  <let name="merger1/input/objects1" value="$(var input/lidar_rule/objects)"/>
+  <let name="merger1/input/objects1" value="$(var input/lidar_cluster/objects)"/>
   <let name="merger1/output/objects" value="$(var output/objects)" if="$(var without_dbt_and_filter)"/>
   <let name="merger1/output/objects" value="temporary_merged_objects" unless="$(var without_dbt_and_filter)"/>
 


### PR DESCRIPTION


## Description

## How was this PR tested?
- Tested with logging simulator: 
```
ros2 launch autoware_launch logging_simulator.launch.xml map_path:=/home/autoware/data/maps .. perception:=true use_semantic_segmentation_ptv3:=true use_multi_channel_tracker_merger:=false
```
<img width="1837" height="1124" alt="image" src="https://github.com/user-attachments/assets/25eada5e-54a9-4956-9448-e3067c7347f0" />

<img width="1837" height="1124" alt="image" src="https://github.com/user-attachments/assets/203170a6-0272-4d37-9a32-715bfc42aa96" />


```
ros2 launch autoware_launch logging_simulator.launch.xml map_path:=/home/autoware/data/maps .. perception:=true use_semantic_segmentation_ptv3:=true use_multi_channel_tracker_merger:=false perception_mode:=lidar
```
<img width="1821" height="333" alt="image" src="https://github.com/user-attachments/assets/b1edd8d1-8875-41d1-9f85-ba229d3967b9" />

<img width="1397" height="651" alt="image" src="https://github.com/user-attachments/assets/bb907ec3-3229-4331-a60d-65732532f435" />

## Notes for reviewers

None.

## Effects on system behavior

None.
