### PR TITLE
feat(tier4_planning_launch): update for new trajectory_processor

### DIFF
--- a/tier4_universe_launch/tier4_planning_launch/launch/learning_based_planning/diffusion_planner.launch.xml
+++ b/tier4_universe_launch/tier4_planning_launch/launch/learning_based_planning/diffusion_planner.launch.xml
@@ -49,7 +49,7 @@
         <arg name="output_trajectories" value="/planning/generator/diffusion_planner/candidate_trajectories"/>
         <arg name="output_turn_indicators" value="/planning/turn_indicators_cmd"/>
       </include>
-      <include file="$(find-pkg-share autoware_trajectory_modifier)/launch/trajectory_modifier.launch.xml">
+      <include file="$(find-pkg-share autoware_trajectory_processor)/launch/trajectory_modifier.launch.xml">
         <arg name="trajectory_modifier_param_path" value="$(var trajectory_modifier_param_path)"/>
         <arg name="input_candidate_trajectories" value="/planning/generator/diffusion_planner/candidate_trajectories"/>
         <arg name="output_candidate_trajectories" value="/planning/generator/diffusion_planner/modified_candidate_trajectories"/>
@@ -58,7 +58,7 @@
         <arg name="input_objects" value="$(var input_objects_topic_name)"/>
         <arg name="input_pointcloud" value="$(var input_pointcloud_topic_name)"/>
       </include>
-      <include file="$(find-pkg-share autoware_trajectory_optimizer)/launch/trajectory_optimizer.launch.xml">
+      <include file="$(find-pkg-share autoware_trajectory_processor)/launch/trajectory_optimizer.launch.xml">
         <arg name="trajectory_optimizer_param_path" value="$(var trajectory_optimizer_param_path)"/>
         <arg name="input_trajectories" value="/planning/generator/diffusion_planner/modified_candidate_trajectories"/>
         <arg name="output_traj" value="/planning/trajectory_generator/trajectory"/>

--- a/tier4_universe_launch/tier4_planning_launch/package.xml
+++ b/tier4_universe_launch/tier4_planning_launch/package.xml
@@ -75,8 +75,7 @@
   <exec_depend>autoware_remaining_distance_time_calculator</exec_depend>
   <exec_depend>autoware_scenario_selector</exec_depend>
   <exec_depend>autoware_surround_obstacle_checker</exec_depend>
-  <exec_depend>autoware_trajectory_modifier</exec_depend>
-  <exec_depend>autoware_trajectory_optimizer</exec_depend>
+  <exec_depend>autoware_trajectory_processor</exec_depend>
   <exec_depend>autoware_velocity_smoother</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
## Description

Rename packages `autoware_trajectory_optimizer` and `autoware_trajectory_modifier` into `autoware_trajectory_processor`.
Required for https://github.com/autowarefoundation/autoware_universe/pull/12934

## How was this PR tested?

(ADDED by @sasakisasaki ) This PR looks needed ~~by solving the following CI error~~ for using the feature provided by [this PR](https://github.com/autowarefoundation/autoware_universe/pull/12934)

## Notes for reviewers

None.

## Effects on system behavior

None.
