### PR TITLE
feat(map): launch map related node as standalone when agnocast

### DIFF
--- a/tier4_universe_launch/tier4_map_launch/launch/map.launch.xml
+++ b/tier4_universe_launch/tier4_map_launch/launch/map.launch.xml
@@ -13,39 +13,39 @@
   <arg name="map_projection_loader_param_path"/>
 
   <!-- select container type -->
-  <arg name="use_multithread" default="false"/>
-  <let name="container_type" value="component_container" unless="$(var use_multithread)"/>
-  <let name="container_type" value="component_container_mt" if="$(var use_multithread)"/>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
 
   <group>
     <push-ros-namespace namespace="map"/>
 
-    <node_container pkg="rclcpp_components" exec="$(var container_type)" name="map_container" namespace="" output="both">
-      <composable_node pkg="autoware_map_loader" plugin="autoware::map_loader::PointCloudMapLoaderNode" name="pointcloud_map_loader">
-        <param from="$(var pointcloud_map_loader_param_path)" allow_substs="true"/>
-        <remap from="output/pointcloud_map" to="pointcloud_map"/>
-        <remap from="output/pointcloud_map_metadata" to="pointcloud_map_metadata"/>
-        <remap from="service/get_partial_pcd_map" to="/map/get_partial_pointcloud_map"/>
-        <remap from="service/get_differential_pcd_map" to="/map/get_differential_pointcloud_map"/>
-        <remap from="service/get_selected_pcd_map" to="/map/get_selected_pointcloud_map"/>
-      </composable_node>
+    <node pkg="autoware_map_loader" exec="autoware_pointcloud_map_loader" name="pointcloud_map_loader" output="both">
+      <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+      <param from="$(var pointcloud_map_loader_param_path)" allow_substs="true"/>
+      <remap from="output/pointcloud_map" to="pointcloud_map"/>
+      <remap from="output/pointcloud_map_metadata" to="pointcloud_map_metadata"/>
+      <remap from="service/get_partial_pcd_map" to="/map/get_partial_pointcloud_map"/>
+      <remap from="service/get_differential_pcd_map" to="/map/get_differential_pointcloud_map"/>
+      <remap from="service/get_selected_pcd_map" to="/map/get_selected_pointcloud_map"/>
+    </node>
 
-      <composable_node pkg="autoware_map_loader" plugin="autoware::map_loader::Lanelet2MapLoaderNode" name="lanelet2_map_loader">
-        <param from="$(var lanelet2_map_loader_param_path)" allow_substs="true"/>
-        <remap from="output/lanelet2_map" to="vector_map"/>
-        <remap from="output/lanelet2_map_metadata" to="/map/vector_map_metadata"/>
-        <remap from="service/get_selected_lanelet2_map" to="/map/get_selected_vector_map"/>
-      </composable_node>
+    <node pkg="autoware_map_loader" exec="autoware_lanelet2_map_loader" name="lanelet2_map_loader" output="both">
+      <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+      <param from="$(var lanelet2_map_loader_param_path)" allow_substs="true"/>
+      <remap from="output/lanelet2_map" to="vector_map"/>
+      <remap from="output/lanelet2_map_metadata" to="/map/vector_map_metadata"/>
+      <remap from="service/get_selected_lanelet2_map" to="/map/get_selected_vector_map"/>
+    </node>
 
-      <composable_node pkg="autoware_lanelet2_map_visualizer" plugin="autoware::lanelet2_map_visualizer::Lanelet2MapVisualizationNode" name="lanelet2_map_visualization">
-        <remap from="input/lanelet2_map" to="vector_map"/>
-        <remap from="output/lanelet2_map_marker" to="vector_map_marker"/>
-      </composable_node>
+    <node pkg="autoware_lanelet2_map_visualizer" exec="autoware_lanelet2_map_visualizer" name="lanelet2_map_visualization" output="both">
+      <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+      <remap from="input/lanelet2_map" to="vector_map"/>
+      <remap from="output/lanelet2_map_marker" to="vector_map_marker"/>
+    </node>
 
-      <composable_node pkg="autoware_map_tf_generator" plugin="autoware::map_tf_generator::VectorMapTFGeneratorNode" name="vector_map_tf_generator">
-        <param from="$(var map_tf_generator_param_path)"/>
-      </composable_node>
-    </node_container>
+    <node pkg="autoware_map_tf_generator" exec="autoware_vector_map_tf_generator" name="vector_map_tf_generator" output="both">
+      <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+      <param from="$(var map_tf_generator_param_path)"/>
+    </node>
 
     <node pkg="autoware_map_loader" exec="map_hash_generator" name="map_hash_generator">
       <param name="lanelet2_map_path" value="$(var lanelet2_map_path)"/>

--- a/tier4_universe_launch/tier4_map_launch/package.xml
+++ b/tier4_universe_launch/tier4_map_launch/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <exec_depend>autoware_agnocast_wrapper</exec_depend>
   <exec_depend>autoware_map_loader</exec_depend>
   <exec_depend>autoware_map_projection_loader</exec_depend>
   <exec_depend>autoware_map_tf_generator</exec_depend>


### PR DESCRIPTION
## Description
When the map nodes are built with Agnocast enabled (`ENABLE_AGNOCAST=1`), they become `AgnocastOnly` nodes and can no longer run as composable nodes inside the standard `rclcpp` component container: the
  container only calls `rclcpp::init()`, so the Agnocast signal handler is never installed and the node fails to start.

  This PR makes the map node placement in `map.launch.xml` depend on `ENABLE_AGNOCAST`:

  - **`ENABLE_AGNOCAST=0` (default):** unchanged — `pointcloud_map_loader`, `lanelet2_map_loader`, `lanelet2_map_visualization`, and `vector_map_tf_generator` are loaded as composable nodes into 
  `map_container`.
  - **`ENABLE_AGNOCAST=1`:** the same nodes run as standalone executables (with `LD_PRELOAD` for the heaphook) so each one calls `agnocast::init()`. Zero-copy still works across processes via Agnocast, so
  co-locating them in a container is unnecessary.

  The switch is driven by a single `agnocast_enabled` flag (`if`/`unless` on each node), so the default (non-Agnocast) behavior is fully preserved.

  ## Related PRs
  - autowarefoundation/autoware_core#1193
  - autowarefoundation/autoware_core#1197
  - autowarefoundation/autoware_core#1198
  - autowarefoundation/autoware_universe#12832



## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
