### PR TITLE
chore(rviz): adjust object recognition line widths and disable raw detection by default

### DIFF
--- a/autoware_launch/rviz/autoware.rviz
+++ b/autoware_launch/rviz/autoware.rviz
@@ -835,7 +835,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: Centerpoint(red)
                   Namespaces:
                     {}
@@ -878,7 +878,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: Stream PETR(yellow)
                   Namespaces:
                     {}
@@ -921,7 +921,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: PTv3 Cluster(light_green)
                   Namespaces:
                     {}
@@ -964,7 +964,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: Irregular object(pink)
                   Namespaces:
                     {}
@@ -1007,7 +1007,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: PTv3 Object(magenta)
                   Namespaces:
                     {}
@@ -1050,7 +1050,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: BEV Fusion(cyan)
                   Namespaces:
                     {}
@@ -1083,7 +1083,7 @@ Visualization Manager:
                   Vector:
                     Twist: true
                     Yaw Rate: false
-              Enabled: true
+              Enabled: false
               Name: Detection
             - Class: rviz_common/Group
               Displays:
@@ -1097,7 +1097,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.03
+                  Line Width: 0.15000000596046448
                   Name: TrackedObjects
                   Namespaces:
                     {}
@@ -1154,7 +1154,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.03
+                  Line Width: 0.15000000596046448
                   Name: PredictedObjects
                   Namespaces:
                     {}
@@ -2987,7 +2987,7 @@ Visualization Manager:
                 Yaw: false
                 Yaw Rate: false
               Enabled: true
-              Line Width: 0.029999999329447746
+              Line Width: 0.03
               Name: RadarRawObjects(white)
               Namespaces:
                 {}

--- a/autoware_launch/rviz/autoware_test_utils.rviz
+++ b/autoware_launch/rviz/autoware_test_utils.rviz
@@ -731,7 +731,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: Centerpoint(red)
                   Namespaces:
                     {}
@@ -774,7 +774,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: Stream PETR(yellow)
                   Namespaces:
                     {}
@@ -817,7 +817,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: PTv3 Cluster(light_green)
                   Namespaces:
                     {}
@@ -860,7 +860,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: Irregular object(pink)
                   Namespaces:
                     {}
@@ -903,7 +903,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: PTv3 Object(magenta)
                   Namespaces:
                     {}
@@ -946,7 +946,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: BEV Fusion(cyan)
                   Namespaces:
                     {}
@@ -979,7 +979,7 @@ Visualization Manager:
                   Vector:
                     Twist: true
                     Yaw Rate: false
-              Enabled: true
+              Enabled: false
               Name: Detection
             - Class: rviz_common/Group
               Displays:
@@ -994,7 +994,7 @@ Visualization Manager:
                     Yaw Rate: false
                   Dynamic Status: All
                   Enabled: true
-                  Line Width: 0.029999999329447746
+                  Line Width: 0.15000000596046448
                   Name: TrackedObjects
                   Namespaces:
                     {}
@@ -1051,7 +1051,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.029999999329447746
+                  Line Width: 0.15000000596046448
                   Name: PredictedObjects
                   Namespaces:
                     {}
@@ -3602,7 +3602,7 @@ Visualization Manager:
                 Yaw: false
                 Yaw Rate: false
               Enabled: true
-              Line Width: 0.029999999329447746
+              Line Width: 0.03
               Name: RadarRawObjects(white)
               Namespaces:
                 {}

--- a/autoware_launch/rviz/perception.rviz
+++ b/autoware_launch/rviz/perception.rviz
@@ -836,7 +836,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: Centerpoint(red)
                   Namespaces:
                     {}
@@ -879,7 +879,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: Stream PETR(yellow)
                   Namespaces:
                     {}
@@ -922,7 +922,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: PTv3 Cluster(light_green)
                   Namespaces:
                     {}
@@ -965,7 +965,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: Irregular object(pink)
                   Namespaces:
                     {}
@@ -1008,7 +1008,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: PTv3 Object(magenta)
                   Namespaces:
                     {}
@@ -1051,7 +1051,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: BEV Fusion(cyan)
                   Namespaces:
                     {}
@@ -1084,7 +1084,7 @@ Visualization Manager:
                   Vector:
                     Twist: true
                     Yaw Rate: false
-              Enabled: true
+              Enabled: false
               Name: Detection
             - Class: rviz_common/Group
               Displays:
@@ -1099,7 +1099,7 @@ Visualization Manager:
                     Yaw Rate: false
                   Dynamic Status: All
                   Enabled: true
-                  Line Width: 0.029999999329447746
+                  Line Width: 0.15000000596046448
                   Name: TrackedObjects
                   Namespaces:
                     {}
@@ -1156,7 +1156,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.029999999329447746
+                  Line Width: 0.15000000596046448
                   Name: PredictedObjects
                   Namespaces:
                     {}
@@ -3620,7 +3620,7 @@ Visualization Manager:
                 Yaw: false
                 Yaw Rate: false
               Enabled: true
-              Line Width: 0.029999999329447746
+              Line Width: 0.03
               Name: RadarRawObjects(white)
               Namespaces:
                 {}

--- a/autoware_launch/rviz/planning_bev.rviz
+++ b/autoware_launch/rviz/planning_bev.rviz
@@ -867,7 +867,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: Centerpoint(red)
                   Namespaces:
                     {}
@@ -910,7 +910,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: Stream PETR(yellow)
                   Namespaces:
                     {}
@@ -953,7 +953,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: PTv3 Cluster(light_green)
                   Namespaces:
                     {}
@@ -996,7 +996,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: Irregular object(pink)
                   Namespaces:
                     {}
@@ -1039,7 +1039,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: PTv3 Object(magenta)
                   Namespaces:
                     {}
@@ -1082,7 +1082,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: BEV Fusion(cyan)
                   Namespaces:
                     {}
@@ -1115,7 +1115,7 @@ Visualization Manager:
                   Vector:
                     Twist: true
                     Yaw Rate: false
-              Enabled: true
+              Enabled: false
               Name: Detection
             - Class: rviz_common/Group
               Displays:
@@ -1129,7 +1129,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.03
+                  Line Width: 0.15000000596046448
                   Name: TrackedObjects
                   Namespaces:
                     {}
@@ -1186,7 +1186,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.03
+                  Line Width: 0.15000000596046448
                   Name: PredictedObjects
                   Namespaces:
                     {}
@@ -3018,7 +3018,7 @@ Visualization Manager:
                 Yaw: false
                 Yaw Rate: false
               Enabled: true
-              Line Width: 0.029999999329447746
+              Line Width: 0.03
               Name: RadarRawObjects(white)
               Namespaces:
                 {}

--- a/autoware_launch/rviz/planning_tpv.rviz
+++ b/autoware_launch/rviz/planning_tpv.rviz
@@ -867,7 +867,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: Centerpoint(red)
                   Namespaces:
                     {}
@@ -910,7 +910,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: Stream PETR(yellow)
                   Namespaces:
                     {}
@@ -953,7 +953,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: PTv3 Cluster(light_green)
                   Namespaces:
                     {}
@@ -996,7 +996,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: Irregular object(pink)
                   Namespaces:
                     {}
@@ -1039,7 +1039,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: PTv3 Object(magenta)
                   Namespaces:
                     {}
@@ -1082,7 +1082,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.10000000149011612
+                  Line Width: 0.03
                   Name: BEV Fusion(cyan)
                   Namespaces:
                     {}
@@ -1115,7 +1115,7 @@ Visualization Manager:
                   Vector:
                     Twist: true
                     Yaw Rate: false
-              Enabled: true
+              Enabled: false
               Name: Detection
             - Class: rviz_common/Group
               Displays:
@@ -1129,7 +1129,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.03
+                  Line Width: 0.15000000596046448
                   Name: TrackedObjects
                   Namespaces:
                     {}
@@ -1186,7 +1186,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.03
+                  Line Width: 0.15000000596046448
                   Name: PredictedObjects
                   Namespaces:
                     {}
@@ -3018,7 +3018,7 @@ Visualization Manager:
                 Yaw: false
                 Yaw Rate: false
               Enabled: true
-              Line Width: 0.029999999329447746
+              Line Width: 0.03
               Name: RadarRawObjects(white)
               Namespaces:
                 {}

--- a/autoware_launch/rviz/scenario_simulator.rviz
+++ b/autoware_launch/rviz/scenario_simulator.rviz
@@ -678,7 +678,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.029999999329447746
+                  Line Width: 0.03
                   Name: DetectedObjects
                   Namespaces:
                     {}
@@ -731,7 +731,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.029999999329447746
+                  Line Width: 0.03
                   Name: BEV Fusion(cyan)
                   Namespaces:
                     {}
@@ -778,7 +778,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.029999999329447746
+                  Line Width: 0.15000000596046448
                   Name: TrackedObjects
                   Namespaces:
                     {}
@@ -847,7 +847,7 @@ Visualization Manager:
                     Yaw: false
                     Yaw Rate: false
                   Enabled: true
-                  Line Width: 0.5
+                  Line Width: 0.15000000596046448
                   Name: PredictedObjects
                   Namespaces:
                     {}
@@ -3103,7 +3103,7 @@ Visualization Manager:
                 Yaw: false
                 Yaw Rate: false
               Enabled: true
-              Line Width: 0.029999999329447746
+              Line Width: 0.03
               Name: Detected Objects
               Namespaces:
                 {}


### PR DESCRIPTION
## Description

Adjusts the object-recognition visualization in the RViz configs so the
perception output is easier to read, and changes the default detection toggle.

For every `Perception/ObjectRecognition` group across all RViz configs:

- **Detected objects** (`Detection` group): line width `0.10` → `0.03`, so the
  many raw per-detector boxes (Centerpoint, Stream PETR, PTv3 Cluster, Irregular
  object, PTv3 Object, BEV Fusion, …) render as thin outlines and overlap less.
- **Tracked / predicted objects**: line width `0.03` → `0.15`, so the final
  tracking/prediction output stands out clearly over the raw detections.
- **`Perception/ObjectRecognition/Detection` group**: `Enabled: true` → `false`,
  so the raw detection layer is hidden by default and only the
  tracking/prediction output is shown on startup.

Files updated:

- `autoware_launch/rviz/autoware.rviz`
- `autoware_launch/rviz/autoware_test_utils.rviz`
- `autoware_launch/rviz/perception.rviz`
- `autoware_launch/rviz/planning_bev.rviz`
- `autoware_launch/rviz/planning_tpv.rviz`
- `autoware_launch/rviz/scenario_simulator.rviz`

Changes are scoped strictly to the `ObjectRecognition` group; `DetectedObjects` /
`PredictedObjects` displays in other groups (planning debug, etc.) are untouched.

## How was this PR tested?

Visual check in RViz: detected-object boxes render as thin outlines, tracked /
predicted objects render with thicker outlines, and the raw `Detection` layer is
off by default and can still be re-enabled from the display tree.

## Notes for reviewers

Display-only RViz config change — no runtime/node behavior is affected. The
`Detection` group is only toggled off by default; it remains available to
enable manually.

## Effects on system behavior

None.
