### PR TITLE
feat(direction_change): propagate allow area for downstream modules

### DIFF
--- a/autoware_launch/config/control/lane_departure_checker/lane_departure_checker.param.yaml
+++ b/autoware_launch/config/control/lane_departure_checker/lane_departure_checker.param.yaml
@@ -26,7 +26,7 @@
     include_opposite_lanes: false
     include_conflicting_lanes: false
     # Must match mission_planner allow_area when using lanelet-area-lanelet routes
-    allow_area: true
+    allow_area: false
     boundary_types_to_detect: [curbstone]
 
 

--- a/autoware_launch/config/control/lane_departure_checker/lane_departure_checker.param.yaml
+++ b/autoware_launch/config/control/lane_departure_checker/lane_departure_checker.param.yaml
@@ -25,6 +25,8 @@
     include_left_lanes: false
     include_opposite_lanes: false
     include_conflicting_lanes: false
+    # Must match mission_planner allow_area when using lanelet-area-lanelet routes
+    allow_area: true
     boundary_types_to_detect: [curbstone]
 
 

--- a/autoware_launch/config/planning/mission_planning/mission_planner/mission_planner.param.yaml
+++ b/autoware_launch/config/planning/mission_planning/mission_planner/mission_planner.param.yaml
@@ -25,6 +25,6 @@
     minimum_reroute_length: 30.0
     consider_no_drivable_lanes: false # This flag is for considering no_drivable_lanes in planning or not.
     check_footprint_inside_lanes: true
-    allow_area: true # Set true to plan routes through lanelet-area-lanelet (e.g. direction change)
+    allow_area: false # Set true to plan routes through lanelet-area-lanelet (e.g. direction change)
     allow_reroute_in_autonomous_mode: true
     goal_lanelet_transparency: 0.05 # {OVERRIDE: Sets the transparency of the goal lanelet marker in RViz. Higher value makes the marker more visible.}

--- a/autoware_launch/config/planning/mission_planning/mission_planner/mission_planner.param.yaml
+++ b/autoware_launch/config/planning/mission_planning/mission_planner/mission_planner.param.yaml
@@ -25,5 +25,6 @@
     minimum_reroute_length: 30.0
     consider_no_drivable_lanes: false # This flag is for considering no_drivable_lanes in planning or not.
     check_footprint_inside_lanes: true
+    allow_area: true # Set true to plan routes through lanelet-area-lanelet (e.g. direction change)
     allow_reroute_in_autonomous_mode: true
     goal_lanelet_transparency: 0.05 # {OVERRIDE: Sets the transparency of the goal lanelet marker in RViz. Higher value makes the marker more visible.}

--- a/autoware_launch/config/planning/scenario_planning/common/planning_validator/planning_validator.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/common/planning_validator/planning_validator.param.yaml
@@ -36,3 +36,6 @@
 
     # discard outdated traffic light information and do not use it in validation.
     th_traffic_light_timeout: 0.5 # [s]
+
+    # Must match mission_planner allow_area when using lanelet-area-lanelet routes
+    allow_area: true

--- a/autoware_launch/config/planning/scenario_planning/common/planning_validator/planning_validator.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/common/planning_validator/planning_validator.param.yaml
@@ -38,4 +38,4 @@
     th_traffic_light_timeout: 0.5 # [s]
 
     # Must match mission_planner allow_area when using lanelet-area-lanelet routes
-    allow_area: true
+    allow_area: false

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_direction_change_module/direction_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/autoware_behavior_path_direction_change_module/direction_change.param.yaml
@@ -3,12 +3,8 @@
     direction_change:
       # ========================================
       # General parameters
-      # Module-level feature toggles and settings
       # ========================================
-      enable_cusp_detection: true  # Enable cusp point detection
-      enable_reverse_following: true  # Enable reverse lane following
-      publish_debug_marker: false  # Publish debug markers for visualization
-      print_debug_info: true # When true, log debug info (segment state, cusps, path analysis, etc.)
+      print_debug_info: false
       th_arrived_distance: 0.5  # [m] If ego within this distance of route goal, do not activate (align with arrival_check / th_arrived_distance)
 
       # ========================================
@@ -16,28 +12,19 @@
       # Detection of direction change points in path
       # ========================================
       cusp_detection_angle_threshold_deg: 90.0  # [deg] Angle threshold to detect cusp point
-      cusp_detection_distance_threshold: 0.2  # [m] Distance threshold to detect approaching cusp
-      cusp_detection_distance_start_approaching: 10.0  # [m] Distance to start approaching cusp (transition to APPROACHING_CUSP)
+      cusp_detection_distance_threshold: 1.2  # [m] Distance threshold to detect approaching cusp
+      cusp_detection_distance_start_approaching: 10.0  # [m] Distance to zero terminal velocity at cusp
 
       # ========================================
       # State transition parameters
       # Vehicle stop detection and state transitions
       # ========================================
       stop_velocity_threshold: 0.5  # [m/s] Velocity threshold to determine vehicle has stopped
-      th_stopped_time: 0.090  # [s] Duration velocity must stay below stop_velocity_threshold before direction switch at cusp
-
-      # ========================================
-      # Reverse behavior parameters
-      # Speed limits and path generation for reverse motion
-      # ========================================
-      reverse_initial_speed: 0.5  # [m/s] Upper speed limit for backward_slow_speed
-      reverse_speed_limit: 2.0  # [m/s] Upper speed limit for backward_cruise_speed (clamped by reference path speed)
-      reverse_path_densify_max_yaw_step_deg: 5.0  # [deg] Maximum yaw angle step for reverse path densification
-      reverse_path_densify_max_distance_step: 0.5  # [m] Maximum distance step for reverse path densification
+      th_stopped_time: 10.0  # [s] Duration velocity must stay below stop_velocity_threshold before direction switch at cusp
 
       # ========================================
       # Goal lateral shift parameters
       # Cubic polynomial blend from centerline to route goal pose
       # ========================================
       enable_goal_lateral_shift: true  # Enable cubic lateral shift toward goal on terminal approach
-      max_allowed_yaw_deg: 20.0  # [deg] Max heading change rate for maneuver length (nominal: 20, aggressive: 30)
+      max_allowed_yaw_deg: 10.0  # [deg] Max heading change rate for maneuver length (nominal: 20, aggressive: 30)

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -37,3 +37,6 @@
     enable_cog_on_centerline: false
     input_path_interval: 2.0
     output_path_interval: 2.0
+
+    # Must match mission_planner allow_area when using lanelet-area-lanelet routes
+    allow_area: true

--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/behavior_path_planner.param.yaml
@@ -39,4 +39,4 @@
     output_path_interval: 2.0
 
     # Must match mission_planner allow_area when using lanelet-area-lanelet routes
-    allow_area: true
+    allow_area: false


### PR DESCRIPTION
## Description

This PR is part of a  feature `direction_change` that allows cusp and reverse maneuvers in narrow spaces.  
This PR is to add parameter `allow_area` to allow the lanelet-area-lanelet route in the downstream modules. Since in current architecture each module validates the route with independently and separately, parameters in the respective modules created. 

**Related PRs**
- [link1](https://github.com/autowarefoundation/autoware_universe/pull/12815)
- [link2](https://github.com/autowarefoundation/autoware_universe/pull/12638) 
- [link3](https://github.com/autowarefoundation/autoware_core/pull/1194)
- [link4](https://github.com/autowarefoundation/autoware_launch/pull/1857)

## How was this PR tested?

- Colcon build and ran `Psim` simulations 

## Notes for reviewers

None.

## Effects on system behavior

None.
