### PR TITLE
refactor(tier4_system_launch): remove retired service_log_checker references

### DIFF
--- a/autoware_launch/config/system/diagnostics/autoware-carla.yaml
+++ b/autoware_launch/config/system/diagnostics/autoware-carla.yaml
@@ -74,11 +74,6 @@ units:
       - { type: link, link: /autoware/vehicle }
       - { type: link, link: /autoware/system }
 
-  - path: /autoware/debug/tools
-    type: and
-    list:
-      - { type: link, link: /autoware/system/service_log_checker }
-
   # Localization units with extended timeouts for CARLA
   # Note: Removed transform and pose_twist_fusion topic monitors as they fail to load
   - path: /autoware/localization

--- a/autoware_launch/config/system/diagnostics/autoware-main.yaml
+++ b/autoware_launch/config/system/diagnostics/autoware-main.yaml
@@ -69,11 +69,6 @@ units:
       - { type: link, link: /autoware/vehicle }
       - { type: link, link: /autoware/system }
 
-  - path: /autoware/debug/tools
-    type: and
-    list:
-      - { type: link, link: /autoware/system/service_log_checker }
-
   - path: /adapi/mrm_request/delegate
     type: diag
     node: /adapi/node/mrm_request

--- a/autoware_launch/config/system/diagnostics/system.yaml
+++ b/autoware_launch/config/system/diagnostics/system.yaml
@@ -17,11 +17,6 @@ units:
     node: duplicated_node_checker
     name: duplicated_node_checker
 
-  - path: /autoware/system/service_log_checker
-    type: diag
-    node: service_log_checker
-    name: response_status
-
   - path: /autoware/system/topic_rate_check/emergency_control_command
     type: diag
     node: topic_state_monitor_system_emergency_control_cmd

--- a/tier4_universe_launch/tier4_system_launch/launch/system.launch.xml
+++ b/tier4_universe_launch/tier4_system_launch/launch/system.launch.xml
@@ -102,11 +102,6 @@
       </include>
     </group>
 
-    <!-- Service Log Checker -->
-    <group>
-      <include file="$(find-pkg-share autoware_component_interface_tools)/launch/service_log_checker.launch.xml"/>
-    </group>
-
     <!-- Component State Monitor -->
     <group>
       <include file="$(find-pkg-share autoware_component_state_monitor)/launch/component_state_monitor.launch.py">

--- a/tier4_universe_launch/tier4_system_launch/package.xml
+++ b/tier4_universe_launch/tier4_system_launch/package.xml
@@ -13,7 +13,6 @@
 
   <exec_depend>autoware_command_mode_decider</exec_depend>
   <exec_depend>autoware_command_mode_switcher</exec_depend>
-  <exec_depend>autoware_component_interface_tools</exec_depend>
   <exec_depend>autoware_component_state_monitor</exec_depend>
   <exec_depend>autoware_diagnostic_graph_aggregator</exec_depend>
   <exec_depend>autoware_dummy_diag_publisher</exec_depend>


### PR DESCRIPTION
## Description

Removes all references to the retired `service_log_checker` node (`autoware_component_interface_tools`), which is being removed from `autoware_universe`.

- `tier4_universe_launch/tier4_system_launch/launch/system.launch.xml` — drop the `service_log_checker.launch.xml` include.
- `tier4_universe_launch/tier4_system_launch/package.xml` — drop the `autoware_component_interface_tools` `exec_depend`.
- `autoware_launch/config/system/diagnostics/system.yaml` — drop the `/autoware/system/service_log_checker` analyzer.
- `autoware_launch/config/system/diagnostics/autoware-main.yaml`, `autoware-carla.yaml` — drop the `/autoware/debug/tools` "and" analyzers whose only member was the `service_log_checker` link.

This is the `autoware_launch` (cleanup) half of a coordinated cross-repo move of `autoware_component_interface_utils` from `autoware_universe` into `autoware_core`. All three PRs must land together — otherwise `tier4_system_launch` fails rosdep resolution of `autoware_component_interface_tools`:

- **autowarefoundation/autoware_core#1262** — adds `autoware_component_interface_utils` to core.
- **autowarefoundation/autoware_universe#13002** — removes the universe copy and retires `service_log_checker`.
- **autowarefoundation/autoware_launch** (this PR) — removes the `service_log_checker` launch/diagnostics references.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

**Background.** `service_log_checker` monitored the `/service_log` ServiceLog topic published by `autoware_component_interface_utils`. That package has moved to `autoware_core` with ServiceLog replaced by ROS 2 service introspection, so `/service_log` is no longer published and the checker is retired in `autoware_universe`.

## How was this PR tested?

Verified on the youtalk fork: `tier4_system_launch` resolves cleanly once `autoware_component_interface_tools` is gone from both the launch references and universe.

### youtalk fork CI — build-and-test

Staged on the youtalk fork before submission; the `build-and-test-differential` gate is green (verified `conclusion == success`):

- `build-and-test-differential (jazzy)`: https://github.com/youtalk/autoware_launch/actions/runs/29389990804/job/87271106553
- `build-and-test-differential (humble)`: https://github.com/youtalk/autoware_launch/actions/runs/29389990804/job/87271106598

The `check-params` / `check-params-per-category (control, map)` jobs are red on a pre-existing failure that also fails on the fork's `main` (`sync-params`) and is unrelated to this change — this PR touches only the `system` diagnostics configs and `tier4_system_launch`. The fork `spell-check-differential` flags only `Ubicloud` in the fork-only `.github/workflows/build-and-test.yaml` CI-routing file, which is not part of this PR's diff.

## Effects on system behavior

The `/autoware/system/service_log_checker` diagnostic is removed from the aggregator tree. Service-call failures remain observable at call sites via the `Client` wrapper exceptions (`ServiceUnready` / `ServiceTimeout`) and the response `status`.
