### PR TITLE
feat(tier4_planning_launch): launch velocity_smoother as standalone node when agnocast

### DIFF
--- a/tier4_universe_launch/tier4_planning_launch/launch/scenario_planning/scenario_planning.launch.xml
+++ b/tier4_universe_launch/tier4_planning_launch/launch/scenario_planning/scenario_planning.launch.xml
@@ -1,10 +1,4 @@
 <launch>
-  <let name="use_agnocast" value="$(env ENABLE_AGNOCAST 0)"/>
-  <let name="container_package" value="rclcpp_components" unless="$(eval &quot;'$(var use_agnocast)' == '1'&quot;)"/>
-  <let name="container_package" value="agnocast_components" if="$(eval &quot;'$(var use_agnocast)' == '1'&quot;)"/>
-  <let name="container_executable" value="component_container" unless="$(eval &quot;'$(var use_agnocast)' == '1'&quot;)"/>
-  <let name="container_executable" value="agnocast_component_container_cie" if="$(eval &quot;'$(var use_agnocast)' == '1'&quot;)"/>
-
   <arg name="enable_all_modules_auto_mode"/>
   <arg name="is_simulation"/>
   <!-- Input topic parameters -->
@@ -35,25 +29,28 @@
       </include>
     </group>
     <!-- motion velocity smoother -->
+    <!-- standalone (not a composable_node in a container): agnocast::Node does not run inside a
+         component container, so this node is always launched standalone. -->
     <group>
-      <node_container pkg="$(var container_package)" exec="$(var container_executable)" name="velocity_smoother_container" namespace="">
-        <composable_node pkg="autoware_velocity_smoother" plugin="autoware::velocity_smoother::VelocitySmootherNode" name="velocity_smoother" namespace="">
-          <param name="algorithm_type" value="$(var velocity_smoother_type)"/>
-          <param from="$(var common_param_path)"/>
-          <param from="$(var nearest_search_param_path)"/>
-          <param from="$(var velocity_smoother_param_path)"/>
-          <param from="$(var velocity_smoother_type_param_path)"/>
+      <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
 
-          <param name="publish_debug_trajs" value="false"/>
-          <remap from="~/input/trajectory" to="/planning/scenario_planning/scenario_selector/trajectory"/>
-          <remap from="~/output/trajectory" to="/planning/scenario_planning/velocity_smoother/trajectory"/>
+      <node pkg="autoware_velocity_smoother" exec="velocity_smoother_node" name="velocity_smoother" namespace="">
+        <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+        <param name="algorithm_type" value="$(var velocity_smoother_type)"/>
+        <param from="$(var common_param_path)"/>
+        <param from="$(var nearest_search_param_path)"/>
+        <param from="$(var velocity_smoother_param_path)"/>
+        <param from="$(var velocity_smoother_type_param_path)"/>
 
-          <remap from="~/input/external_velocity_limit_mps" to="/planning/scenario_planning/max_velocity"/>
-          <remap from="~/input/acceleration" to="/localization/acceleration"/>
-          <remap from="~/input/operation_mode_state" to="/system/operation_mode/state"/>
-          <remap from="~/output/current_velocity_limit_mps" to="/planning/scenario_planning/current_max_velocity"/>
-        </composable_node>
-      </node_container>
+        <param name="publish_debug_trajs" value="false"/>
+        <remap from="~/input/trajectory" to="/planning/scenario_planning/scenario_selector/trajectory"/>
+        <remap from="~/output/trajectory" to="/planning/scenario_planning/velocity_smoother/trajectory"/>
+
+        <remap from="~/input/external_velocity_limit_mps" to="/planning/scenario_planning/max_velocity"/>
+        <remap from="~/input/acceleration" to="/localization/acceleration"/>
+        <remap from="~/input/operation_mode_state" to="/system/operation_mode/state"/>
+        <remap from="~/output/current_velocity_limit_mps" to="/planning/scenario_planning/current_max_velocity"/>
+      </node>
     </group>
   </group>
 

--- a/tier4_universe_launch/tier4_planning_launch/launch/scenario_planning/scenario_planning.launch.xml
+++ b/tier4_universe_launch/tier4_planning_launch/launch/scenario_planning/scenario_planning.launch.xml
@@ -29,8 +29,6 @@
       </include>
     </group>
     <!-- motion velocity smoother -->
-    <!-- standalone (not a composable_node in a container): agnocast::Node does not run inside a
-         component container, so this node is always launched standalone. -->
     <group>
       <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
 

--- a/tier4_universe_launch/tier4_planning_launch/package.xml
+++ b/tier4_universe_launch/tier4_planning_launch/package.xml
@@ -58,6 +58,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend condition="$ENABLE_AGNOCAST == 1">agnocast_components</exec_depend>
+  <exec_depend>autoware_agnocast_wrapper</exec_depend>
   <exec_depend>autoware_behavior_path_planner</exec_depend>
   <exec_depend>autoware_behavior_velocity_planner</exec_depend>
   <exec_depend>autoware_costmap_generator</exec_depend>


### PR DESCRIPTION
## Description
When `velocity_smoother` is built with Agnocast enabled (`ENABLE_AGNOCAST=1`), it becomes an `AgnocastOnly` node (`agnocast_wrapper::Node`, [Method2](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-2-agnocast_wrappernode-inheritance)) and can no longer run as a composable node inside the standard `rclcpp` component container: the container only calls `rclcpp::init()`, so the Agnocast signal handler is never installed and the node fails to start.

This PR launches `velocity_smoother` as a standalone node in `scenario_planning.launch.xml`:

- Replace the `composable_node` (inside `velocity_smoother_container`) with a standalone `<node>`, so the node calls `agnocast::init()` on its own.
- Include `autoware_agnocast_wrapper`'s `agnocast_env.launch.xml` and set `LD_PRELOAD` (`$(var ld_preload_value)`) for the heaphook.
- Remove the now-unused `use_agnocast` / `container_package` / `container_executable` `<let>` switches (`velocity_smoother` was their only consumer).
- Add `autoware_agnocast_wrapper` as an `exec_depend` in `package.xml`.

The node is **always launched standalone** (no `ENABLE_AGNOCAST` conditional branching). Zero-copy still works across processes via Agnocast, so co-locating it in a container is unnecessary. When `ENABLE_AGNOCAST` is not set or `0`, `ld_preload_value` resolves to the existing `LD_PRELOAD`, so the default behavior is preserved.

## Related PRs
- https://github.com/autowarefoundation/autoware_core/pull/1264

## How was this PR tested?
- Build: `colcon build` succeeds with both `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0`.
- LSim (sample rosbag): The Logging Simulator runs to completion under both `ENABLE_AGNOCAST=0` and `ENABLE_AGNOCAST=1` with no `process died`, and `velocity_smoother` launches as a standalone node (not inside a component container).

## Notes for reviewers
This is the launch-side change paired with the node-side `agnocast_wrapper::Node` adoption for `autoware_velocity_smoother`. This PR should be merged before the node-side PR.

## Effects on system behavior

None when `ENABLE_AGNOCAST` is not set or `0`. When `ENABLE_AGNOCAST=1`, `velocity_smoother` runs standalone with the Agnocast heaphook and CPU time for message serialization/deserialization is reduced.