### PR TITLE
feat(control_launch): launch as standalone node for control check container nodes

### DIFF
--- a/tier4_universe_launch/tier4_control_launch/launch/control.launch.xml
+++ b/tier4_universe_launch/tier4_control_launch/launch/control.launch.xml
@@ -213,63 +213,56 @@
 
       <!-- lane departure checker -->
       <group if="$(var launch_lane_departure_checker)">
-        <load_composable_node target="/control/control_check_container">
-          <composable_node pkg="autoware_lane_departure_checker" plugin="autoware::lane_departure_checker::LaneDepartureCheckerNode" name="lane_departure_checker_node" namespace="trajectory_follower">
-            <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-            <remap from="~/input/lanelet_map_bin" to="/map/vector_map"/>
-            <remap from="~/input/route" to="/planning/mission_planning/route"/>
-            <remap from="~/input/reference_trajectory" to="/planning/trajectory"/>
-            <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-            <param from="$(var nearest_search_param_path)"/>
-            <param from="$(var lane_departure_checker_param_path)"/>
-            <param from="$(var vehicle_param_file)"/>
-            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-          </composable_node>
-        </load_composable_node>
+        <node pkg="autoware_lane_departure_checker" exec="lane_departure_checker_node" name="lane_departure_checker_node" namespace="trajectory_follower" output="screen">
+          <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+          <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+          <remap from="~/input/lanelet_map_bin" to="/map/vector_map"/>
+          <remap from="~/input/route" to="/planning/mission_planning/route"/>
+          <remap from="~/input/reference_trajectory" to="/planning/trajectory"/>
+          <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
+          <param from="$(var nearest_search_param_path)"/>
+          <param from="$(var lane_departure_checker_param_path)"/>
+          <param from="$(var vehicle_param_file)"/>
+        </node>
       </group>
 
       <!-- control validator checker -->
       <group if="$(var launch_control_validator)">
-        <load_composable_node target="/control/control_check_container">
-          <composable_node pkg="autoware_control_validator" plugin="autoware::control_validator::ControlValidator" name="control_validator">
-            <remap from="~/input/control_cmd" to="/control/command/control_cmd"/>
-            <remap from="~/input/kinematics" to="/localization/kinematic_state"/>
-            <remap from="~/input/operational_mode_state" to="/api/operation_mode/state"/>
-            <remap from="~/input/measured_acceleration" to="/localization/acceleration"/>
-            <remap from="~/input/reference_trajectory" to="/planning/trajectory"/>
-            <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-            <remap from="~/output/validation_status" to="~/validation_status"/>
-            <param from="$(var control_validator_param_path)"/>
-          </composable_node>
-        </load_composable_node>
+        <node pkg="autoware_control_validator" exec="autoware_control_validator_node" name="control_validator" output="screen">
+          <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+          <remap from="~/input/control_cmd" to="/control/command/control_cmd"/>
+          <remap from="~/input/kinematics" to="/localization/kinematic_state"/>
+          <remap from="~/input/operational_mode_state" to="/api/operation_mode/state"/>
+          <remap from="~/input/measured_acceleration" to="/localization/acceleration"/>
+          <remap from="~/input/reference_trajectory" to="/planning/trajectory"/>
+          <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
+          <remap from="~/output/validation_status" to="~/validation_status"/>
+          <param from="$(var control_validator_param_path)"/>
+        </node>
       </group>
 
       <!-- autonomous emergency braking -->
       <group if="$(var launch_autonomous_emergency_braking)">
-        <load_composable_node target="/control/control_check_container">
-          <composable_node pkg="autoware_autonomous_emergency_braking" plugin="autoware::motion::control::autonomous_emergency_braking::AEB" name="autonomous_emergency_braking">
-            <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>
-            <remap from="~/input/velocity" to="/vehicle/status/velocity_status"/>
-            <remap from="~/input/imu" to="/sensing/imu/imu_data"/>
-            <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
-            <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-            <param from="$(var aeb_param_path)"/>
-            <param name="check_autoware_state" value="$(var use_aeb_autoware_state_check)"/>
-            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-          </composable_node>
-        </load_composable_node>
+        <node pkg="autoware_autonomous_emergency_braking" exec="autoware_autonomous_emergency_braking" name="autonomous_emergency_braking" output="screen">
+          <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+          <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>
+          <remap from="~/input/velocity" to="/vehicle/status/velocity_status"/>
+          <remap from="~/input/imu" to="/sensing/imu/imu_data"/>
+          <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
+          <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
+          <param from="$(var aeb_param_path)"/>
+          <param name="check_autoware_state" value="$(var use_aeb_autoware_state_check)"/>
+        </node>
       </group>
 
       <!-- collision detector-->
       <group if="$(var launch_collision_detector)">
-        <load_composable_node target="/control/control_check_container">
-          <composable_node pkg="autoware_collision_detector" plugin="autoware::collision_detector::CollisionDetectorNode" name="collision_detector">
-            <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-            <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>
-            <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
-            <param from="$(var collision_detector_param_path)"/>
-          </composable_node>
-        </load_composable_node>
+        <include file="$(find-pkg-share autoware_collision_detector)/launch/collision_detector.launch.xml">
+          <arg name="param_path" value="$(var collision_detector_param_path)"/>
+          <arg name="input_odometry" value="/localization/kinematic_state"/>
+          <arg name="input_pointcloud" value="$(var input_pointcloud_topic_name)"/>
+          <arg name="input_objects" value="$(var input_objects_topic_name)"/>
+        </include>
       </group>
 
       <!-- obstacle collision checker -->

--- a/tier4_universe_launch/tier4_control_launch/launch/control.launch.xml
+++ b/tier4_universe_launch/tier4_control_launch/launch/control.launch.xml
@@ -257,12 +257,13 @@
 
       <!-- collision detector-->
       <group if="$(var launch_collision_detector)">
-        <include file="$(find-pkg-share autoware_collision_detector)/launch/collision_detector.launch.xml">
-          <arg name="param_path" value="$(var collision_detector_param_path)"/>
-          <arg name="input_odometry" value="/localization/kinematic_state"/>
-          <arg name="input_pointcloud" value="$(var input_pointcloud_topic_name)"/>
-          <arg name="input_objects" value="$(var input_objects_topic_name)"/>
-        </include>
+        <node pkg="autoware_collision_detector" exec="autoware_collision_detector_node" name="collision_detector" output="screen">
+          <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+          <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+          <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>
+          <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
+          <param from="$(var collision_detector_param_path)"/>
+        </node>
       </group>
 
       <!-- obstacle collision checker -->

--- a/tier4_universe_launch/tier4_control_launch/package.xml
+++ b/tier4_universe_launch/tier4_control_launch/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend>autoware_agnocast_wrapper</exec_depend>
+  <exec_depend>autoware_collision_detector</exec_depend>
   <exec_depend>autoware_control_command_gate</exec_depend>
   <exec_depend>autoware_control_evaluator</exec_depend>
   <exec_depend>autoware_external_cmd_converter</exec_depend>

--- a/tier4_universe_launch/tier4_control_launch/package.xml
+++ b/tier4_universe_launch/tier4_control_launch/package.xml
@@ -16,9 +16,11 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend>autoware_agnocast_wrapper</exec_depend>
+  <exec_depend>autoware_autonomous_emergency_braking</exec_depend>
   <exec_depend>autoware_collision_detector</exec_depend>
   <exec_depend>autoware_control_command_gate</exec_depend>
   <exec_depend>autoware_control_evaluator</exec_depend>
+  <exec_depend>autoware_control_validator</exec_depend>
   <exec_depend>autoware_external_cmd_converter</exec_depend>
   <exec_depend>autoware_external_cmd_selector</exec_depend>
   <exec_depend>autoware_lane_departure_checker</exec_depend>


### PR DESCRIPTION
## Description
Following the adoption of `agnocast_wrapper::Node`, the control-check nodes must run as standalone processes — a component container's executor cannot spin Agnocast entities.

  This PR moves the following nodes out of `control_check_container` and launches them as standalone nodes (with `LD_PRELOAD` set for the Agnocast heaphook):

  - `lane_departure_checker_node`
  - `control_validator`
  - `autonomous_emergency_braking`
  - `collision_detector`

  Also adds `autoware_collision_detector` , `autoware_autonomous_emergency_braking`, and `autoware_control_validator` as an `exec_depend` in `package.xml`.

## How was this PR tested?
Tested by running LSim/Psim with the following PRs merged

- https://github.com/autowarefoundation/autoware_universe/pull/12939
- https://github.com/autowarefoundation/autoware_universe/pull/12950
- https://github.com/autowarefoundation/autoware_universe/pull/12951
- https://github.com/autowarefoundation/autoware_universe/pull/12953

## Notes for reviewers

None.

## Effects on system behavior

None.
