### PR TITLE
chore(rviz): update perception configs for refactored rviz plugin and latest detection pipeline

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -3309,6 +3309,18 @@ Visualization Manager:
               Vector:
                 Twist: true
                 Yaw Rate: false
+            - Class: rviz_default_plugins/MarkerArray
+              Enabled: true
+              Name: TrackerDebug
+              Namespaces:
+                {}
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Reliable
+                Value: /perception/object_recognition/tracking/multi_object_tracker/debug/objects_markers
+              Value: true
           Enabled: false
           Name: Perception
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -792,9 +792,9 @@ Visualization Manager:
           Displays:
             - Class: rviz_common/Group
               Displays:
-                - Alpha: 0.999
+                - Alpha: 0.9990000128746033
                   Class: autoware_perception_rviz_plugin/DetectedObjects
-                  Color: 255; 255; 255
+                  Color: 255; 138; 128
                   Covariance:
                     Confidence Interval: 95%
                     Pose: true
@@ -802,8 +802,8 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.03
-                  Name: DetectedObjects
+                  Line Width: 0.10000000149011612
+                  Name: Centerpoint(red)
                   Namespaces:
                     {}
                   Path:
@@ -812,17 +812,7 @@ Visualization Manager:
                     Path Resolution: Normal
                     Predicted Path: true
                   Per Class Color:
-                    ANIMAL: 255; 105; 180
-                    BUS: 30; 144; 255
-                    CAR: 30; 144; 255
-                    CYCLIST: 119; 11; 32
-                    HAZARD: 255; 69; 0
-                    MOTORCYCLE: 119; 11; 32
-                    PEDESTRIAN: 255; 192; 203
-                    TRAILER: 30; 144; 255
-                    TRUCK: 30; 144; 255
-                    UNKNOWN: 255; 255; 255
-                    Value: true
+                    Value: false
                   Shape:
                     BBox Footprint: false
                     Mesh:
@@ -830,7 +820,7 @@ Visualization Manager:
                       Value: false
                     Shape Type: Skeleton 3D
                   Text:
-                    Acceleration: false
+                    Acceleration: true
                     Existence Probability: false
                     Label: true
                     UUID: true
@@ -840,18 +830,190 @@ Visualization Manager:
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
-                    Value: /perception/object_recognition/detection/objects
+                    Value: /perception/object_recognition/detection/centerpoint/objects
                   Value: true
                   Vector:
                     Twist: true
                     Yaw Rate: false
-              Enabled: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 255; 234; 0
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: Stream PETR(yellow)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/camera_only/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 178; 255; 89
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: PTv3 Cluster(light_green)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/clustering/label_based_euclidean_cluster/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 255; 128; 171
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: Irregular object(pink)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/irregular_object/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 255; 0; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: PTv3 Object(magenta)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/obstacle_segmentation/ptv3/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+              Enabled: true
               Name: Detection
             - Class: rviz_common/Group
               Displays:
                 - Alpha: 0.999
                   Class: autoware_perception_rviz_plugin/TrackedObjects
-                  Color: 255; 255; 255
+                  Color: 0; 255; 255
                   Covariance:
                     Confidence Interval: 95%
                     Pose: true
@@ -879,7 +1041,7 @@ Visualization Manager:
                     TRAILER: 30; 144; 255
                     TRUCK: 30; 144; 255
                     UNKNOWN: 255; 255; 255
-                    Value: true
+                    Value: false
                   Shape:
                     BBox Footprint: false
                     Mesh:
@@ -908,7 +1070,7 @@ Visualization Manager:
               Displays:
                 - Alpha: 0.999
                   Class: autoware_perception_rviz_plugin/PredictedObjects
-                  Color: 255; 255; 255
+                  Color: 30; 144; 255
                   Covariance:
                     Confidence Interval: 95%
                     Pose: false
@@ -936,7 +1098,7 @@ Visualization Manager:
                     TRAILER: 30; 144; 255
                     TRUCK: 30; 144; 255
                     UNKNOWN: 255; 255; 255
-                    Value: true
+                    Value: false
                   Shape:
                     BBox Footprint: false
                     Mesh:
@@ -2492,14 +2654,6 @@ Visualization Manager:
                   Map: true
                   Perception:
                     CameraLidarFusion(purple): true
-                    Centerpoint(red1): true
-                    CenterpointROIFusion(red2): true
-                    CenterpointValidator(red3): true
-                    Detection(yellow): true
-                    DetectionByTracker(cyan): true
-                    PointPainting(light_green1): true
-                    PointPaintingROIFusion(light_green2): true
-                    PointPaintingValidator(light_green3): true
                     Prediction(light_blue): true
                     RadarFarObjects(white): true
                     Tracking(green): true
@@ -2530,7 +2684,11 @@ Visualization Manager:
                 Perception:
                   ObjectRecognition:
                     Detection:
-                      DetectedObjects: true
+                      Centerpoint(red): true
+                      Irregular object(pink): true
+                      PTv3 Cluster(light_green): true
+                      PTv3 Object(magenta): true
+                      Stream PETR(yellow): true
                       Value: true
                     Prediction:
                       Maneuver: true
@@ -2917,377 +3075,6 @@ Visualization Manager:
                 Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              Name: Centerpoint(red1)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 138; 128
-                CAR: 255; 138; 128
-                CYCLIST: 255; 138; 128
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 138; 128
-                PEDESTRIAN: 255; 138; 128
-                TRAILER: 255; 138; 128
-                TRUCK: 255; 138; 128
-                UNKNOWN: 255; 138; 128
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/centerpoint/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: CenterpointROIFusion(red2)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 82; 82
-                CAR: 255; 82; 82
-                CYCLIST: 255; 82; 82
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 82; 82
-                PEDESTRIAN: 255; 82; 82
-                TRAILER: 255; 82; 82
-                TRUCK: 255; 82; 82
-                UNKNOWN: 255; 82; 82
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/centerpoint/roi_fusion/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: CenterpointValidator(red3)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 213; 0; 0
-                CAR: 213; 0; 0
-                CYCLIST: 213; 0; 0
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 213; 0; 0
-                PEDESTRIAN: 213; 0; 0
-                TRAILER: 213; 0; 0
-                TRUCK: 213; 0; 0
-                UNKNOWN: 213; 0; 0
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/centerpoint/validation/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: PointPainting(light_green1)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 178; 255; 89
-                CAR: 178; 255; 89
-                CYCLIST: 178; 255; 89
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 178; 255; 89
-                PEDESTRIAN: 178; 255; 89
-                TRAILER: 178; 255; 89
-                TRUCK: 178; 255; 89
-                UNKNOWN: 178; 255; 89
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/pointpainting/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: PointPaintingROIFusion(light_green2)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 118; 255; 3
-                CAR: 118; 255; 3
-                CYCLIST: 118; 255; 3
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 118; 255; 3
-                PEDESTRIAN: 118; 255; 3
-                TRAILER: 118; 255; 3
-                TRUCK: 118; 255; 3
-                UNKNOWN: 118; 255; 3
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/pointpainting/roi_fusion/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: PointPaintingValidator(light_green3)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 100; 221; 23
-                CAR: 100; 221; 23
-                CYCLIST: 100; 221; 23
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 100; 221; 23
-                PEDESTRIAN: 100; 221; 23
-                TRAILER: 100; 221; 23
-                TRUCK: 100; 221; 23
-                UNKNOWN: 100; 221; 23
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/pointpainting/validation/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: DetectionByTracker(orange)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 145; 0
-                CAR: 255; 145; 0
-                CYCLIST: 255; 145; 0
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 145; 0
-                PEDESTRIAN: 255; 145; 0
-                TRAILER: 255; 145; 0
-                TRUCK: 255; 145; 0
-                UNKNOWN: 255; 145; 0
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/detection_by_tracker/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
               Name: CameraLidarFusion(purple)
               Namespaces:
                 {}
@@ -3379,59 +3166,6 @@ Visualization Manager:
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/radar/far_objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: Detection(yellow)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 234; 0
-                CAR: 255; 234; 0
-                CYCLIST: 255; 234; 0
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 234; 0
-                PEDESTRIAN: 255; 234; 0
-                TRAILER: 255; 234; 0
-                TRUCK: 255; 234; 0
-                UNKNOWN: 255; 234; 0
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/objects
               Value: false
               Vector:
                 Twist: true

--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -792,147 +792,173 @@ Visualization Manager:
           Displays:
             - Class: rviz_common/Group
               Displays:
-                - BUS:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  CAR:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  CYCLIST:
-                    Alpha: 0.999
-                    Color: 119; 11; 32
+                - Alpha: 0.999
                   Class: autoware_perception_rviz_plugin/DetectedObjects
-                  Display 3d polygon: true
-                  Display Label: true
-                  Display PoseWithCovariance: true
-                  Display Predicted Path Confidence: true
-                  Display Predicted Paths: true
-                  Display Twist: true
-                  Display UUID: true
-                  Display Velocity: true
-                  Line Width: 0.03
+                  Color: 255; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
                   Enabled: true
-                  MOTORCYCLE:
-                    Alpha: 0.999
-                    Color: 119; 11; 32
+                  Line Width: 0.03
                   Name: DetectedObjects
-                  Namespaces: {}
-                  PEDESTRIAN:
-                    Alpha: 0.999
-                    Color: 255; 192; 203
-                  TRAILER:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  TRUCK:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    ANIMAL: 255; 105; 180
+                    BUS: 30; 144; 255
+                    CAR: 30; 144; 255
+                    CYCLIST: 119; 11; 32
+                    HAZARD: 255; 69; 0
+                    MOTORCYCLE: 119; 11; 32
+                    PEDESTRIAN: 255; 192; 203
+                    TRAILER: 30; 144; 255
+                    TRUCK: 30; 144; 255
+                    UNKNOWN: 255; 255; 255
+                    Value: true
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: false
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
                   Topic:
                     Depth: 5
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
                     Value: /perception/object_recognition/detection/objects
-                  UNKNOWN:
-                    Alpha: 0.999
-                    Color: 255; 255; 255
                   Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
               Enabled: false
               Name: Detection
             - Class: rviz_common/Group
               Displays:
-                - BUS:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  CAR:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  CYCLIST:
-                    Alpha: 0.999
-                    Color: 119; 11; 32
+                - Alpha: 0.999
                   Class: autoware_perception_rviz_plugin/TrackedObjects
-                  Display 3d polygon: true
-                  Display Label: true
-                  Display PoseWithCovariance: true
-                  Display Predicted Path Confidence: true
-                  Display Predicted Paths: true
-                  Display Twist: true
-                  Display UUID: true
-                  Display Velocity: true
-                  Line Width: 0.03
+                  Color: 255; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
                   Enabled: true
-                  MOTORCYCLE:
-                    Alpha: 0.999
-                    Color: 119; 11; 32
+                  Line Width: 0.03
                   Name: TrackedObjects
-                  Namespaces: {}
-                  PEDESTRIAN:
-                    Alpha: 0.999
-                    Color: 255; 192; 203
-                  TRAILER:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  TRUCK:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    ANIMAL: 255; 105; 180
+                    BUS: 30; 144; 255
+                    CAR: 30; 144; 255
+                    CYCLIST: 119; 11; 32
+                    HAZARD: 255; 69; 0
+                    MOTORCYCLE: 119; 11; 32
+                    PEDESTRIAN: 255; 192; 203
+                    TRAILER: 30; 144; 255
+                    TRUCK: 30; 144; 255
+                    UNKNOWN: 255; 255; 255
+                    Value: true
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: false
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
                   Topic:
                     Depth: 5
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
                     Value: /perception/object_recognition/tracking/objects
-                  UNKNOWN:
-                    Alpha: 0.999
-                    Color: 255; 255; 255
                   Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
               Enabled: false
               Name: Tracking
             - Class: rviz_common/Group
               Displays:
-                - BUS:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  CAR:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  CYCLIST:
-                    Alpha: 0.999
-                    Color: 119; 11; 32
+                - Alpha: 0.999
                   Class: autoware_perception_rviz_plugin/PredictedObjects
-                  Display 3d polygon: true
-                  Display Mesh: true
-                  Display Label: true
-                  Display PoseWithCovariance: false
-                  Display Predicted Path Confidence: true
-                  Display Predicted Paths: true
-                  Display Twist: true
-                  Display UUID: true
-                  Display Velocity: true
-                  Line Width: 0.03
+                  Color: 255; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: false
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
                   Enabled: true
-                  MOTORCYCLE:
-                    Alpha: 0.999
-                    Color: 119; 11; 32
+                  Line Width: 0.03
                   Name: PredictedObjects
-                  Namespaces: {}
-                  PEDESTRIAN:
-                    Alpha: 0.999
-                    Color: 255; 192; 203
-                  TRAILER:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  TRUCK:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    ANIMAL: 255; 105; 180
+                    BUS: 30; 144; 255
+                    CAR: 30; 144; 255
+                    CYCLIST: 119; 11; 32
+                    HAZARD: 255; 69; 0
+                    MOTORCYCLE: 119; 11; 32
+                    PEDESTRIAN: 255; 192; 203
+                    TRAILER: 30; 144; 255
+                    TRUCK: 30; 144; 255
+                    UNKNOWN: 255; 255; 255
+                    Value: true
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: true
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: false
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
                   Topic:
                     Depth: 5
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
                     Value: /perception/object_recognition/objects
-                  UNKNOWN:
-                    Alpha: 0.999
-                    Color: 255; 255; 255
                   Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
                 - Class: rviz_default_plugins/MarkerArray
                   Enabled: false
                   Name: Maneuver
@@ -2137,35 +2163,17 @@ Visualization Manager:
                 Value: /planning/planning_factors/diffusion_planner
               Value: true
               show_safety_factors: false
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 119; 11; 32
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/PredictedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 119; 11; 32
               Name: PredictedObjects
               Namespaces:
                 acceleration: true
@@ -2177,28 +2185,45 @@ Visualization Manager:
                 twist: true
                 uuid: true
                 velocity: true
-              Object Fill Type: Fill
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 192; 203
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 30; 144; 255
+                CAR: 30; 144; 255
+                CYCLIST: 119; 11; 32
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 119; 11; 32
+                PEDESTRIAN: 255; 192; 203
+                TRAILER: 30; 144; 255
+                TRUCK: 30; 144; 255
+                UNKNOWN: 255; 255; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Fill
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/output/predicted_objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
               Value: true
-              Visualization Type: Normal
+              Vector:
+                Twist: true
+                Yaw Rate: false
           Enabled: true
           Name: NeuralNetworkBasedPlanner
         - Class: rviz_common/Group
@@ -2718,53 +2743,59 @@ Visualization Manager:
               Use Fixed Frame: false
               Use rainbow: true
               Value: true
-            - BUS:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              CAR:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              CYCLIST:
-                Alpha: 0.5
-                Color: 255; 255; 255
+            - Alpha: 0.5
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.029999999329447746
-              MOTORCYCLE:
-                Alpha: 0.5
-                Color: 255; 255; 255
               Name: RadarRawObjects(white)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              TRUCK:
-                Alpha: 0.5
-                Color: 255; 255; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 255; 255
+                CAR: 255; 255; 255
+                CYCLIST: 255; 255; 255
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 255; 255
+                PEDESTRIAN: 255; 255; 255
+                TRAILER: 255; 255; 255
+                TRUCK: 255; 255; 255
+                UNKNOWN: 255; 255; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /sensing/radar/detected_objects
-              UNKNOWN:
-                Alpha: 0.5
-                Color: 255; 255; 255
               Value: true
-              Visualization Type: Normal
+              Vector:
+                Twist: true
+                Yaw Rate: false
           Enabled: false
           Name: Sensing
         - Class: rviz_common/Group
@@ -2875,570 +2906,642 @@ Visualization Manager:
               Value: true
         - Class: rviz_common/Group
           Displays:
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
               Name: Centerpoint(red1)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 138; 128
+                CAR: 255; 138; 128
+                CYCLIST: 255; 138; 128
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 138; 128
+                PEDESTRIAN: 255; 138; 128
+                TRAILER: 255; 138; 128
+                TRUCK: 255; 138; 128
+                UNKNOWN: 255; 138; 128
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/centerpoint/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
               Name: CenterpointROIFusion(red2)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 82; 82
+                CAR: 255; 82; 82
+                CYCLIST: 255; 82; 82
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 82; 82
+                PEDESTRIAN: 255; 82; 82
+                TRAILER: 255; 82; 82
+                TRUCK: 255; 82; 82
+                UNKNOWN: 255; 82; 82
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/centerpoint/roi_fusion/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
               Name: CenterpointValidator(red3)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 213; 0; 0
+                CAR: 213; 0; 0
+                CYCLIST: 213; 0; 0
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 213; 0; 0
+                PEDESTRIAN: 213; 0; 0
+                TRAILER: 213; 0; 0
+                TRUCK: 213; 0; 0
+                UNKNOWN: 213; 0; 0
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/centerpoint/validation/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
               Name: PointPainting(light_green1)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 178; 255; 89
+                CAR: 178; 255; 89
+                CYCLIST: 178; 255; 89
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 178; 255; 89
+                PEDESTRIAN: 178; 255; 89
+                TRAILER: 178; 255; 89
+                TRUCK: 178; 255; 89
+                UNKNOWN: 178; 255; 89
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/pointpainting/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
               Name: PointPaintingROIFusion(light_green2)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 118; 255; 3
+                CAR: 118; 255; 3
+                CYCLIST: 118; 255; 3
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 118; 255; 3
+                PEDESTRIAN: 118; 255; 3
+                TRAILER: 118; 255; 3
+                TRUCK: 118; 255; 3
+                UNKNOWN: 118; 255; 3
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/pointpainting/roi_fusion/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
               Name: PointPaintingValidator(light_green3)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 100; 221; 23
+                CAR: 100; 221; 23
+                CYCLIST: 100; 221; 23
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 100; 221; 23
+                PEDESTRIAN: 100; 221; 23
+                TRAILER: 100; 221; 23
+                TRUCK: 100; 221; 23
+                UNKNOWN: 100; 221; 23
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/pointpainting/validation/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
               Name: DetectionByTracker(orange)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 145; 0
+                CAR: 255; 145; 0
+                CYCLIST: 255; 145; 0
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 145; 0
+                PEDESTRIAN: 255; 145; 0
+                TRAILER: 255; 145; 0
+                TRUCK: 255; 145; 0
+                UNKNOWN: 255; 145; 0
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/detection_by_tracker/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
               Name: CameraLidarFusion(purple)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 213; 0; 249
+                CAR: 213; 0; 249
+                CYCLIST: 213; 0; 249
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 213; 0; 249
+                PEDESTRIAN: 213; 0; 249
+                TRAILER: 213; 0; 249
+                TRUCK: 213; 0; 249
+                UNKNOWN: 213; 0; 249
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/clustering/camera_lidar_fusion/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
               Name: RadarFarObjects(white)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 255; 255
+                CAR: 255; 255; 255
+                CYCLIST: 255; 255; 255
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 255; 255
+                PEDESTRIAN: 255; 255; 255
+                TRAILER: 255; 255; 255
+                TRUCK: 255; 255; 255
+                UNKNOWN: 255; 255; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/radar/far_objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
               Name: Detection(yellow)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 234; 0
+                CAR: 255; 234; 0
+                CYCLIST: 255; 234; 0
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 234; 0
+                PEDESTRIAN: 255; 234; 0
+                TRAILER: 255; 234; 0
+                TRUCK: 255; 234; 0
+                UNKNOWN: 255; 234; 0
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/TrackedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
               Name: Tracking(green)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 0; 230; 118
+                CAR: 0; 230; 118
+                CYCLIST: 0; 230; 118
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 0; 230; 118
+                PEDESTRIAN: 0; 230; 118
+                TRAILER: 0; 230; 118
+                TRUCK: 0; 230; 118
+                UNKNOWN: 0; 230; 118
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/tracking/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/PredictedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: false
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: false
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
               Name: Prediction(light_blue)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 0; 176; 255
+                CAR: 0; 176; 255
+                CYCLIST: 0; 176; 255
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 0; 176; 255
+                PEDESTRIAN: 0; 176; 255
+                TRAILER: 0; 176; 255
+                TRUCK: 0; 176; 255
+                UNKNOWN: 0; 176; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
               Value: false
-              Visualization Type: Normal
+              Vector:
+                Twist: true
+                Yaw Rate: false
           Enabled: false
           Name: Perception
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -1040,6 +1040,49 @@ Visualization Manager:
                   Vector:
                     Twist: true
                     Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 0; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: BEV Fusion(cyan)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/bevfusion/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
               Enabled: true
               Name: Detection
             - Class: rviz_common/Group

--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -786,6 +786,39 @@ Visualization Manager:
               Use Fixed Frame: true
               Use rainbow: true
               Value: true
+            - Alpha: 0.999
+              Autocompute Intensity Bounds: false
+              Autocompute Value Bounds:
+                Max Value: 15
+                Min Value: -2
+                Value: false
+              Axis: Z
+              Channel Name: class_id
+              Class: rviz_default_plugins/PointCloud2
+              Color: 200; 200; 200
+              Color Transformer: Intensity
+              Decay Time: 0
+              Enabled: false
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 16
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: SegmentedPointCloud
+              Position Transformer: XYZ
+              Selectable: false
+              Size (Pixels): 1.5
+              Size (m): 0.02
+              Style: Points
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /perception/segmented/pointcloud
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
           Enabled: true
           Name: Segmentation
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/autoware_test_utils.rviz
+++ b/autoware_launch/rviz/autoware_test_utils.rviz
@@ -3925,6 +3925,18 @@ Visualization Manager:
               Vector:
                 Twist: true
                 Yaw Rate: false
+            - Class: rviz_default_plugins/MarkerArray
+              Enabled: true
+              Name: TrackerDebug
+              Namespaces:
+                {}
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Reliable
+                Value: /perception/object_recognition/tracking/multi_object_tracker/debug/objects_markers
+              Value: true
           Enabled: true
           Name: Perception
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/autoware_test_utils.rviz
+++ b/autoware_launch/rviz/autoware_test_utils.rviz
@@ -688,177 +688,174 @@ Visualization Manager:
           Displays:
             - Class: rviz_common/Group
               Displays:
-                - BUS:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  CAR:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  CYCLIST:
-                    Alpha: 0.9990000128746033
-                    Color: 119; 11; 32
+                - Alpha: 0.9990000128746033
                   Class: autoware_perception_rviz_plugin/DetectedObjects
-                  Confidence Interval: 95%
-                  Display Acceleration: true
-                  Display Existence Probability: false
-                  Display Label: true
-                  Display Pose Covariance: true
-                  Display Predicted Path Confidence: true
-                  Display Predicted Paths: true
-                  Display Twist: true
-                  Display Twist Covariance: false
-                  Display UUID: true
-                  Display Velocity: true
-                  Display Yaw Covariance: false
-                  Display Yaw Rate: false
-                  Display Yaw Rate Covariance: false
+                  Color: 255; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
                   Enabled: true
                   Line Width: 0.029999999329447746
-                  MOTORCYCLE:
-                    Alpha: 0.9990000128746033
-                    Color: 119; 11; 32
                   Name: DetectedObjects
                   Namespaces:
                     {}
-                  Object Fill Type: skeleton
-                  PEDESTRIAN:
-                    Alpha: 0.9990000128746033
-                    Color: 255; 192; 203
-                  Polygon Type: 3d
-                  TRAILER:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  TRUCK:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    ANIMAL: 255; 105; 180
+                    BUS: 30; 144; 255
+                    CAR: 30; 144; 255
+                    CYCLIST: 119; 11; 32
+                    HAZARD: 255; 69; 0
+                    MOTORCYCLE: 119; 11; 32
+                    PEDESTRIAN: 255; 192; 203
+                    TRAILER: 30; 144; 255
+                    TRUCK: 30; 144; 255
+                    UNKNOWN: 255; 255; 255
+                    Value: true
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
                   Topic:
                     Depth: 5
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
                     Value: /perception/object_recognition/detection/objects
-                  UNKNOWN:
-                    Alpha: 0.9990000128746033
-                    Color: 255; 255; 255
                   Value: true
-                  Visualization Type: Normal
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
               Enabled: false
               Name: Detection
             - Class: rviz_common/Group
               Displays:
-                - BUS:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  CAR:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  CYCLIST:
-                    Alpha: 0.9990000128746033
-                    Color: 119; 11; 32
+                - Alpha: 0.9990000128746033
                   Class: autoware_perception_rviz_plugin/TrackedObjects
-                  Confidence Interval: 95%
-                  Display Acceleration: true
-                  Display Existence Probability: false
-                  Display Label: true
-                  Display Pose Covariance: true
-                  Display Predicted Path Confidence: true
-                  Display Predicted Paths: true
-                  Display Twist: true
-                  Display Twist Covariance: false
-                  Display UUID: true
-                  Display Velocity: true
-                  Display Yaw Covariance: false
-                  Display Yaw Rate: false
-                  Display Yaw Rate Covariance: false
+                  Color: 255; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
                   Dynamic Status: All
                   Enabled: true
                   Line Width: 0.029999999329447746
-                  MOTORCYCLE:
-                    Alpha: 0.9990000128746033
-                    Color: 119; 11; 32
                   Name: TrackedObjects
                   Namespaces:
                     {}
-                  Object Fill Type: skeleton
-                  PEDESTRIAN:
-                    Alpha: 0.9990000128746033
-                    Color: 255; 192; 203
-                  Polygon Type: 3d
-                  TRAILER:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  TRUCK:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    ANIMAL: 255; 105; 180
+                    BUS: 30; 144; 255
+                    CAR: 30; 144; 255
+                    CYCLIST: 119; 11; 32
+                    HAZARD: 255; 69; 0
+                    MOTORCYCLE: 119; 11; 32
+                    PEDESTRIAN: 255; 192; 203
+                    TRAILER: 30; 144; 255
+                    TRUCK: 30; 144; 255
+                    UNKNOWN: 255; 255; 255
+                    Value: true
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
                   Topic:
                     Depth: 5
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
                     Value: /perception/object_recognition/tracking/objects
-                  UNKNOWN:
-                    Alpha: 0.9990000128746033
-                    Color: 255; 255; 255
                   Value: true
-                  Visualization Type: Normal
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
               Enabled: false
               Name: Tracking
             - Class: rviz_common/Group
               Displays:
-                - BUS:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  CAR:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  CYCLIST:
-                    Alpha: 0.9990000128746033
-                    Color: 119; 11; 32
+                - Alpha: 0.9990000128746033
                   Class: autoware_perception_rviz_plugin/PredictedObjects
-                  Confidence Interval: 95%
-                  Display Acceleration: true
-                  Display Existence Probability: false
-                  Display Label: true
-                  Display Pose Covariance: true
-                  Display Predicted Path Confidence: true
-                  Display Predicted Paths: true
-                  Display Twist: true
-                  Display Twist Covariance: false
-                  Display UUID: true
-                  Display Velocity: true
-                  Display Yaw Covariance: false
-                  Display Yaw Rate: false
-                  Display Yaw Rate Covariance: false
+                  Color: 255; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
                   Enabled: true
                   Line Width: 0.029999999329447746
-                  MOTORCYCLE:
-                    Alpha: 0.9990000128746033
-                    Color: 119; 11; 32
                   Name: PredictedObjects
                   Namespaces:
                     {}
-                  Object Fill Type: skeleton
-                  PEDESTRIAN:
-                    Alpha: 0.9990000128746033
-                    Color: 255; 192; 203
-                  Polygon Type: 3d
-                  TRAILER:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  TRUCK:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    ANIMAL: 255; 105; 180
+                    BUS: 30; 144; 255
+                    CAR: 30; 144; 255
+                    CYCLIST: 119; 11; 32
+                    HAZARD: 255; 69; 0
+                    MOTORCYCLE: 119; 11; 32
+                    PEDESTRIAN: 255; 192; 203
+                    TRAILER: 30; 144; 255
+                    TRUCK: 30; 144; 255
+                    UNKNOWN: 255; 255; 255
+                    Value: true
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
                   Topic:
                     Depth: 5
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
                     Value: /perception/object_recognition/objects
-                  UNKNOWN:
-                    Alpha: 0.9990000128746033
-                    Color: 255; 255; 255
                   Value: true
-                  Visualization Type: Normal
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
                 - Class: rviz_default_plugins/MarkerArray
                   Enabled: false
                   Name: Maneuver
@@ -3353,60 +3350,59 @@ Visualization Manager:
               Use Fixed Frame: false
               Use rainbow: true
               Value: true
-            - BUS:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              CAR:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              CYCLIST:
-                Alpha: 0.5
-                Color: 255; 255; 255
+            - Alpha: 0.5
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.029999999329447746
-              MOTORCYCLE:
-                Alpha: 0.5
-                Color: 255; 255; 255
               Name: RadarRawObjects(white)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              TRUCK:
-                Alpha: 0.5
-                Color: 255; 255; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 255; 255
+                CAR: 255; 255; 255
+                CYCLIST: 255; 255; 255
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 255; 255
+                PEDESTRIAN: 255; 255; 255
+                TRAILER: 255; 255; 255
+                TRUCK: 255; 255; 255
+                UNKNOWN: 255; 255; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /sensing/radar/detected_objects
-              UNKNOWN:
-                Alpha: 0.5
-                Color: 255; 255; 255
               Value: true
-              Visualization Type: Normal
+              Vector:
+                Twist: true
+                Yaw Rate: false
           Enabled: false
           Name: Sensing
         - Class: rviz_common/Group
@@ -3517,655 +3513,643 @@ Visualization Manager:
           Name: Localization
         - Class: rviz_common/Group
           Displays:
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
               Name: Centerpoint(red1)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 138; 128
+                CAR: 255; 138; 128
+                CYCLIST: 255; 138; 128
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 138; 128
+                PEDESTRIAN: 255; 138; 128
+                TRAILER: 255; 138; 128
+                TRUCK: 255; 138; 128
+                UNKNOWN: 255; 138; 128
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/centerpoint/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
               Name: CenterpointROIFusion(red2)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 82; 82
+                CAR: 255; 82; 82
+                CYCLIST: 255; 82; 82
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 82; 82
+                PEDESTRIAN: 255; 82; 82
+                TRAILER: 255; 82; 82
+                TRUCK: 255; 82; 82
+                UNKNOWN: 255; 82; 82
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/centerpoint/roi_fusion/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
               Name: CenterpointValidator(red3)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 213; 0; 0
+                CAR: 213; 0; 0
+                CYCLIST: 213; 0; 0
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 213; 0; 0
+                PEDESTRIAN: 213; 0; 0
+                TRAILER: 213; 0; 0
+                TRUCK: 213; 0; 0
+                UNKNOWN: 213; 0; 0
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/centerpoint/validation/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
               Name: PointPainting(light_green1)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 178; 255; 89
+                CAR: 178; 255; 89
+                CYCLIST: 178; 255; 89
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 178; 255; 89
+                PEDESTRIAN: 178; 255; 89
+                TRAILER: 178; 255; 89
+                TRUCK: 178; 255; 89
+                UNKNOWN: 178; 255; 89
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/pointpainting/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
               Name: PointPaintingROIFusion(light_green2)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 118; 255; 3
+                CAR: 118; 255; 3
+                CYCLIST: 118; 255; 3
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 118; 255; 3
+                PEDESTRIAN: 118; 255; 3
+                TRAILER: 118; 255; 3
+                TRUCK: 118; 255; 3
+                UNKNOWN: 118; 255; 3
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/pointpainting/roi_fusion/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
               Name: PointPaintingValidator(light_green3)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 100; 221; 23
+                CAR: 100; 221; 23
+                CYCLIST: 100; 221; 23
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 100; 221; 23
+                PEDESTRIAN: 100; 221; 23
+                TRAILER: 100; 221; 23
+                TRUCK: 100; 221; 23
+                UNKNOWN: 100; 221; 23
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/pointpainting/validation/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
               Name: DetectionByTracker(orange)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 145; 0
+                CAR: 255; 145; 0
+                CYCLIST: 255; 145; 0
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 145; 0
+                PEDESTRIAN: 255; 145; 0
+                TRAILER: 255; 145; 0
+                TRUCK: 255; 145; 0
+                UNKNOWN: 255; 145; 0
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/detection_by_tracker/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
               Name: CameraLidarFusion(purple)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 213; 0; 249
+                CAR: 213; 0; 249
+                CYCLIST: 213; 0; 249
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 213; 0; 249
+                PEDESTRIAN: 213; 0; 249
+                TRAILER: 213; 0; 249
+                TRUCK: 213; 0; 249
+                UNKNOWN: 213; 0; 249
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/clustering/camera_lidar_fusion/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
               Name: RadarFarObjects(white)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 255; 255
+                CAR: 255; 255; 255
+                CYCLIST: 255; 255; 255
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 255; 255
+                PEDESTRIAN: 255; 255; 255
+                TRAILER: 255; 255; 255
+                TRUCK: 255; 255; 255
+                UNKNOWN: 255; 255; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/radar/far_objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
               Name: Detection(yellow)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 234; 0
+                CAR: 255; 234; 0
+                CYCLIST: 255; 234; 0
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 234; 0
+                PEDESTRIAN: 255; 234; 0
+                TRAILER: 255; 234; 0
+                TRUCK: 255; 234; 0
+                UNKNOWN: 255; 234; 0
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/TrackedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Dynamic Status: All
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
               Name: Tracking(green)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 0; 230; 118
+                CAR: 0; 230; 118
+                CYCLIST: 0; 230; 118
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 0; 230; 118
+                PEDESTRIAN: 0; 230; 118
+                TRAILER: 0; 230; 118
+                TRUCK: 0; 230; 118
+                UNKNOWN: 0; 230; 118
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/tracking/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/PredictedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
               Name: Prediction(light_blue)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 0; 176; 255
+                CAR: 0; 176; 255
+                CYCLIST: 0; 176; 255
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 0; 176; 255
+                PEDESTRIAN: 0; 176; 255
+                TRAILER: 0; 176; 255
+                TRUCK: 0; 176; 255
+                UNKNOWN: 0; 176; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
               Value: true
-              Visualization Type: Normal
+              Vector:
+                Twist: true
+                Yaw Rate: false
           Enabled: true
           Name: Perception
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/autoware_test_utils.rviz
+++ b/autoware_launch/rviz/autoware_test_utils.rviz
@@ -936,6 +936,49 @@ Visualization Manager:
                   Vector:
                     Twist: true
                     Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 0; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: BEV Fusion(cyan)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/bevfusion/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
               Enabled: true
               Name: Detection
             - Class: rviz_common/Group

--- a/autoware_launch/rviz/autoware_test_utils.rviz
+++ b/autoware_launch/rviz/autoware_test_utils.rviz
@@ -690,7 +690,7 @@ Visualization Manager:
               Displays:
                 - Alpha: 0.9990000128746033
                   Class: autoware_perception_rviz_plugin/DetectedObjects
-                  Color: 255; 255; 255
+                  Color: 255; 138; 128
                   Covariance:
                     Confidence Interval: 95%
                     Pose: true
@@ -698,8 +698,8 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.029999999329447746
-                  Name: DetectedObjects
+                  Line Width: 0.10000000149011612
+                  Name: Centerpoint(red)
                   Namespaces:
                     {}
                   Path:
@@ -708,17 +708,7 @@ Visualization Manager:
                     Path Resolution: Normal
                     Predicted Path: true
                   Per Class Color:
-                    ANIMAL: 255; 105; 180
-                    BUS: 30; 144; 255
-                    CAR: 30; 144; 255
-                    CYCLIST: 119; 11; 32
-                    HAZARD: 255; 69; 0
-                    MOTORCYCLE: 119; 11; 32
-                    PEDESTRIAN: 255; 192; 203
-                    TRAILER: 30; 144; 255
-                    TRUCK: 30; 144; 255
-                    UNKNOWN: 255; 255; 255
-                    Value: true
+                    Value: false
                   Shape:
                     BBox Footprint: false
                     Mesh:
@@ -736,12 +726,184 @@ Visualization Manager:
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
-                    Value: /perception/object_recognition/detection/objects
+                    Value: /perception/object_recognition/detection/centerpoint/objects
                   Value: true
                   Vector:
                     Twist: true
                     Yaw Rate: false
-              Enabled: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 255; 234; 0
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: Stream PETR(yellow)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/camera_only/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 178; 255; 89
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: PTv3 Cluster(light_green)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/clustering/label_based_euclidean_cluster/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 255; 128; 171
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: Irregular object(pink)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/irregular_object/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 255; 0; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: PTv3 Object(magenta)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/obstacle_segmentation/ptv3/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+              Enabled: true
               Name: Detection
             - Class: rviz_common/Group
               Displays:
@@ -3144,7 +3306,11 @@ Visualization Manager:
                 Perception:
                   ObjectRecognition:
                     Detection:
-                      DetectedObjects: true
+                      Centerpoint(red): true
+                      Irregular object(pink): true
+                      PTv3 Cluster(light_green): true
+                      PTv3 Object(magenta): true
+                      Stream PETR(yellow): true
                       Value: true
                     Prediction:
                       Maneuver: true
@@ -3524,377 +3690,6 @@ Visualization Manager:
                 Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              Name: Centerpoint(red1)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 138; 128
-                CAR: 255; 138; 128
-                CYCLIST: 255; 138; 128
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 138; 128
-                PEDESTRIAN: 255; 138; 128
-                TRAILER: 255; 138; 128
-                TRUCK: 255; 138; 128
-                UNKNOWN: 255; 138; 128
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/centerpoint/objects
-              Value: true
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: CenterpointROIFusion(red2)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 82; 82
-                CAR: 255; 82; 82
-                CYCLIST: 255; 82; 82
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 82; 82
-                PEDESTRIAN: 255; 82; 82
-                TRAILER: 255; 82; 82
-                TRUCK: 255; 82; 82
-                UNKNOWN: 255; 82; 82
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/centerpoint/roi_fusion/objects
-              Value: true
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: CenterpointValidator(red3)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 213; 0; 0
-                CAR: 213; 0; 0
-                CYCLIST: 213; 0; 0
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 213; 0; 0
-                PEDESTRIAN: 213; 0; 0
-                TRAILER: 213; 0; 0
-                TRUCK: 213; 0; 0
-                UNKNOWN: 213; 0; 0
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/centerpoint/validation/objects
-              Value: true
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: PointPainting(light_green1)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 178; 255; 89
-                CAR: 178; 255; 89
-                CYCLIST: 178; 255; 89
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 178; 255; 89
-                PEDESTRIAN: 178; 255; 89
-                TRAILER: 178; 255; 89
-                TRUCK: 178; 255; 89
-                UNKNOWN: 178; 255; 89
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/pointpainting/objects
-              Value: true
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: PointPaintingROIFusion(light_green2)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 118; 255; 3
-                CAR: 118; 255; 3
-                CYCLIST: 118; 255; 3
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 118; 255; 3
-                PEDESTRIAN: 118; 255; 3
-                TRAILER: 118; 255; 3
-                TRUCK: 118; 255; 3
-                UNKNOWN: 118; 255; 3
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/pointpainting/roi_fusion/objects
-              Value: true
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: PointPaintingValidator(light_green3)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 100; 221; 23
-                CAR: 100; 221; 23
-                CYCLIST: 100; 221; 23
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 100; 221; 23
-                PEDESTRIAN: 100; 221; 23
-                TRAILER: 100; 221; 23
-                TRUCK: 100; 221; 23
-                UNKNOWN: 100; 221; 23
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/pointpainting/validation/objects
-              Value: true
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: DetectionByTracker(orange)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 145; 0
-                CAR: 255; 145; 0
-                CYCLIST: 255; 145; 0
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 145; 0
-                PEDESTRIAN: 255; 145; 0
-                TRAILER: 255; 145; 0
-                TRUCK: 255; 145; 0
-                UNKNOWN: 255; 145; 0
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/detection_by_tracker/objects
-              Value: true
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
               Name: CameraLidarFusion(purple)
               Namespaces:
                 {}
@@ -3986,59 +3781,6 @@ Visualization Manager:
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/radar/far_objects
-              Value: true
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: Detection(yellow)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 234; 0
-                CAR: 255; 234; 0
-                CYCLIST: 255; 234; 0
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 234; 0
-                PEDESTRIAN: 255; 234; 0
-                TRAILER: 255; 234; 0
-                TRUCK: 255; 234; 0
-                UNKNOWN: 255; 234; 0
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/objects
               Value: true
               Vector:
                 Twist: true

--- a/autoware_launch/rviz/autoware_test_utils.rviz
+++ b/autoware_launch/rviz/autoware_test_utils.rviz
@@ -682,6 +682,39 @@ Visualization Manager:
               Use Fixed Frame: true
               Use rainbow: true
               Value: true
+            - Alpha: 0.999
+              Autocompute Intensity Bounds: false
+              Autocompute Value Bounds:
+                Max Value: 15
+                Min Value: -2
+                Value: false
+              Axis: Z
+              Channel Name: class_id
+              Class: rviz_default_plugins/PointCloud2
+              Color: 200; 200; 200
+              Color Transformer: Intensity
+              Decay Time: 0
+              Enabled: false
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 16
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: SegmentedPointCloud
+              Position Transformer: XYZ
+              Selectable: false
+              Size (Pixels): 1.5
+              Size (m): 0.02
+              Style: Points
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /perception/segmented/pointcloud
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
           Enabled: true
           Name: Segmentation
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/perception.rviz
+++ b/autoware_launch/rviz/perception.rviz
@@ -808,177 +808,174 @@ Visualization Manager:
           Displays:
             - Class: rviz_common/Group
               Displays:
-                - BUS:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  CAR:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  CYCLIST:
-                    Alpha: 0.9990000128746033
-                    Color: 119; 11; 32
+                - Alpha: 0.9990000128746033
                   Class: autoware_perception_rviz_plugin/DetectedObjects
-                  Confidence Interval: 95%
-                  Display Acceleration: true
-                  Display Existence Probability: false
-                  Display Label: true
-                  Display Pose Covariance: true
-                  Display Predicted Path Confidence: true
-                  Display Predicted Paths: true
-                  Display Twist: true
-                  Display Twist Covariance: false
-                  Display UUID: true
-                  Display Velocity: true
-                  Display Yaw Covariance: false
-                  Display Yaw Rate: false
-                  Display Yaw Rate Covariance: false
+                  Color: 255; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
                   Enabled: true
                   Line Width: 0.029999999329447746
-                  MOTORCYCLE:
-                    Alpha: 0.9990000128746033
-                    Color: 119; 11; 32
                   Name: DetectedObjects
                   Namespaces:
                     {}
-                  Object Fill Type: skeleton
-                  PEDESTRIAN:
-                    Alpha: 0.9990000128746033
-                    Color: 255; 192; 203
-                  Polygon Type: 3d
-                  TRAILER:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  TRUCK:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    ANIMAL: 255; 105; 180
+                    BUS: 30; 144; 255
+                    CAR: 30; 144; 255
+                    CYCLIST: 119; 11; 32
+                    HAZARD: 255; 69; 0
+                    MOTORCYCLE: 119; 11; 32
+                    PEDESTRIAN: 255; 192; 203
+                    TRAILER: 30; 144; 255
+                    TRUCK: 30; 144; 255
+                    UNKNOWN: 255; 255; 255
+                    Value: true
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
                   Topic:
                     Depth: 5
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
                     Value: /perception/object_recognition/detection/objects
-                  UNKNOWN:
-                    Alpha: 0.9990000128746033
-                    Color: 255; 255; 255
                   Value: true
-                  Visualization Type: Normal
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
               Enabled: false
               Name: Detection
             - Class: rviz_common/Group
               Displays:
-                - BUS:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  CAR:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  CYCLIST:
-                    Alpha: 0.9990000128746033
-                    Color: 119; 11; 32
+                - Alpha: 0.9990000128746033
                   Class: autoware_perception_rviz_plugin/TrackedObjects
-                  Confidence Interval: 95%
-                  Display Acceleration: true
-                  Display Existence Probability: false
-                  Display Label: true
-                  Display Pose Covariance: true
-                  Display Predicted Path Confidence: true
-                  Display Predicted Paths: true
-                  Display Twist: true
-                  Display Twist Covariance: false
-                  Display UUID: true
-                  Display Velocity: true
-                  Display Yaw Covariance: false
-                  Display Yaw Rate: false
-                  Display Yaw Rate Covariance: false
+                  Color: 255; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
                   Dynamic Status: All
                   Enabled: true
                   Line Width: 0.029999999329447746
-                  MOTORCYCLE:
-                    Alpha: 0.9990000128746033
-                    Color: 119; 11; 32
                   Name: TrackedObjects
                   Namespaces:
                     {}
-                  Object Fill Type: skeleton
-                  PEDESTRIAN:
-                    Alpha: 0.9990000128746033
-                    Color: 255; 192; 203
-                  Polygon Type: 3d
-                  TRAILER:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  TRUCK:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    ANIMAL: 255; 105; 180
+                    BUS: 30; 144; 255
+                    CAR: 30; 144; 255
+                    CYCLIST: 119; 11; 32
+                    HAZARD: 255; 69; 0
+                    MOTORCYCLE: 119; 11; 32
+                    PEDESTRIAN: 255; 192; 203
+                    TRAILER: 30; 144; 255
+                    TRUCK: 30; 144; 255
+                    UNKNOWN: 255; 255; 255
+                    Value: true
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
                   Topic:
                     Depth: 5
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
                     Value: /perception/object_recognition/tracking/objects
-                  UNKNOWN:
-                    Alpha: 0.9990000128746033
-                    Color: 255; 255; 255
                   Value: true
-                  Visualization Type: Normal
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
               Enabled: false
               Name: Tracking
             - Class: rviz_common/Group
               Displays:
-                - BUS:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  CAR:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  CYCLIST:
-                    Alpha: 0.9990000128746033
-                    Color: 119; 11; 32
+                - Alpha: 0.9990000128746033
                   Class: autoware_perception_rviz_plugin/PredictedObjects
-                  Confidence Interval: 95%
-                  Display Acceleration: true
-                  Display Existence Probability: false
-                  Display Label: true
-                  Display Pose Covariance: true
-                  Display Predicted Path Confidence: true
-                  Display Predicted Paths: true
-                  Display Twist: true
-                  Display Twist Covariance: false
-                  Display UUID: true
-                  Display Velocity: true
-                  Display Yaw Covariance: false
-                  Display Yaw Rate: false
-                  Display Yaw Rate Covariance: false
+                  Color: 255; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
                   Enabled: true
                   Line Width: 0.029999999329447746
-                  MOTORCYCLE:
-                    Alpha: 0.9990000128746033
-                    Color: 119; 11; 32
                   Name: PredictedObjects
                   Namespaces:
                     {}
-                  Object Fill Type: skeleton
-                  PEDESTRIAN:
-                    Alpha: 0.9990000128746033
-                    Color: 255; 192; 203
-                  Polygon Type: 3d
-                  TRAILER:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  TRUCK:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    ANIMAL: 255; 105; 180
+                    BUS: 30; 144; 255
+                    CAR: 30; 144; 255
+                    CYCLIST: 119; 11; 32
+                    HAZARD: 255; 69; 0
+                    MOTORCYCLE: 119; 11; 32
+                    PEDESTRIAN: 255; 192; 203
+                    TRAILER: 30; 144; 255
+                    TRUCK: 30; 144; 255
+                    UNKNOWN: 255; 255; 255
+                    Value: true
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
                   Topic:
                     Depth: 5
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
                     Value: /perception/object_recognition/objects
-                  UNKNOWN:
-                    Alpha: 0.9990000128746033
-                    Color: 255; 255; 255
                   Value: true
-                  Visualization Type: Normal
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
                 - Class: rviz_default_plugins/MarkerArray
                   Enabled: false
                   Name: Maneuver
@@ -3394,60 +3391,59 @@ Visualization Manager:
               Use Fixed Frame: false
               Use rainbow: true
               Value: true
-            - BUS:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              CAR:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              CYCLIST:
-                Alpha: 0.5
-                Color: 255; 255; 255
+            - Alpha: 0.5
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.029999999329447746
-              MOTORCYCLE:
-                Alpha: 0.5
-                Color: 255; 255; 255
               Name: RadarRawObjects(white)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              TRUCK:
-                Alpha: 0.5
-                Color: 255; 255; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 255; 255
+                CAR: 255; 255; 255
+                CYCLIST: 255; 255; 255
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 255; 255
+                PEDESTRIAN: 255; 255; 255
+                TRAILER: 255; 255; 255
+                TRUCK: 255; 255; 255
+                UNKNOWN: 255; 255; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /sensing/radar/detected_objects
-              UNKNOWN:
-                Alpha: 0.5
-                Color: 255; 255; 255
               Value: true
-              Visualization Type: Normal
+              Vector:
+                Twist: true
+                Yaw Rate: false
           Enabled: false
           Name: Sensing
         - Class: rviz_common/Group
@@ -3558,35 +3554,17 @@ Visualization Manager:
           Name: Localization
         - Class: rviz_common/Group
           Displays:
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
               Name: Centerpoint(red1)
               Namespaces:
                 label: true
@@ -3594,111 +3572,109 @@ Visualization Manager:
                 shape: true
                 twist: true
                 velocity: true
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 138; 128
+                CAR: 255; 138; 128
+                CYCLIST: 255; 138; 128
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 138; 128
+                PEDESTRIAN: 255; 138; 128
+                TRAILER: 255; 138; 128
+                TRUCK: 255; 138; 128
+                UNKNOWN: 255; 138; 128
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/centerpoint/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
               Name: CenterpointROIFusion(red2)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 82; 82
+                CAR: 255; 82; 82
+                CYCLIST: 255; 82; 82
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 82; 82
+                PEDESTRIAN: 255; 82; 82
+                TRAILER: 255; 82; 82
+                TRUCK: 255; 82; 82
+                UNKNOWN: 255; 82; 82
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/centerpoint/roi_fusion/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
               Name: CenterpointValidator(red3)
               Namespaces:
                 label: true
@@ -3706,219 +3682,215 @@ Visualization Manager:
                 shape: true
                 twist: true
                 velocity: true
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 213; 0; 0
+                CAR: 213; 0; 0
+                CYCLIST: 213; 0; 0
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 213; 0; 0
+                PEDESTRIAN: 213; 0; 0
+                TRAILER: 213; 0; 0
+                TRUCK: 213; 0; 0
+                UNKNOWN: 213; 0; 0
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/centerpoint/validation/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: false
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: false
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
               Name: PointPainting(light_green1)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              Polygon Type: 2d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 178; 255; 89
+                CAR: 178; 255; 89
+                CYCLIST: 178; 255; 89
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 178; 255; 89
+                PEDESTRIAN: 178; 255; 89
+                TRAILER: 178; 255; 89
+                TRUCK: 178; 255; 89
+                UNKNOWN: 178; 255; 89
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 2D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: false
+                UUID: true
+                Velocity: false
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/pointpainting/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: false
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: false
-              Display Velocity: false
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
               Name: PointPaintingROIFusion(light_green2)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              Polygon Type: 2d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 118; 255; 3
+                CAR: 118; 255; 3
+                CYCLIST: 118; 255; 3
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 118; 255; 3
+                PEDESTRIAN: 118; 255; 3
+                TRAILER: 118; 255; 3
+                TRUCK: 118; 255; 3
+                UNKNOWN: 118; 255; 3
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 2D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: false
+                UUID: false
+                Velocity: false
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/pointpainting/roi_fusion/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: false
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: false
-              Display Velocity: false
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
               Name: PointPaintingValidator(light_green3)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              Polygon Type: 2d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 100; 221; 23
+                CAR: 100; 221; 23
+                CYCLIST: 100; 221; 23
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 100; 221; 23
+                PEDESTRIAN: 100; 221; 23
+                TRAILER: 100; 221; 23
+                TRUCK: 100; 221; 23
+                UNKNOWN: 100; 221; 23
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 2D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: false
+                UUID: false
+                Velocity: false
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/pointpainting/validation/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
               Name: DetectionByTracker(orange)
               Namespaces:
                 label: true
@@ -3926,165 +3898,162 @@ Visualization Manager:
                 shape: true
                 twist: true
                 velocity: true
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              Polygon Type: 2d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 145; 0
+                CAR: 255; 145; 0
+                CYCLIST: 255; 145; 0
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 145; 0
+                PEDESTRIAN: 255; 145; 0
+                TRAILER: 255; 145; 0
+                TRUCK: 255; 145; 0
+                UNKNOWN: 255; 145; 0
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 2D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/detection_by_tracker/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.30000001192092896
-                Color: 213; 0; 249
-              CAR:
-                Alpha: 0.30000001192092896
-                Color: 213; 0; 249
-              CYCLIST:
-                Alpha: 0.30000001192092896
-                Color: 213; 0; 249
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.30000001192092896
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: false
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: false
-              Display Velocity: false
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: false
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.30000001192092896
-                Color: 213; 0; 249
               Name: CameraLidarFusion(purple)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.30000001192092896
-                Color: 213; 0; 249
-              Polygon Type: 2d
-              TRAILER:
-                Alpha: 0.30000001192092896
-                Color: 213; 0; 249
-              TRUCK:
-                Alpha: 0.30000001192092896
-                Color: 213; 0; 249
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 213; 0; 249
+                CAR: 213; 0; 249
+                CYCLIST: 213; 0; 249
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 213; 0; 249
+                PEDESTRIAN: 213; 0; 249
+                TRAILER: 213; 0; 249
+                TRUCK: 213; 0; 249
+                UNKNOWN: 213; 0; 249
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 2D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: false
+                UUID: false
+                Velocity: false
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/clustering/camera_lidar_fusion/objects
-              UNKNOWN:
-                Alpha: 0.30000001192092896
-                Color: 213; 0; 249
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: false
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
               Name: RadarFarObjects(white)
               Namespaces:
                 {}
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 255; 255
+                CAR: 255; 255; 255
+                CYCLIST: 255; 255; 255
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 255; 255
+                PEDESTRIAN: 255; 255; 255
+                TRAILER: 255; 255; 255
+                TRUCK: 255; 255; 255
+                UNKNOWN: 255; 255; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/radar/far_objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
               Name: Detection(yellow)
               Namespaces:
                 label: true
@@ -4092,58 +4061,57 @@ Visualization Manager:
                 shape: true
                 twist: true
                 velocity: true
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 234; 0
+                CAR: 255; 234; 0
+                CYCLIST: 255; 234; 0
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 234; 0
+                PEDESTRIAN: 255; 234; 0
+                TRAILER: 255; 234; 0
+                TRUCK: 255; 234; 0
+                UNKNOWN: 255; 234; 0
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/TrackedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Dynamic Status: All
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
               Name: Tracking(green)
               Namespaces:
                 acceleration: true
@@ -4153,57 +4121,56 @@ Visualization Manager:
                 twist: true
                 uuid: true
                 velocity: true
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 0; 230; 118
+                CAR: 0; 230; 118
+                CYCLIST: 0; 230; 118
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 0; 230; 118
+                PEDESTRIAN: 0; 230; 118
+                TRAILER: 0; 230; 118
+                TRUCK: 0; 230; 118
+                UNKNOWN: 0; 230; 118
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/tracking/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
               Value: true
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/PredictedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
               Name: Prediction(light_blue)
               Namespaces:
                 acceleration: true
@@ -4215,28 +4182,45 @@ Visualization Manager:
                 twist: true
                 uuid: true
                 velocity: true
-              Object Fill Type: skeleton
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              Polygon Type: 2d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 0; 176; 255
+                CAR: 0; 176; 255
+                CYCLIST: 0; 176; 255
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 0; 176; 255
+                PEDESTRIAN: 0; 176; 255
+                TRAILER: 0; 176; 255
+                TRUCK: 0; 176; 255
+                UNKNOWN: 0; 176; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 2D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
               Value: true
-              Visualization Type: Normal
+              Vector:
+                Twist: true
+                Yaw Rate: false
           Enabled: true
           Name: Perception
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/perception.rviz
+++ b/autoware_launch/rviz/perception.rviz
@@ -1041,6 +1041,49 @@ Visualization Manager:
                   Vector:
                     Twist: true
                     Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 0; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: BEV Fusion(cyan)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/bevfusion/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
               Enabled: true
               Name: Detection
             - Class: rviz_common/Group

--- a/autoware_launch/rviz/perception.rviz
+++ b/autoware_launch/rviz/perception.rviz
@@ -25,22 +25,7 @@ Panels:
         - /Debug1/Sensing1/PointcloudOnCamera1
         - /Debug1/Sensing1/ConcatenatePointCloud1/Autocompute Value Bounds1
         - /Debug1/Perception1
-        - /Debug1/Perception1/Centerpoint(red1)1/UNKNOWN1
-        - /Debug1/Perception1/Centerpoint(red1)1/CAR1
-        - /Debug1/Perception1/Centerpoint(red1)1/TRUCK1
-        - /Debug1/Perception1/Centerpoint(red1)1/BUS1
-        - /Debug1/Perception1/Centerpoint(red1)1/TRAILER1
-        - /Debug1/Perception1/Centerpoint(red1)1/MOTORCYCLE1
-        - /Debug1/Perception1/Centerpoint(red1)1/CYCLIST1
-        - /Debug1/Perception1/Centerpoint(red1)1/PEDESTRIAN1
-        - /Debug1/Perception1/CenterpointROIFusion(red2)1/UNKNOWN1
-        - /Debug1/Perception1/CenterpointValidator(red3)1/UNKNOWN1
-        - /Debug1/Perception1/PointPainting(light_green1)1/UNKNOWN1
-        - /Debug1/Perception1/PointPaintingROIFusion(light_green2)1/UNKNOWN1
-        - /Debug1/Perception1/PointPaintingValidator(light_green3)1/UNKNOWN1
-        - /Debug1/Perception1/DetectionByTracker(orange)1/UNKNOWN1
         - /Debug1/Perception1/RadarFarObjects(white)1/UNKNOWN1
-        - /Debug1/Perception1/Detection(yellow)1/UNKNOWN1
         - /Image1/Topic1
       Splitter Ratio: 0.7641357183456421
     Tree Height: 588
@@ -810,7 +795,7 @@ Visualization Manager:
               Displays:
                 - Alpha: 0.9990000128746033
                   Class: autoware_perception_rviz_plugin/DetectedObjects
-                  Color: 255; 255; 255
+                  Color: 255; 138; 128
                   Covariance:
                     Confidence Interval: 95%
                     Pose: true
@@ -818,8 +803,8 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.029999999329447746
-                  Name: DetectedObjects
+                  Line Width: 0.10000000149011612
+                  Name: Centerpoint(red)
                   Namespaces:
                     {}
                   Path:
@@ -828,17 +813,7 @@ Visualization Manager:
                     Path Resolution: Normal
                     Predicted Path: true
                   Per Class Color:
-                    ANIMAL: 255; 105; 180
-                    BUS: 30; 144; 255
-                    CAR: 30; 144; 255
-                    CYCLIST: 119; 11; 32
-                    HAZARD: 255; 69; 0
-                    MOTORCYCLE: 119; 11; 32
-                    PEDESTRIAN: 255; 192; 203
-                    TRAILER: 30; 144; 255
-                    TRUCK: 30; 144; 255
-                    UNKNOWN: 255; 255; 255
-                    Value: true
+                    Value: false
                   Shape:
                     BBox Footprint: false
                     Mesh:
@@ -856,12 +831,184 @@ Visualization Manager:
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
-                    Value: /perception/object_recognition/detection/objects
+                    Value: /perception/object_recognition/detection/centerpoint/objects
                   Value: true
                   Vector:
                     Twist: true
                     Yaw Rate: false
-              Enabled: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 255; 234; 0
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: Stream PETR(yellow)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/camera_only/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 178; 255; 89
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: PTv3 Cluster(light_green)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/clustering/label_based_euclidean_cluster/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 255; 128; 171
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: Irregular object(pink)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/irregular_object/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 255; 0; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: PTv3 Object(magenta)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/obstacle_segmentation/ptv3/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+              Enabled: true
               Name: Detection
             - Class: rviz_common/Group
               Displays:
@@ -3128,14 +3275,6 @@ Visualization Manager:
                   Map: true
                   Perception:
                     CameraLidarFusion(purple): true
-                    Centerpoint(red1): true
-                    CenterpointROIFusion(red2): true
-                    CenterpointValidator(red3): true
-                    Detection(yellow): true
-                    DetectionByTracker(orange): true
-                    PointPainting(light_green1): true
-                    PointPaintingROIFusion(light_green2): true
-                    PointPaintingValidator(light_green3): true
                     Prediction(light_blue): true
                     RadarFarObjects(white): true
                     Tracking(green): true
@@ -3184,7 +3323,11 @@ Visualization Manager:
                 Perception:
                   ObjectRecognition:
                     Detection:
-                      DetectedObjects: true
+                      Centerpoint(red): true
+                      Irregular object(pink): true
+                      PTv3 Cluster(light_green): true
+                      PTv3 Object(magenta): true
+                      Stream PETR(yellow): true
                       Value: true
                     Prediction:
                       Maneuver: true
@@ -3554,389 +3697,6 @@ Visualization Manager:
           Name: Localization
         - Class: rviz_common/Group
           Displays:
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: Centerpoint(red1)
-              Namespaces:
-                label: true
-                position covariance: true
-                shape: true
-                twist: true
-                velocity: true
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 138; 128
-                CAR: 255; 138; 128
-                CYCLIST: 255; 138; 128
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 138; 128
-                PEDESTRIAN: 255; 138; 128
-                TRAILER: 255; 138; 128
-                TRUCK: 255; 138; 128
-                UNKNOWN: 255; 138; 128
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/centerpoint/objects
-              Value: true
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: CenterpointROIFusion(red2)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 82; 82
-                CAR: 255; 82; 82
-                CYCLIST: 255; 82; 82
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 82; 82
-                PEDESTRIAN: 255; 82; 82
-                TRAILER: 255; 82; 82
-                TRUCK: 255; 82; 82
-                UNKNOWN: 255; 82; 82
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/centerpoint/roi_fusion/objects
-              Value: true
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: CenterpointValidator(red3)
-              Namespaces:
-                label: true
-                position covariance: true
-                shape: true
-                twist: true
-                velocity: true
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 213; 0; 0
-                CAR: 213; 0; 0
-                CYCLIST: 213; 0; 0
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 213; 0; 0
-                PEDESTRIAN: 213; 0; 0
-                TRAILER: 213; 0; 0
-                TRUCK: 213; 0; 0
-                UNKNOWN: 213; 0; 0
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/centerpoint/validation/objects
-              Value: true
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: PointPainting(light_green1)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 178; 255; 89
-                CAR: 178; 255; 89
-                CYCLIST: 178; 255; 89
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 178; 255; 89
-                PEDESTRIAN: 178; 255; 89
-                TRAILER: 178; 255; 89
-                TRUCK: 178; 255; 89
-                UNKNOWN: 178; 255; 89
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 2D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: false
-                UUID: true
-                Velocity: false
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/pointpainting/objects
-              Value: true
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: PointPaintingROIFusion(light_green2)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 118; 255; 3
-                CAR: 118; 255; 3
-                CYCLIST: 118; 255; 3
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 118; 255; 3
-                PEDESTRIAN: 118; 255; 3
-                TRAILER: 118; 255; 3
-                TRUCK: 118; 255; 3
-                UNKNOWN: 118; 255; 3
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 2D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: false
-                UUID: false
-                Velocity: false
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/pointpainting/roi_fusion/objects
-              Value: true
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: PointPaintingValidator(light_green3)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 100; 221; 23
-                CAR: 100; 221; 23
-                CYCLIST: 100; 221; 23
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 100; 221; 23
-                PEDESTRIAN: 100; 221; 23
-                TRAILER: 100; 221; 23
-                TRUCK: 100; 221; 23
-                UNKNOWN: 100; 221; 23
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 2D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: false
-                UUID: false
-                Velocity: false
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/pointpainting/validation/objects
-              Value: true
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: DetectionByTracker(orange)
-              Namespaces:
-                label: true
-                position covariance: true
-                shape: true
-                twist: true
-                velocity: true
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 145; 0
-                CAR: 255; 145; 0
-                CYCLIST: 255; 145; 0
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 145; 0
-                PEDESTRIAN: 255; 145; 0
-                TRAILER: 255; 145; 0
-                TRUCK: 255; 145; 0
-                UNKNOWN: 255; 145; 0
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 2D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/detection_by_tracker/objects
-              Value: true
-              Vector:
-                Twist: true
-                Yaw Rate: false
             - Alpha: 0.30000001192092896
               Class: autoware_perception_rviz_plugin/DetectedObjects
               Color: 255; 255; 255
@@ -4040,63 +3800,6 @@ Visualization Manager:
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/radar/far_objects
               Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: Detection(yellow)
-              Namespaces:
-                label: true
-                position covariance: true
-                shape: true
-                twist: true
-                velocity: true
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 234; 0
-                CAR: 255; 234; 0
-                CYCLIST: 255; 234; 0
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 234; 0
-                PEDESTRIAN: 255; 234; 0
-                TRAILER: 255; 234; 0
-                TRUCK: 255; 234; 0
-                UNKNOWN: 255; 234; 0
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/objects
-              Value: true
               Vector:
                 Twist: true
                 Yaw Rate: false

--- a/autoware_launch/rviz/perception.rviz
+++ b/autoware_launch/rviz/perception.rviz
@@ -3957,6 +3957,18 @@ Visualization Manager:
               Vector:
                 Twist: true
                 Yaw Rate: false
+            - Class: rviz_default_plugins/MarkerArray
+              Enabled: true
+              Name: TrackerDebug
+              Namespaces:
+                {}
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Reliable
+                Value: /perception/object_recognition/tracking/multi_object_tracker/debug/objects_markers
+              Value: true
           Enabled: true
           Name: Perception
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/perception.rviz
+++ b/autoware_launch/rviz/perception.rviz
@@ -787,6 +787,39 @@ Visualization Manager:
               Use Fixed Frame: true
               Use rainbow: true
               Value: true
+            - Alpha: 0.999
+              Autocompute Intensity Bounds: false
+              Autocompute Value Bounds:
+                Max Value: 15
+                Min Value: -2
+                Value: false
+              Axis: Z
+              Channel Name: class_id
+              Class: rviz_default_plugins/PointCloud2
+              Color: 200; 200; 200
+              Color Transformer: Intensity
+              Decay Time: 0
+              Enabled: false
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 16
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: SegmentedPointCloud
+              Position Transformer: XYZ
+              Selectable: false
+              Size (Pixels): 1.5
+              Size (m): 0.02
+              Style: Points
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /perception/segmented/pointcloud
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
           Enabled: true
           Name: Segmentation
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/planning_bev.rviz
+++ b/autoware_launch/rviz/planning_bev.rviz
@@ -22,22 +22,7 @@ Panels:
         - /Control1/Predicted Trajectory1
         - /Debug1/Sensing1/PointcloudOnCamera1
         - /Debug1/Sensing1/ConcatenatePointCloud1/Autocompute Value Bounds1
-        - /Debug1/Perception1/Centerpoint(red1)1/UNKNOWN1
-        - /Debug1/Perception1/Centerpoint(red1)1/CAR1
-        - /Debug1/Perception1/Centerpoint(red1)1/TRUCK1
-        - /Debug1/Perception1/Centerpoint(red1)1/BUS1
-        - /Debug1/Perception1/Centerpoint(red1)1/TRAILER1
-        - /Debug1/Perception1/Centerpoint(red1)1/MOTORCYCLE1
-        - /Debug1/Perception1/Centerpoint(red1)1/CYCLIST1
-        - /Debug1/Perception1/Centerpoint(red1)1/PEDESTRIAN1
-        - /Debug1/Perception1/CenterpointROIFusion(red2)1/UNKNOWN1
-        - /Debug1/Perception1/CenterpointValidator(red3)1/UNKNOWN1
-        - /Debug1/Perception1/PointPainting(light_green1)1/UNKNOWN1
-        - /Debug1/Perception1/PointPaintingROIFusion(light_green2)1/UNKNOWN1
-        - /Debug1/Perception1/PointPaintingValidator(light_green3)1/UNKNOWN1
-        - /Debug1/Perception1/DetectionByTracker(orange)1/UNKNOWN1
         - /Debug1/Perception1/RadarFarObjects(white)1/UNKNOWN1
-        - /Debug1/Perception1/Detection(yellow)1/UNKNOWN1
         - /Debug1/Planning1
       Splitter Ratio: 0.7641357183456421
     Tree Height: 378
@@ -839,9 +824,9 @@ Visualization Manager:
           Displays:
             - Class: rviz_common/Group
               Displays:
-                - Alpha: 0.999
+                - Alpha: 0.9990000128746033
                   Class: autoware_perception_rviz_plugin/DetectedObjects
-                  Color: 255; 255; 255
+                  Color: 255; 138; 128
                   Covariance:
                     Confidence Interval: 95%
                     Pose: true
@@ -849,8 +834,8 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.03
-                  Name: DetectedObjects
+                  Line Width: 0.10000000149011612
+                  Name: Centerpoint(red)
                   Namespaces:
                     {}
                   Path:
@@ -859,17 +844,7 @@ Visualization Manager:
                     Path Resolution: Normal
                     Predicted Path: true
                   Per Class Color:
-                    ANIMAL: 255; 105; 180
-                    BUS: 30; 144; 255
-                    CAR: 30; 144; 255
-                    CYCLIST: 119; 11; 32
-                    HAZARD: 255; 69; 0
-                    MOTORCYCLE: 119; 11; 32
-                    PEDESTRIAN: 255; 192; 203
-                    TRAILER: 30; 144; 255
-                    TRUCK: 30; 144; 255
-                    UNKNOWN: 255; 255; 255
-                    Value: true
+                    Value: false
                   Shape:
                     BBox Footprint: false
                     Mesh:
@@ -877,7 +852,7 @@ Visualization Manager:
                       Value: false
                     Shape Type: Skeleton 3D
                   Text:
-                    Acceleration: false
+                    Acceleration: true
                     Existence Probability: false
                     Label: true
                     UUID: true
@@ -887,12 +862,184 @@ Visualization Manager:
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
-                    Value: /perception/object_recognition/detection/objects
+                    Value: /perception/object_recognition/detection/centerpoint/objects
                   Value: true
                   Vector:
                     Twist: true
                     Yaw Rate: false
-              Enabled: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 255; 234; 0
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: Stream PETR(yellow)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/camera_only/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 178; 255; 89
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: PTv3 Cluster(light_green)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/clustering/label_based_euclidean_cluster/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 255; 128; 171
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: Irregular object(pink)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/irregular_object/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 255; 0; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: PTv3 Object(magenta)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/obstacle_segmentation/ptv3/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+              Enabled: true
               Name: Detection
             - Class: rviz_common/Group
               Displays:
@@ -2539,14 +2686,6 @@ Visualization Manager:
                   Map: true
                   Perception:
                     CameraLidarFusion(purple): true
-                    Centerpoint(red1): true
-                    CenterpointROIFusion(red2): true
-                    CenterpointValidator(red3): true
-                    Detection(yellow): true
-                    DetectionByTracker(cyan): true
-                    PointPainting(light_green1): true
-                    PointPaintingROIFusion(light_green2): true
-                    PointPaintingValidator(light_green3): true
                     Prediction(light_blue): true
                     RadarFarObjects(white): true
                     Tracking(green): true
@@ -2577,7 +2716,11 @@ Visualization Manager:
                 Perception:
                   ObjectRecognition:
                     Detection:
-                      DetectedObjects: true
+                      Centerpoint(red): true
+                      Irregular object(pink): true
+                      PTv3 Cluster(light_green): true
+                      PTv3 Object(magenta): true
+                      Stream PETR(yellow): true
                       Value: true
                     Prediction:
                       Maneuver: true
@@ -2963,377 +3106,6 @@ Visualization Manager:
                 Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              Name: Centerpoint(red1)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 138; 128
-                CAR: 255; 138; 128
-                CYCLIST: 255; 138; 128
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 138; 128
-                PEDESTRIAN: 255; 138; 128
-                TRAILER: 255; 138; 128
-                TRUCK: 255; 138; 128
-                UNKNOWN: 255; 138; 128
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/centerpoint/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: CenterpointROIFusion(red2)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 82; 82
-                CAR: 255; 82; 82
-                CYCLIST: 255; 82; 82
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 82; 82
-                PEDESTRIAN: 255; 82; 82
-                TRAILER: 255; 82; 82
-                TRUCK: 255; 82; 82
-                UNKNOWN: 255; 82; 82
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/centerpoint/roi_fusion/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: CenterpointValidator(red3)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 213; 0; 0
-                CAR: 213; 0; 0
-                CYCLIST: 213; 0; 0
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 213; 0; 0
-                PEDESTRIAN: 213; 0; 0
-                TRAILER: 213; 0; 0
-                TRUCK: 213; 0; 0
-                UNKNOWN: 213; 0; 0
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/centerpoint/validation/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: PointPainting(light_green1)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 178; 255; 89
-                CAR: 178; 255; 89
-                CYCLIST: 178; 255; 89
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 178; 255; 89
-                PEDESTRIAN: 178; 255; 89
-                TRAILER: 178; 255; 89
-                TRUCK: 178; 255; 89
-                UNKNOWN: 178; 255; 89
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/pointpainting/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: PointPaintingROIFusion(light_green2)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 118; 255; 3
-                CAR: 118; 255; 3
-                CYCLIST: 118; 255; 3
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 118; 255; 3
-                PEDESTRIAN: 118; 255; 3
-                TRAILER: 118; 255; 3
-                TRUCK: 118; 255; 3
-                UNKNOWN: 118; 255; 3
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/pointpainting/roi_fusion/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: PointPaintingValidator(light_green3)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 100; 221; 23
-                CAR: 100; 221; 23
-                CYCLIST: 100; 221; 23
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 100; 221; 23
-                PEDESTRIAN: 100; 221; 23
-                TRAILER: 100; 221; 23
-                TRUCK: 100; 221; 23
-                UNKNOWN: 100; 221; 23
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/pointpainting/validation/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: DetectionByTracker(orange)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 145; 0
-                CAR: 255; 145; 0
-                CYCLIST: 255; 145; 0
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 145; 0
-                PEDESTRIAN: 255; 145; 0
-                TRAILER: 255; 145; 0
-                TRUCK: 255; 145; 0
-                UNKNOWN: 255; 145; 0
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/detection_by_tracker/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
               Name: CameraLidarFusion(purple)
               Namespaces:
                 {}
@@ -3425,59 +3197,6 @@ Visualization Manager:
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/radar/far_objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: Detection(yellow)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 234; 0
-                CAR: 255; 234; 0
-                CYCLIST: 255; 234; 0
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 234; 0
-                PEDESTRIAN: 255; 234; 0
-                TRAILER: 255; 234; 0
-                TRUCK: 255; 234; 0
-                UNKNOWN: 255; 234; 0
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/objects
               Value: false
               Vector:
                 Twist: true

--- a/autoware_launch/rviz/planning_bev.rviz
+++ b/autoware_launch/rviz/planning_bev.rviz
@@ -839,146 +839,173 @@ Visualization Manager:
           Displays:
             - Class: rviz_common/Group
               Displays:
-                - BUS:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  CAR:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  CYCLIST:
-                    Alpha: 0.999
-                    Color: 119; 11; 32
+                - Alpha: 0.999
                   Class: autoware_perception_rviz_plugin/DetectedObjects
-                  Display 3d polygon: true
-                  Display Label: true
-                  Display PoseWithCovariance: true
-                  Display Predicted Path Confidence: true
-                  Display Predicted Paths: true
-                  Display Twist: true
-                  Display UUID: true
-                  Display Velocity: true
-                  Line Width: 0.03
+                  Color: 255; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
                   Enabled: true
-                  MOTORCYCLE:
-                    Alpha: 0.999
-                    Color: 119; 11; 32
+                  Line Width: 0.03
                   Name: DetectedObjects
-                  Namespaces: {}
-                  PEDESTRIAN:
-                    Alpha: 0.999
-                    Color: 255; 192; 203
-                  TRAILER:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  TRUCK:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    ANIMAL: 255; 105; 180
+                    BUS: 30; 144; 255
+                    CAR: 30; 144; 255
+                    CYCLIST: 119; 11; 32
+                    HAZARD: 255; 69; 0
+                    MOTORCYCLE: 119; 11; 32
+                    PEDESTRIAN: 255; 192; 203
+                    TRAILER: 30; 144; 255
+                    TRUCK: 30; 144; 255
+                    UNKNOWN: 255; 255; 255
+                    Value: true
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: false
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
                   Topic:
                     Depth: 5
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
                     Value: /perception/object_recognition/detection/objects
-                  UNKNOWN:
-                    Alpha: 0.999
-                    Color: 255; 255; 255
                   Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
               Enabled: false
               Name: Detection
             - Class: rviz_common/Group
               Displays:
-                - BUS:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  CAR:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  CYCLIST:
-                    Alpha: 0.999
-                    Color: 119; 11; 32
+                - Alpha: 0.999
                   Class: autoware_perception_rviz_plugin/TrackedObjects
-                  Display 3d polygon: true
-                  Display Label: true
-                  Display PoseWithCovariance: true
-                  Display Predicted Path Confidence: true
-                  Display Predicted Paths: true
-                  Display Twist: true
-                  Display UUID: true
-                  Display Velocity: true
-                  Line Width: 0.03
+                  Color: 255; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
                   Enabled: true
-                  MOTORCYCLE:
-                    Alpha: 0.999
-                    Color: 119; 11; 32
+                  Line Width: 0.03
                   Name: TrackedObjects
-                  Namespaces: {}
-                  PEDESTRIAN:
-                    Alpha: 0.999
-                    Color: 255; 192; 203
-                  TRAILER:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  TRUCK:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    ANIMAL: 255; 105; 180
+                    BUS: 30; 144; 255
+                    CAR: 30; 144; 255
+                    CYCLIST: 119; 11; 32
+                    HAZARD: 255; 69; 0
+                    MOTORCYCLE: 119; 11; 32
+                    PEDESTRIAN: 255; 192; 203
+                    TRAILER: 30; 144; 255
+                    TRUCK: 30; 144; 255
+                    UNKNOWN: 255; 255; 255
+                    Value: true
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: false
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
                   Topic:
                     Depth: 5
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
                     Value: /perception/object_recognition/tracking/objects
-                  UNKNOWN:
-                    Alpha: 0.999
-                    Color: 255; 255; 255
                   Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
               Enabled: false
               Name: Tracking
             - Class: rviz_common/Group
               Displays:
-                - BUS:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  CAR:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  CYCLIST:
-                    Alpha: 0.999
-                    Color: 119; 11; 32
+                - Alpha: 0.999
                   Class: autoware_perception_rviz_plugin/PredictedObjects
-                  Display 3d polygon: true
-                  Display Label: true
-                  Display PoseWithCovariance: false
-                  Display Predicted Path Confidence: true
-                  Display Predicted Paths: true
-                  Display Twist: true
-                  Display UUID: true
-                  Display Velocity: true
-                  Line Width: 0.03
+                  Color: 255; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: false
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
                   Enabled: true
-                  MOTORCYCLE:
-                    Alpha: 0.999
-                    Color: 119; 11; 32
+                  Line Width: 0.03
                   Name: PredictedObjects
-                  Namespaces: {}
-                  PEDESTRIAN:
-                    Alpha: 0.999
-                    Color: 255; 192; 203
-                  TRAILER:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  TRUCK:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    ANIMAL: 255; 105; 180
+                    BUS: 30; 144; 255
+                    CAR: 30; 144; 255
+                    CYCLIST: 119; 11; 32
+                    HAZARD: 255; 69; 0
+                    MOTORCYCLE: 119; 11; 32
+                    PEDESTRIAN: 255; 192; 203
+                    TRAILER: 30; 144; 255
+                    TRUCK: 30; 144; 255
+                    UNKNOWN: 255; 255; 255
+                    Value: true
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: false
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
                   Topic:
                     Depth: 5
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
                     Value: /perception/object_recognition/objects
-                  UNKNOWN:
-                    Alpha: 0.999
-                    Color: 255; 255; 255
                   Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
                 - Class: rviz_default_plugins/MarkerArray
                   Enabled: false
                   Name: Maneuver
@@ -2183,35 +2210,17 @@ Visualization Manager:
                 Value: /planning/planning_factors/diffusion_planner
               Value: true
               show_safety_factors: false
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 119; 11; 32
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/PredictedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 119; 11; 32
               Name: PredictedObjects
               Namespaces:
                 acceleration: true
@@ -2223,28 +2232,45 @@ Visualization Manager:
                 twist: true
                 uuid: true
                 velocity: true
-              Object Fill Type: Fill
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 192; 203
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 30; 144; 255
+                CAR: 30; 144; 255
+                CYCLIST: 119; 11; 32
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 119; 11; 32
+                PEDESTRIAN: 255; 192; 203
+                TRAILER: 30; 144; 255
+                TRUCK: 30; 144; 255
+                UNKNOWN: 255; 255; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Fill
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/output/predicted_objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
               Value: true
-              Visualization Type: Normal
+              Vector:
+                Twist: true
+                Yaw Rate: false
           Enabled: true
           Name: NeuralNetworkBasedPlanner
         - Class: rviz_common/Group
@@ -2763,53 +2789,59 @@ Visualization Manager:
               Use Fixed Frame: false
               Use rainbow: true
               Value: true
-            - BUS:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              CAR:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              CYCLIST:
-                Alpha: 0.5
-                Color: 255; 255; 255
+            - Alpha: 0.5
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.029999999329447746
-              MOTORCYCLE:
-                Alpha: 0.5
-                Color: 255; 255; 255
               Name: RadarRawObjects(white)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              TRUCK:
-                Alpha: 0.5
-                Color: 255; 255; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 255; 255
+                CAR: 255; 255; 255
+                CYCLIST: 255; 255; 255
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 255; 255
+                PEDESTRIAN: 255; 255; 255
+                TRAILER: 255; 255; 255
+                TRUCK: 255; 255; 255
+                UNKNOWN: 255; 255; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /sensing/radar/detected_objects
-              UNKNOWN:
-                Alpha: 0.5
-                Color: 255; 255; 255
               Value: true
-              Visualization Type: Normal
+              Vector:
+                Twist: true
+                Yaw Rate: false
           Enabled: false
           Name: Sensing
         - Class: rviz_common/Group
@@ -2920,570 +2952,642 @@ Visualization Manager:
               Value: true
         - Class: rviz_common/Group
           Displays:
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
               Name: Centerpoint(red1)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 138; 128
+                CAR: 255; 138; 128
+                CYCLIST: 255; 138; 128
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 138; 128
+                PEDESTRIAN: 255; 138; 128
+                TRAILER: 255; 138; 128
+                TRUCK: 255; 138; 128
+                UNKNOWN: 255; 138; 128
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/centerpoint/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
               Name: CenterpointROIFusion(red2)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 82; 82
+                CAR: 255; 82; 82
+                CYCLIST: 255; 82; 82
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 82; 82
+                PEDESTRIAN: 255; 82; 82
+                TRAILER: 255; 82; 82
+                TRUCK: 255; 82; 82
+                UNKNOWN: 255; 82; 82
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/centerpoint/roi_fusion/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
               Name: CenterpointValidator(red3)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 213; 0; 0
+                CAR: 213; 0; 0
+                CYCLIST: 213; 0; 0
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 213; 0; 0
+                PEDESTRIAN: 213; 0; 0
+                TRAILER: 213; 0; 0
+                TRUCK: 213; 0; 0
+                UNKNOWN: 213; 0; 0
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/centerpoint/validation/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
               Name: PointPainting(light_green1)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 178; 255; 89
+                CAR: 178; 255; 89
+                CYCLIST: 178; 255; 89
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 178; 255; 89
+                PEDESTRIAN: 178; 255; 89
+                TRAILER: 178; 255; 89
+                TRUCK: 178; 255; 89
+                UNKNOWN: 178; 255; 89
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/pointpainting/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
               Name: PointPaintingROIFusion(light_green2)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 118; 255; 3
+                CAR: 118; 255; 3
+                CYCLIST: 118; 255; 3
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 118; 255; 3
+                PEDESTRIAN: 118; 255; 3
+                TRAILER: 118; 255; 3
+                TRUCK: 118; 255; 3
+                UNKNOWN: 118; 255; 3
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/pointpainting/roi_fusion/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
               Name: PointPaintingValidator(light_green3)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 100; 221; 23
+                CAR: 100; 221; 23
+                CYCLIST: 100; 221; 23
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 100; 221; 23
+                PEDESTRIAN: 100; 221; 23
+                TRAILER: 100; 221; 23
+                TRUCK: 100; 221; 23
+                UNKNOWN: 100; 221; 23
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/pointpainting/validation/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
               Name: DetectionByTracker(orange)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 145; 0
+                CAR: 255; 145; 0
+                CYCLIST: 255; 145; 0
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 145; 0
+                PEDESTRIAN: 255; 145; 0
+                TRAILER: 255; 145; 0
+                TRUCK: 255; 145; 0
+                UNKNOWN: 255; 145; 0
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/detection_by_tracker/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
               Name: CameraLidarFusion(purple)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 213; 0; 249
+                CAR: 213; 0; 249
+                CYCLIST: 213; 0; 249
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 213; 0; 249
+                PEDESTRIAN: 213; 0; 249
+                TRAILER: 213; 0; 249
+                TRUCK: 213; 0; 249
+                UNKNOWN: 213; 0; 249
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/clustering/camera_lidar_fusion/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
               Name: RadarFarObjects(white)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 255; 255
+                CAR: 255; 255; 255
+                CYCLIST: 255; 255; 255
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 255; 255
+                PEDESTRIAN: 255; 255; 255
+                TRAILER: 255; 255; 255
+                TRUCK: 255; 255; 255
+                UNKNOWN: 255; 255; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/radar/far_objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
               Name: Detection(yellow)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 234; 0
+                CAR: 255; 234; 0
+                CYCLIST: 255; 234; 0
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 234; 0
+                PEDESTRIAN: 255; 234; 0
+                TRAILER: 255; 234; 0
+                TRUCK: 255; 234; 0
+                UNKNOWN: 255; 234; 0
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/TrackedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
               Name: Tracking(green)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 0; 230; 118
+                CAR: 0; 230; 118
+                CYCLIST: 0; 230; 118
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 0; 230; 118
+                PEDESTRIAN: 0; 230; 118
+                TRAILER: 0; 230; 118
+                TRUCK: 0; 230; 118
+                UNKNOWN: 0; 230; 118
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/tracking/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/PredictedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: false
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: false
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
               Name: Prediction(light_blue)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 0; 176; 255
+                CAR: 0; 176; 255
+                CYCLIST: 0; 176; 255
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 0; 176; 255
+                PEDESTRIAN: 0; 176; 255
+                TRAILER: 0; 176; 255
+                TRUCK: 0; 176; 255
+                UNKNOWN: 0; 176; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
               Value: false
-              Visualization Type: Normal
+              Vector:
+                Twist: true
+                Yaw Rate: false
           Enabled: false
           Name: Perception
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/planning_bev.rviz
+++ b/autoware_launch/rviz/planning_bev.rviz
@@ -3340,6 +3340,18 @@ Visualization Manager:
               Vector:
                 Twist: true
                 Yaw Rate: false
+            - Class: rviz_default_plugins/MarkerArray
+              Enabled: true
+              Name: TrackerDebug
+              Namespaces:
+                {}
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Reliable
+                Value: /perception/object_recognition/tracking/multi_object_tracker/debug/objects_markers
+              Value: true
           Enabled: false
           Name: Perception
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/planning_bev.rviz
+++ b/autoware_launch/rviz/planning_bev.rviz
@@ -818,6 +818,39 @@ Visualization Manager:
               Use Fixed Frame: true
               Use rainbow: true
               Value: true
+            - Alpha: 0.999
+              Autocompute Intensity Bounds: false
+              Autocompute Value Bounds:
+                Max Value: 15
+                Min Value: -2
+                Value: false
+              Axis: Z
+              Channel Name: class_id
+              Class: rviz_default_plugins/PointCloud2
+              Color: 200; 200; 200
+              Color Transformer: Intensity
+              Decay Time: 0
+              Enabled: false
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 16
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: SegmentedPointCloud
+              Position Transformer: XYZ
+              Selectable: false
+              Size (Pixels): 1.5
+              Size (m): 0.02
+              Style: Points
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /perception/segmented/pointcloud
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
           Enabled: true
           Name: Segmentation
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/planning_bev.rviz
+++ b/autoware_launch/rviz/planning_bev.rviz
@@ -1072,6 +1072,49 @@ Visualization Manager:
                   Vector:
                     Twist: true
                     Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 0; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: BEV Fusion(cyan)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/bevfusion/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
               Enabled: true
               Name: Detection
             - Class: rviz_common/Group

--- a/autoware_launch/rviz/planning_tpv.rviz
+++ b/autoware_launch/rviz/planning_tpv.rviz
@@ -839,146 +839,173 @@ Visualization Manager:
           Displays:
             - Class: rviz_common/Group
               Displays:
-                - BUS:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  CAR:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  CYCLIST:
-                    Alpha: 0.999
-                    Color: 119; 11; 32
+                - Alpha: 0.999
                   Class: autoware_perception_rviz_plugin/DetectedObjects
-                  Display 3d polygon: true
-                  Display Label: true
-                  Display PoseWithCovariance: true
-                  Display Predicted Path Confidence: true
-                  Display Predicted Paths: true
-                  Display Twist: true
-                  Display UUID: true
-                  Display Velocity: true
-                  Line Width: 0.03
+                  Color: 255; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
                   Enabled: true
-                  MOTORCYCLE:
-                    Alpha: 0.999
-                    Color: 119; 11; 32
+                  Line Width: 0.03
                   Name: DetectedObjects
-                  Namespaces: {}
-                  PEDESTRIAN:
-                    Alpha: 0.999
-                    Color: 255; 192; 203
-                  TRAILER:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  TRUCK:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    ANIMAL: 255; 105; 180
+                    BUS: 30; 144; 255
+                    CAR: 30; 144; 255
+                    CYCLIST: 119; 11; 32
+                    HAZARD: 255; 69; 0
+                    MOTORCYCLE: 119; 11; 32
+                    PEDESTRIAN: 255; 192; 203
+                    TRAILER: 30; 144; 255
+                    TRUCK: 30; 144; 255
+                    UNKNOWN: 255; 255; 255
+                    Value: true
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: false
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
                   Topic:
                     Depth: 5
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
                     Value: /perception/object_recognition/detection/objects
-                  UNKNOWN:
-                    Alpha: 0.999
-                    Color: 255; 255; 255
                   Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
               Enabled: false
               Name: Detection
             - Class: rviz_common/Group
               Displays:
-                - BUS:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  CAR:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  CYCLIST:
-                    Alpha: 0.999
-                    Color: 119; 11; 32
+                - Alpha: 0.999
                   Class: autoware_perception_rviz_plugin/TrackedObjects
-                  Display 3d polygon: true
-                  Display Label: true
-                  Display PoseWithCovariance: true
-                  Display Predicted Path Confidence: true
-                  Display Predicted Paths: true
-                  Display Twist: true
-                  Display UUID: true
-                  Display Velocity: true
-                  Line Width: 0.03
+                  Color: 255; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
                   Enabled: true
-                  MOTORCYCLE:
-                    Alpha: 0.999
-                    Color: 119; 11; 32
+                  Line Width: 0.03
                   Name: TrackedObjects
-                  Namespaces: {}
-                  PEDESTRIAN:
-                    Alpha: 0.999
-                    Color: 255; 192; 203
-                  TRAILER:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  TRUCK:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    ANIMAL: 255; 105; 180
+                    BUS: 30; 144; 255
+                    CAR: 30; 144; 255
+                    CYCLIST: 119; 11; 32
+                    HAZARD: 255; 69; 0
+                    MOTORCYCLE: 119; 11; 32
+                    PEDESTRIAN: 255; 192; 203
+                    TRAILER: 30; 144; 255
+                    TRUCK: 30; 144; 255
+                    UNKNOWN: 255; 255; 255
+                    Value: true
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: false
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
                   Topic:
                     Depth: 5
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
                     Value: /perception/object_recognition/tracking/objects
-                  UNKNOWN:
-                    Alpha: 0.999
-                    Color: 255; 255; 255
                   Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
               Enabled: false
               Name: Tracking
             - Class: rviz_common/Group
               Displays:
-                - BUS:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  CAR:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  CYCLIST:
-                    Alpha: 0.999
-                    Color: 119; 11; 32
+                - Alpha: 0.999
                   Class: autoware_perception_rviz_plugin/PredictedObjects
-                  Display 3d polygon: true
-                  Display Label: true
-                  Display PoseWithCovariance: false
-                  Display Predicted Path Confidence: true
-                  Display Predicted Paths: true
-                  Display Twist: true
-                  Display UUID: true
-                  Display Velocity: true
-                  Line Width: 0.03
+                  Color: 255; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: false
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
                   Enabled: true
-                  MOTORCYCLE:
-                    Alpha: 0.999
-                    Color: 119; 11; 32
+                  Line Width: 0.03
                   Name: PredictedObjects
-                  Namespaces: {}
-                  PEDESTRIAN:
-                    Alpha: 0.999
-                    Color: 255; 192; 203
-                  TRAILER:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
-                  TRUCK:
-                    Alpha: 0.999
-                    Color: 30; 144; 255
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    ANIMAL: 255; 105; 180
+                    BUS: 30; 144; 255
+                    CAR: 30; 144; 255
+                    CYCLIST: 119; 11; 32
+                    HAZARD: 255; 69; 0
+                    MOTORCYCLE: 119; 11; 32
+                    PEDESTRIAN: 255; 192; 203
+                    TRAILER: 30; 144; 255
+                    TRUCK: 30; 144; 255
+                    UNKNOWN: 255; 255; 255
+                    Value: true
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: false
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
                   Topic:
                     Depth: 5
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
                     Value: /perception/object_recognition/objects
-                  UNKNOWN:
-                    Alpha: 0.999
-                    Color: 255; 255; 255
                   Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
                 - Class: rviz_default_plugins/MarkerArray
                   Enabled: false
                   Name: Maneuver
@@ -2183,35 +2210,17 @@ Visualization Manager:
                 Value: /planning/planning_factors/diffusion_planner
               Value: true
               show_safety_factors: false
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 119; 11; 32
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/PredictedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 119; 11; 32
               Name: PredictedObjects
               Namespaces:
                 acceleration: true
@@ -2223,28 +2232,45 @@ Visualization Manager:
                 twist: true
                 uuid: true
                 velocity: true
-              Object Fill Type: Fill
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 192; 203
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 30; 144; 255
+                CAR: 30; 144; 255
+                CYCLIST: 119; 11; 32
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 119; 11; 32
+                PEDESTRIAN: 255; 192; 203
+                TRAILER: 30; 144; 255
+                TRUCK: 30; 144; 255
+                UNKNOWN: 255; 255; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Fill
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/output/predicted_objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
               Value: true
-              Visualization Type: Normal
+              Vector:
+                Twist: true
+                Yaw Rate: false
           Enabled: true
           Name: NeuralNetworkBasedPlanner
         - Class: rviz_common/Group
@@ -2763,53 +2789,59 @@ Visualization Manager:
               Use Fixed Frame: false
               Use rainbow: true
               Value: true
-            - BUS:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              CAR:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              CYCLIST:
-                Alpha: 0.5
-                Color: 255; 255; 255
+            - Alpha: 0.5
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.029999999329447746
-              MOTORCYCLE:
-                Alpha: 0.5
-                Color: 255; 255; 255
               Name: RadarRawObjects(white)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.5
-                Color: 255; 255; 255
-              TRUCK:
-                Alpha: 0.5
-                Color: 255; 255; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 255; 255
+                CAR: 255; 255; 255
+                CYCLIST: 255; 255; 255
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 255; 255
+                PEDESTRIAN: 255; 255; 255
+                TRAILER: 255; 255; 255
+                TRUCK: 255; 255; 255
+                UNKNOWN: 255; 255; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /sensing/radar/detected_objects
-              UNKNOWN:
-                Alpha: 0.5
-                Color: 255; 255; 255
               Value: true
-              Visualization Type: Normal
+              Vector:
+                Twist: true
+                Yaw Rate: false
           Enabled: false
           Name: Sensing
         - Class: rviz_common/Group
@@ -2920,570 +2952,642 @@ Visualization Manager:
               Value: true
         - Class: rviz_common/Group
           Displays:
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
               Name: Centerpoint(red1)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 138; 128
+                CAR: 255; 138; 128
+                CYCLIST: 255; 138; 128
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 138; 128
+                PEDESTRIAN: 255; 138; 128
+                TRAILER: 255; 138; 128
+                TRUCK: 255; 138; 128
+                UNKNOWN: 255; 138; 128
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/centerpoint/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 138; 128
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
               Name: CenterpointROIFusion(red2)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 82; 82
+                CAR: 255; 82; 82
+                CYCLIST: 255; 82; 82
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 82; 82
+                PEDESTRIAN: 255; 82; 82
+                TRAILER: 255; 82; 82
+                TRUCK: 255; 82; 82
+                UNKNOWN: 255; 82; 82
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/centerpoint/roi_fusion/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 82; 82
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
               Name: CenterpointValidator(red3)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 213; 0; 0
+                CAR: 213; 0; 0
+                CYCLIST: 213; 0; 0
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 213; 0; 0
+                PEDESTRIAN: 213; 0; 0
+                TRAILER: 213; 0; 0
+                TRUCK: 213; 0; 0
+                UNKNOWN: 213; 0; 0
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/centerpoint/validation/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 0
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
               Name: PointPainting(light_green1)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 178; 255; 89
+                CAR: 178; 255; 89
+                CYCLIST: 178; 255; 89
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 178; 255; 89
+                PEDESTRIAN: 178; 255; 89
+                TRAILER: 178; 255; 89
+                TRUCK: 178; 255; 89
+                UNKNOWN: 178; 255; 89
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/pointpainting/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 178; 255; 89
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
               Name: PointPaintingROIFusion(light_green2)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 118; 255; 3
+                CAR: 118; 255; 3
+                CYCLIST: 118; 255; 3
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 118; 255; 3
+                PEDESTRIAN: 118; 255; 3
+                TRAILER: 118; 255; 3
+                TRUCK: 118; 255; 3
+                UNKNOWN: 118; 255; 3
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/pointpainting/roi_fusion/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 118; 255; 3
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
               Name: PointPaintingValidator(light_green3)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 100; 221; 23
+                CAR: 100; 221; 23
+                CYCLIST: 100; 221; 23
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 100; 221; 23
+                PEDESTRIAN: 100; 221; 23
+                TRAILER: 100; 221; 23
+                TRUCK: 100; 221; 23
+                UNKNOWN: 100; 221; 23
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/pointpainting/validation/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 100; 221; 23
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
               Name: DetectionByTracker(orange)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 145; 0
+                CAR: 255; 145; 0
+                CYCLIST: 255; 145; 0
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 145; 0
+                PEDESTRIAN: 255; 145; 0
+                TRAILER: 255; 145; 0
+                TRUCK: 255; 145; 0
+                UNKNOWN: 255; 145; 0
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/detection_by_tracker/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 145; 0
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
               Name: CameraLidarFusion(purple)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 213; 0; 249
+                CAR: 213; 0; 249
+                CYCLIST: 213; 0; 249
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 213; 0; 249
+                PEDESTRIAN: 213; 0; 249
+                TRAILER: 213; 0; 249
+                TRUCK: 213; 0; 249
+                UNKNOWN: 213; 0; 249
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/clustering/camera_lidar_fusion/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 213; 0; 249
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
               Name: RadarFarObjects(white)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 255; 255
+                CAR: 255; 255; 255
+                CYCLIST: 255; 255; 255
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 255; 255
+                PEDESTRIAN: 255; 255; 255
+                TRAILER: 255; 255; 255
+                TRUCK: 255; 255; 255
+                UNKNOWN: 255; 255; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/radar/far_objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
               Name: Detection(yellow)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 255; 234; 0
+                CAR: 255; 234; 0
+                CYCLIST: 255; 234; 0
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 255; 234; 0
+                PEDESTRIAN: 255; 234; 0
+                TRAILER: 255; 234; 0
+                TRUCK: 255; 234; 0
+                UNKNOWN: 255; 234; 0
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 234; 0
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/TrackedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
               Name: Tracking(green)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 0; 230; 118
+                CAR: 0; 230; 118
+                CYCLIST: 0; 230; 118
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 0; 230; 118
+                PEDESTRIAN: 0; 230; 118
+                TRAILER: 0; 230; 118
+                TRUCK: 0; 230; 118
+                UNKNOWN: 0; 230; 118
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/tracking/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 0; 230; 118
               Value: false
-              Visualization Type: Normal
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
+              Vector:
+                Twist: true
+                Yaw Rate: false
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/PredictedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: false
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: false
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
               Name: Prediction(light_blue)
               Namespaces:
                 {}
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 0; 176; 255
+                CAR: 0; 176; 255
+                CYCLIST: 0; 176; 255
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 0; 176; 255
+                PEDESTRIAN: 0; 176; 255
+                TRAILER: 0; 176; 255
+                TRUCK: 0; 176; 255
+                UNKNOWN: 0; 176; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 0; 176; 255
               Value: false
-              Visualization Type: Normal
+              Vector:
+                Twist: true
+                Yaw Rate: false
           Enabled: false
           Name: Perception
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/planning_tpv.rviz
+++ b/autoware_launch/rviz/planning_tpv.rviz
@@ -3340,6 +3340,18 @@ Visualization Manager:
               Vector:
                 Twist: true
                 Yaw Rate: false
+            - Class: rviz_default_plugins/MarkerArray
+              Enabled: true
+              Name: TrackerDebug
+              Namespaces:
+                {}
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Reliable
+                Value: /perception/object_recognition/tracking/multi_object_tracker/debug/objects_markers
+              Value: true
           Enabled: false
           Name: Perception
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/planning_tpv.rviz
+++ b/autoware_launch/rviz/planning_tpv.rviz
@@ -818,6 +818,39 @@ Visualization Manager:
               Use Fixed Frame: true
               Use rainbow: true
               Value: true
+            - Alpha: 0.999
+              Autocompute Intensity Bounds: false
+              Autocompute Value Bounds:
+                Max Value: 15
+                Min Value: -2
+                Value: false
+              Axis: Z
+              Channel Name: class_id
+              Class: rviz_default_plugins/PointCloud2
+              Color: 200; 200; 200
+              Color Transformer: Intensity
+              Decay Time: 0
+              Enabled: false
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 16
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: SegmentedPointCloud
+              Position Transformer: XYZ
+              Selectable: false
+              Size (Pixels): 1.5
+              Size (m): 0.02
+              Style: Points
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /perception/segmented/pointcloud
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
           Enabled: true
           Name: Segmentation
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/planning_tpv.rviz
+++ b/autoware_launch/rviz/planning_tpv.rviz
@@ -21,22 +21,7 @@ Panels:
         - /Control1/Predicted Trajectory1
         - /Debug1/Sensing1/PointcloudOnCamera1
         - /Debug1/Sensing1/ConcatenatePointCloud1/Autocompute Value Bounds1
-        - /Debug1/Perception1/Centerpoint(red1)1/UNKNOWN1
-        - /Debug1/Perception1/Centerpoint(red1)1/CAR1
-        - /Debug1/Perception1/Centerpoint(red1)1/TRUCK1
-        - /Debug1/Perception1/Centerpoint(red1)1/BUS1
-        - /Debug1/Perception1/Centerpoint(red1)1/TRAILER1
-        - /Debug1/Perception1/Centerpoint(red1)1/MOTORCYCLE1
-        - /Debug1/Perception1/Centerpoint(red1)1/CYCLIST1
-        - /Debug1/Perception1/Centerpoint(red1)1/PEDESTRIAN1
-        - /Debug1/Perception1/CenterpointROIFusion(red2)1/UNKNOWN1
-        - /Debug1/Perception1/CenterpointValidator(red3)1/UNKNOWN1
-        - /Debug1/Perception1/PointPainting(light_green1)1/UNKNOWN1
-        - /Debug1/Perception1/PointPaintingROIFusion(light_green2)1/UNKNOWN1
-        - /Debug1/Perception1/PointPaintingValidator(light_green3)1/UNKNOWN1
-        - /Debug1/Perception1/DetectionByTracker(orange)1/UNKNOWN1
         - /Debug1/Perception1/RadarFarObjects(white)1/UNKNOWN1
-        - /Debug1/Perception1/Detection(yellow)1/UNKNOWN1
         - /Debug1/Planning1
         - /Debug1/Planning1/Objects Of Interest1
       Splitter Ratio: 0.7641357183456421
@@ -839,9 +824,9 @@ Visualization Manager:
           Displays:
             - Class: rviz_common/Group
               Displays:
-                - Alpha: 0.999
+                - Alpha: 0.9990000128746033
                   Class: autoware_perception_rviz_plugin/DetectedObjects
-                  Color: 255; 255; 255
+                  Color: 255; 138; 128
                   Covariance:
                     Confidence Interval: 95%
                     Pose: true
@@ -849,8 +834,8 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.03
-                  Name: DetectedObjects
+                  Line Width: 0.10000000149011612
+                  Name: Centerpoint(red)
                   Namespaces:
                     {}
                   Path:
@@ -859,17 +844,7 @@ Visualization Manager:
                     Path Resolution: Normal
                     Predicted Path: true
                   Per Class Color:
-                    ANIMAL: 255; 105; 180
-                    BUS: 30; 144; 255
-                    CAR: 30; 144; 255
-                    CYCLIST: 119; 11; 32
-                    HAZARD: 255; 69; 0
-                    MOTORCYCLE: 119; 11; 32
-                    PEDESTRIAN: 255; 192; 203
-                    TRAILER: 30; 144; 255
-                    TRUCK: 30; 144; 255
-                    UNKNOWN: 255; 255; 255
-                    Value: true
+                    Value: false
                   Shape:
                     BBox Footprint: false
                     Mesh:
@@ -877,7 +852,7 @@ Visualization Manager:
                       Value: false
                     Shape Type: Skeleton 3D
                   Text:
-                    Acceleration: false
+                    Acceleration: true
                     Existence Probability: false
                     Label: true
                     UUID: true
@@ -887,12 +862,184 @@ Visualization Manager:
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
-                    Value: /perception/object_recognition/detection/objects
+                    Value: /perception/object_recognition/detection/centerpoint/objects
                   Value: true
                   Vector:
                     Twist: true
                     Yaw Rate: false
-              Enabled: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 255; 234; 0
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: Stream PETR(yellow)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/camera_only/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 178; 255; 89
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: PTv3 Cluster(light_green)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/clustering/label_based_euclidean_cluster/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 255; 128; 171
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: Irregular object(pink)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/irregular_object/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 255; 0; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: PTv3 Object(magenta)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/obstacle_segmentation/ptv3/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
+              Enabled: true
               Name: Detection
             - Class: rviz_common/Group
               Displays:
@@ -2539,14 +2686,6 @@ Visualization Manager:
                   Map: true
                   Perception:
                     CameraLidarFusion(purple): true
-                    Centerpoint(red1): true
-                    CenterpointROIFusion(red2): true
-                    CenterpointValidator(red3): true
-                    Detection(yellow): true
-                    DetectionByTracker(cyan): true
-                    PointPainting(light_green1): true
-                    PointPaintingROIFusion(light_green2): true
-                    PointPaintingValidator(light_green3): true
                     Prediction(light_blue): true
                     RadarFarObjects(white): true
                     Tracking(green): true
@@ -2577,7 +2716,11 @@ Visualization Manager:
                 Perception:
                   ObjectRecognition:
                     Detection:
-                      DetectedObjects: true
+                      Centerpoint(red): true
+                      Irregular object(pink): true
+                      PTv3 Cluster(light_green): true
+                      PTv3 Object(magenta): true
+                      Stream PETR(yellow): true
                       Value: true
                     Prediction:
                       Maneuver: true
@@ -2963,377 +3106,6 @@ Visualization Manager:
                 Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              Name: Centerpoint(red1)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 138; 128
-                CAR: 255; 138; 128
-                CYCLIST: 255; 138; 128
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 138; 128
-                PEDESTRIAN: 255; 138; 128
-                TRAILER: 255; 138; 128
-                TRUCK: 255; 138; 128
-                UNKNOWN: 255; 138; 128
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/centerpoint/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: CenterpointROIFusion(red2)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 82; 82
-                CAR: 255; 82; 82
-                CYCLIST: 255; 82; 82
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 82; 82
-                PEDESTRIAN: 255; 82; 82
-                TRAILER: 255; 82; 82
-                TRUCK: 255; 82; 82
-                UNKNOWN: 255; 82; 82
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/centerpoint/roi_fusion/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: CenterpointValidator(red3)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 213; 0; 0
-                CAR: 213; 0; 0
-                CYCLIST: 213; 0; 0
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 213; 0; 0
-                PEDESTRIAN: 213; 0; 0
-                TRAILER: 213; 0; 0
-                TRUCK: 213; 0; 0
-                UNKNOWN: 213; 0; 0
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/centerpoint/validation/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: PointPainting(light_green1)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 178; 255; 89
-                CAR: 178; 255; 89
-                CYCLIST: 178; 255; 89
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 178; 255; 89
-                PEDESTRIAN: 178; 255; 89
-                TRAILER: 178; 255; 89
-                TRUCK: 178; 255; 89
-                UNKNOWN: 178; 255; 89
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/pointpainting/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: PointPaintingROIFusion(light_green2)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 118; 255; 3
-                CAR: 118; 255; 3
-                CYCLIST: 118; 255; 3
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 118; 255; 3
-                PEDESTRIAN: 118; 255; 3
-                TRAILER: 118; 255; 3
-                TRUCK: 118; 255; 3
-                UNKNOWN: 118; 255; 3
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/pointpainting/roi_fusion/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: PointPaintingValidator(light_green3)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 100; 221; 23
-                CAR: 100; 221; 23
-                CYCLIST: 100; 221; 23
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 100; 221; 23
-                PEDESTRIAN: 100; 221; 23
-                TRAILER: 100; 221; 23
-                TRUCK: 100; 221; 23
-                UNKNOWN: 100; 221; 23
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/pointpainting/validation/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: DetectionByTracker(orange)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 145; 0
-                CAR: 255; 145; 0
-                CYCLIST: 255; 145; 0
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 145; 0
-                PEDESTRIAN: 255; 145; 0
-                TRAILER: 255; 145; 0
-                TRUCK: 255; 145; 0
-                UNKNOWN: 255; 145; 0
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/detection_by_tracker/objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
               Name: CameraLidarFusion(purple)
               Namespaces:
                 {}
@@ -3425,59 +3197,6 @@ Visualization Manager:
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /perception/object_recognition/detection/radar/far_objects
-              Value: false
-              Vector:
-                Twist: true
-                Yaw Rate: false
-            - Alpha: 0.9990000128746033
-              Class: autoware_perception_rviz_plugin/DetectedObjects
-              Color: 255; 255; 255
-              Covariance:
-                Confidence Interval: 95%
-                Pose: true
-                Twist: false
-                Yaw: false
-                Yaw Rate: false
-              Enabled: true
-              Line Width: 0.10000000149011612
-              Name: Detection(yellow)
-              Namespaces:
-                {}
-              Path:
-                Path Confidence: true
-                Path Footprint: false
-                Path Resolution: Normal
-                Predicted Path: true
-              Per Class Color:
-                ANIMAL: 255; 105; 180
-                BUS: 255; 234; 0
-                CAR: 255; 234; 0
-                CYCLIST: 255; 234; 0
-                HAZARD: 255; 69; 0
-                MOTORCYCLE: 255; 234; 0
-                PEDESTRIAN: 255; 234; 0
-                TRAILER: 255; 234; 0
-                TRUCK: 255; 234; 0
-                UNKNOWN: 255; 234; 0
-                Value: true
-              Shape:
-                BBox Footprint: false
-                Mesh:
-                  Signal Lights: false
-                  Value: false
-                Shape Type: Skeleton 3D
-              Text:
-                Acceleration: true
-                Existence Probability: false
-                Label: true
-                UUID: true
-                Velocity: true
-              Topic:
-                Depth: 5
-                Durability Policy: Volatile
-                History Policy: Keep Last
-                Reliability Policy: Best Effort
-                Value: /perception/object_recognition/detection/objects
               Value: false
               Vector:
                 Twist: true

--- a/autoware_launch/rviz/planning_tpv.rviz
+++ b/autoware_launch/rviz/planning_tpv.rviz
@@ -1072,6 +1072,49 @@ Visualization Manager:
                   Vector:
                     Twist: true
                     Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 0; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.10000000149011612
+                  Name: BEV Fusion(cyan)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/bevfusion/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
               Enabled: true
               Name: Detection
             - Class: rviz_common/Group

--- a/autoware_launch/rviz/scenario_simulator.rviz
+++ b/autoware_launch/rviz/scenario_simulator.rviz
@@ -778,6 +778,18 @@ Visualization Manager:
                   Vector:
                     Twist: true
                     Yaw Rate: false
+                - Class: rviz_default_plugins/MarkerArray
+                  Enabled: true
+                  Name: TrackerDebug
+                  Namespaces:
+                    {}
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/tracking/multi_object_tracker/debug/objects_markers
+                  Value: true
               Enabled: false
               Name: Tracking
             - Class: rviz_common/Group

--- a/autoware_launch/rviz/scenario_simulator.rviz
+++ b/autoware_launch/rviz/scenario_simulator.rviz
@@ -721,6 +721,49 @@ Visualization Manager:
                   Vector:
                     Twist: true
                     Yaw Rate: false
+                - Alpha: 0.9990000128746033
+                  Class: autoware_perception_rviz_plugin/DetectedObjects
+                  Color: 0; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
+                  Enabled: true
+                  Line Width: 0.029999999329447746
+                  Name: BEV Fusion(cyan)
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    Value: false
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
+                  Topic:
+                    Depth: 5
+                    Durability Policy: Volatile
+                    History Policy: Keep Last
+                    Reliability Policy: Best Effort
+                    Value: /perception/object_recognition/detection/bevfusion/objects
+                  Value: true
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
               Enabled: false
               Name: Detection
             - Class: rviz_common/Group

--- a/autoware_launch/rviz/scenario_simulator.rviz
+++ b/autoware_launch/rviz/scenario_simulator.rviz
@@ -629,6 +629,39 @@ Visualization Manager:
               Use Fixed Frame: true
               Use rainbow: true
               Value: true
+            - Alpha: 0.999
+              Autocompute Intensity Bounds: false
+              Autocompute Value Bounds:
+                Max Value: 15
+                Min Value: -2
+                Value: false
+              Axis: Z
+              Channel Name: class_id
+              Class: rviz_default_plugins/PointCloud2
+              Color: 200; 200; 200
+              Color Transformer: Intensity
+              Decay Time: 0
+              Enabled: false
+              Invert Rainbow: false
+              Max Color: 255; 255; 255
+              Max Intensity: 16
+              Min Color: 0; 0; 0
+              Min Intensity: 0
+              Name: SegmentedPointCloud
+              Position Transformer: XYZ
+              Selectable: false
+              Size (Pixels): 1.5
+              Size (m): 0.02
+              Style: Points
+              Topic:
+                Depth: 5
+                Durability Policy: Volatile
+                History Policy: Keep Last
+                Reliability Policy: Best Effort
+                Value: /perception/segmented/pointcloud
+              Use Fixed Frame: true
+              Use rainbow: true
+              Value: true
           Enabled: true
           Name: Segmentation
         - Class: rviz_common/Group

--- a/autoware_launch/rviz/scenario_simulator.rviz
+++ b/autoware_launch/rviz/scenario_simulator.rviz
@@ -635,152 +635,173 @@ Visualization Manager:
           Displays:
             - Class: rviz_common/Group
               Displays:
-                - BUS:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  CAR:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  CYCLIST:
-                    Alpha: 0.9990000128746033
-                    Color: 119; 11; 32
+                - Alpha: 0.9990000128746033
                   Class: autoware_perception_rviz_plugin/DetectedObjects
-                  Display Acceleration: true
-                  Display Label: true
-                  Display PoseWithCovariance: true
-                  Display Predicted Path Confidence: true
-                  Display Predicted Paths: true
-                  Display Twist: true
-                  Display UUID: true
-                  Display Velocity: true
+                  Color: 255; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
                   Enabled: true
                   Line Width: 0.029999999329447746
-                  MOTORCYCLE:
-                    Alpha: 0.9990000128746033
-                    Color: 119; 11; 32
                   Name: DetectedObjects
-                  Namespaces: ~
-                  PEDESTRIAN:
-                    Alpha: 0.9990000128746033
-                    Color: 255; 192; 203
-                  Polygon Type: 3d
-                  TRAILER:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  TRUCK:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    ANIMAL: 255; 105; 180
+                    BUS: 30; 144; 255
+                    CAR: 30; 144; 255
+                    CYCLIST: 119; 11; 32
+                    HAZARD: 255; 69; 0
+                    MOTORCYCLE: 119; 11; 32
+                    PEDESTRIAN: 255; 192; 203
+                    TRAILER: 30; 144; 255
+                    TRUCK: 30; 144; 255
+                    UNKNOWN: 255; 255; 255
+                    Value: true
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
                   Topic:
                     Depth: 5
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
                     Value: /perception/object_recognition/detection/objects
-                  UNKNOWN:
-                    Alpha: 0.9990000128746033
-                    Color: 255; 255; 255
                   Value: true
-                  Visualization Type: Normal
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
               Enabled: false
               Name: Detection
             - Class: rviz_common/Group
               Displays:
-                - BUS:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  CAR:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  CYCLIST:
-                    Alpha: 0.9990000128746033
-                    Color: 119; 11; 32
+                - Alpha: 0.9990000128746033
                   Class: autoware_perception_rviz_plugin/TrackedObjects
-                  Display Acceleration: true
-                  Display Label: true
-                  Display PoseWithCovariance: true
-                  Display Predicted Path Confidence: true
-                  Display Predicted Paths: true
-                  Display Twist: true
-                  Display UUID: true
-                  Display Velocity: true
+                  Color: 255; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: true
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
                   Enabled: true
                   Line Width: 0.029999999329447746
-                  MOTORCYCLE:
-                    Alpha: 0.9990000128746033
-                    Color: 119; 11; 32
                   Name: TrackedObjects
-                  Namespaces: ~
-                  PEDESTRIAN:
-                    Alpha: 0.9990000128746033
-                    Color: 255; 192; 203
-                  Polygon Type: 3d
-                  TRAILER:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  TRUCK:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    ANIMAL: 255; 105; 180
+                    BUS: 30; 144; 255
+                    CAR: 30; 144; 255
+                    CYCLIST: 119; 11; 32
+                    HAZARD: 255; 69; 0
+                    MOTORCYCLE: 119; 11; 32
+                    PEDESTRIAN: 255; 192; 203
+                    TRAILER: 30; 144; 255
+                    TRUCK: 30; 144; 255
+                    UNKNOWN: 255; 255; 255
+                    Value: true
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
                   Topic:
                     Depth: 5
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
                     Value: /perception/object_recognition/tracking/objects
-                  UNKNOWN:
-                    Alpha: 0.9990000128746033
-                    Color: 255; 255; 255
                   Value: true
-                  Visualization Type: Normal
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
               Enabled: false
               Name: Tracking
             - Class: rviz_common/Group
               Displays:
-                - BUS:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  CAR:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  CYCLIST:
-                    Alpha: 0.9990000128746033
-                    Color: 119; 11; 32
+                - Alpha: 0.9990000128746033
                   Class: autoware_perception_rviz_plugin/PredictedObjects
-                  Display Acceleration: true
-                  Display Label: true
-                  Display PoseWithCovariance: false
-                  Display Predicted Path Confidence: true
-                  Display Predicted Paths: true
-                  Display Twist: true
-                  Display UUID: true
-                  Display Velocity: true
+                  Color: 255; 255; 255
+                  Covariance:
+                    Confidence Interval: 95%
+                    Pose: false
+                    Twist: false
+                    Yaw: false
+                    Yaw Rate: false
                   Enabled: true
                   Line Width: 0.5
-                  MOTORCYCLE:
-                    Alpha: 0.9990000128746033
-                    Color: 119; 11; 32
                   Name: PredictedObjects
-                  Namespaces: ~
-                  PEDESTRIAN:
-                    Alpha: 0.9990000128746033
-                    Color: 255; 192; 203
-                  Polygon Type: 3d
-                  TRAILER:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
-                  TRUCK:
-                    Alpha: 0.9990000128746033
-                    Color: 30; 144; 255
+                  Namespaces:
+                    {}
+                  Path:
+                    Path Confidence: true
+                    Path Footprint: false
+                    Path Resolution: Normal
+                    Predicted Path: true
+                  Per Class Color:
+                    ANIMAL: 255; 105; 180
+                    BUS: 30; 144; 255
+                    CAR: 30; 144; 255
+                    CYCLIST: 119; 11; 32
+                    HAZARD: 255; 69; 0
+                    MOTORCYCLE: 119; 11; 32
+                    PEDESTRIAN: 255; 192; 203
+                    TRAILER: 30; 144; 255
+                    TRUCK: 30; 144; 255
+                    UNKNOWN: 255; 255; 255
+                    Value: true
+                  Shape:
+                    BBox Footprint: false
+                    Mesh:
+                      Signal Lights: false
+                      Value: false
+                    Shape Type: Skeleton 3D
+                  Text:
+                    Acceleration: true
+                    Existence Probability: false
+                    Label: true
+                    UUID: true
+                    Velocity: true
                   Topic:
                     Depth: 5
                     Durability Policy: Volatile
                     History Policy: Keep Last
                     Reliability Policy: Best Effort
                     Value: /perception/object_recognition/objects
-                  UNKNOWN:
-                    Alpha: 0.9990000128746033
-                    Color: 255; 255; 255
                   Value: true
-                  Visualization Type: Normal
+                  Vector:
+                    Twist: true
+                    Yaw Rate: false
                 - Class: rviz_default_plugins/MarkerArray
                   Enabled: false
                   Name: Maneuver
@@ -2718,35 +2739,17 @@ Visualization Manager:
                 Value: /planning/planning_factors/diffusion_planner
               Value: true
               show_safety_factors: false
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 119; 11; 32
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/PredictedObjects
-              Confidence Interval: 95%
-              Display Acceleration: true
-              Display Existence Probability: false
-              Display Label: true
-              Display Pose Covariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display Twist Covariance: false
-              Display UUID: true
-              Display Velocity: true
-              Display Yaw Covariance: false
-              Display Yaw Rate: false
-              Display Yaw Rate Covariance: false
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.10000000149011612
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 119; 11; 32
               Name: PredictedObjects
               Namespaces:
                 acceleration: true
@@ -2758,28 +2761,45 @@ Visualization Manager:
                 twist: true
                 uuid: true
                 velocity: true
-              Object Fill Type: Fill
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 192; 203
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 30; 144; 255
+                CAR: 30; 144; 255
+                CYCLIST: 119; 11; 32
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 119; 11; 32
+                PEDESTRIAN: 255; 192; 203
+                TRAILER: 30; 144; 255
+                TRUCK: 30; 144; 255
+                UNKNOWN: 255; 255; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Fill
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Best Effort
                 Value: /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/output/predicted_objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
               Value: true
-              Visualization Type: Normal
+              Vector:
+                Twist: true
+                Yaw Rate: false
           Enabled: true
           Name: NeuralNetworkBasedPlanner
         - Class: rviz_common/Group
@@ -2985,52 +3005,59 @@ Visualization Manager:
               Use Fixed Frame: true
               Use rainbow: true
               Value: true
-            - BUS:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
-              CAR:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
-              CYCLIST:
-                Alpha: 0.9990000128746033
-                Color: 119; 11; 32
+            - Alpha: 0.9990000128746033
               Class: autoware_perception_rviz_plugin/DetectedObjects
-              Display Acceleration: true
-              Display Label: true
-              Display PoseWithCovariance: true
-              Display Predicted Path Confidence: true
-              Display Predicted Paths: true
-              Display Twist: true
-              Display UUID: true
-              Display Velocity: true
+              Color: 255; 255; 255
+              Covariance:
+                Confidence Interval: 95%
+                Pose: true
+                Twist: false
+                Yaw: false
+                Yaw Rate: false
               Enabled: true
               Line Width: 0.029999999329447746
-              MOTORCYCLE:
-                Alpha: 0.9990000128746033
-                Color: 119; 11; 32
               Name: Detected Objects
-              Namespaces: ~
-              PEDESTRIAN:
-                Alpha: 0.9990000128746033
-                Color: 255; 192; 203
-              Polygon Type: 3d
-              TRAILER:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
-              TRUCK:
-                Alpha: 0.9990000128746033
-                Color: 30; 144; 255
+              Namespaces:
+                {}
+              Path:
+                Path Confidence: true
+                Path Footprint: false
+                Path Resolution: Normal
+                Predicted Path: true
+              Per Class Color:
+                ANIMAL: 255; 105; 180
+                BUS: 30; 144; 255
+                CAR: 30; 144; 255
+                CYCLIST: 119; 11; 32
+                HAZARD: 255; 69; 0
+                MOTORCYCLE: 119; 11; 32
+                PEDESTRIAN: 255; 192; 203
+                TRAILER: 30; 144; 255
+                TRUCK: 30; 144; 255
+                UNKNOWN: 255; 255; 255
+                Value: true
+              Shape:
+                BBox Footprint: false
+                Mesh:
+                  Signal Lights: false
+                  Value: false
+                Shape Type: Skeleton 3D
+              Text:
+                Acceleration: true
+                Existence Probability: false
+                Label: true
+                UUID: true
+                Velocity: true
               Topic:
                 Depth: 5
                 Durability Policy: Volatile
                 History Policy: Keep Last
                 Reliability Policy: Reliable
                 Value: /perception/object_recognition/detection/objects
-              UNKNOWN:
-                Alpha: 0.9990000128746033
-                Color: 255; 255; 255
               Value: true
-              Visualization Type: Normal
+              Vector:
+                Twist: true
+                Yaw Rate: false
             - Alpha: 0.699999988079071
               Class: rviz_default_plugins/Map
               Color Scheme: map


### PR DESCRIPTION
## Description

Update the RViz configurations to match the refactored `autoware_perception_rviz_plugin` https://github.com/autowarefoundation/autoware_rviz_plugins/pull/45 and align the detection displays with the latest perception pipeline.



### 1. Migrate to the new grouped plugin property layout

The plugin's object displays (`DetectedObjects` / `TrackedObjects` / `PredictedObjects`) were refactored from a flat property list into grouped properties. Every affected display in every config is migrated:

- Flat `Display *` toggles → grouped under **Shape / Text / Path / Vector / Covariance**
- `Polygon Type` + `Object Fill Type` (and legacy `Display 3d polygon`) → merged **Shape Type** (`Skeleton 3D` / `Skeleton 2D` / `Fill` / `None`)
- `Visualization Type` → **Path / Path Resolution**; `Confidence Interval` → under **Covariance**
- Legacy `Display PoseWithCovariance` → **Covariance / Pose**
- Per-class `{Alpha, Color}` → shared top-level **Alpha** + unified **Color** + **Per Class Color** toggle
- New object classes **ANIMAL** and **HAZARD** added

Existing per-class colors and per-display values are preserved; properties absent from the old configs fall back to the plugin defaults.

### 2. Align detection displays with the latest perception pipeline

<img width="332" height="373" alt="Screenshot from 2026-06-30 11-32-46" src="https://github.com/user-attachments/assets/b8be2cdc-2cbe-420e-bfb5-2a6f4fadf578" />



Under **ObjectRecognition → Detection**, the merged `/perception/object_recognition/detection/objects` display and obsolete debug detectors are replaced by the current detector outputs.

**Added** (each rendered as a single color via the unified `Color`):

| Display | Topic | Color |
|---|---|---|
| Centerpoint(red) | `…/detection/centerpoint/objects` | red |
| Stream PETR(yellow) | `…/detection/camera_only/objects` | yellow |
| PTv3 Cluster(light_green) | `…/detection/clustering/label_based_euclidean_cluster/objects` | light green |
| Irregular object(pink) | `…/detection/irregular_object/objects` | pink |
| PTv3 Object(magenta) | `…/obstacle_segmentation/ptv3/objects` | magenta |

**Removed:** `/perception/object_recognition/detection/objects`, `CenterpointROIFusion`, `CenterpointValidator`, all PointPainting displays (`PointPainting` / `PointPaintingROIFusion` / `PointPaintingValidator`), and `DetectionByTracker`.

The new displays live under the operational **ObjectRecognition → Detection** group (not Debug → Perception). Stale entries in the camera-image Visibility maps and the saved tree-expansion state were cleaned up accordingly.

### 3. Color-addressed detection displays

The single-color detection displays use the unified `Color` field with `Per Class Color: false`; their now-redundant per-class color lists were removed.

### Affected files

- `rviz/perception.rviz`, `rviz/autoware.rviz`, `rviz/autoware_test_utils.rviz`, `rviz/planning_tpv.rviz`, `rviz/planning_bev.rviz` — full set of changes above
- `rviz/scenario_simulator.rviz` — plugin property migration only (no detection displays)

## How was this PR tested?

- All modified `.rviz` files validated as well-formed YAML.
- Round-trip check confirmed per-class colors and per-display settings are preserved across the property migration (0 mismatches).
- Verified each config ends up with exactly the 5 new displays under `ObjectRecognition → Detection`, and that the removed topics/displays no longer appear anywhere (including Visibility maps and tree state).
- Not yet opened in RViz against a running system — a reviewer loading `perception.rviz` / `autoware.rviz` to visually confirm would be appreciated.

## Notes for reviewers

- Requires the refactored `autoware_perception_rviz_plugin` (grouped properties, `Shape Type` selector, `Per Class Color` toggle, ANIMAL/HAZARD classes). Older plugin builds will ignore the new grouped keys.
- Companion RViz files outside this repo received the same plugin property migration and (for `psim_test_map.rviz`) detection-display update: `autoware_core` → `psim_test_map.rviz` and `autoware_universe` → `autoware_path_optimizer.rviz`. These will be handled in their own PRs.

## Effects on system behavior

None at runtime — this changes RViz visualization configuration only.
