### PR TITLE
feat(tier4_control_launch): launch shift_decider as standalone node when agnocast

### DIFF
--- a/tier4_universe_launch/tier4_control_launch/launch/control.launch.xml
+++ b/tier4_universe_launch/tier4_control_launch/launch/control.launch.xml
@@ -79,18 +79,20 @@
     </group>
 
     <group>
+      <!-- shift decider: runs as autoware::agnocast_wrapper::Node, which does not support
+           being loaded into any component container (agnocast-aware or not), so it is
+           launched standalone instead. -->
+      <node pkg="autoware_shift_decider" exec="autoware_shift_decider" name="autoware_shift_decider" output="screen">
+        <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd"/>
+        <remap from="input/state" to="/autoware/state"/>
+        <remap from="input/current_gear" to="/vehicle/status/gear_status"/>
+        <remap from="output/gear_cmd" to="/control/shift_decider/gear_cmd"/>
+        <param from="$(var shift_decider_param_path)"/>
+        <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+      </node>
+
       <!-- set a control container to run all required components in the same process -->
       <node_container pkg="$(var container_package)" exec="$(var container_executable)" name="control_container" namespace="">
-        <!-- shift decider -->
-        <composable_node pkg="autoware_shift_decider" plugin="autoware::shift_decider::ShiftDecider" name="autoware_shift_decider">
-          <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd"/>
-          <remap from="input/state" to="/autoware/state"/>
-          <remap from="input/current_gear" to="/vehicle/status/gear_status"/>
-          <remap from="output/gear_cmd" to="/control/shift_decider/gear_cmd"/>
-          <param from="$(var shift_decider_param_path)"/>
-          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-        </composable_node>
-
         <!-- vehicle cmd gate -->
         <composable_node pkg="autoware_vehicle_cmd_gate" plugin="autoware::vehicle_cmd_gate::VehicleCmdGate" name="vehicle_cmd_gate" unless="$(var use_control_command_gate)">
           <remap from="input/steering" to="/vehicle/status/steering_status"/>

--- a/tier4_universe_launch/tier4_control_launch/launch/control.launch.xml
+++ b/tier4_universe_launch/tier4_control_launch/launch/control.launch.xml
@@ -79,9 +79,7 @@
     </group>
 
     <group>
-      <!-- shift decider: runs as autoware::agnocast_wrapper::Node, which does not support
-           being loaded into any component container (agnocast-aware or not), so it is
-           launched standalone instead. -->
+      <!-- shift decider -->
       <node pkg="autoware_shift_decider" exec="autoware_shift_decider" name="autoware_shift_decider" output="screen">
         <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd"/>
         <remap from="input/state" to="/autoware/state"/>


### PR DESCRIPTION
## Description
When `shift_decider` is built with Agnocast enabled (`ENABLE_AGNOCAST=1`), it becomes an `AgnocastOnly` node (`agnocast_wrapper::Node`, Method 2) and can no longer run as a composable node inside a component container (agnocast-aware or not): the container's `main()` never calls `agnocast::init()`, so the node fails to start.

This PR launches `shift_decider` as a standalone node in `control.launch.xml`:

- Move `shift_decider` out of `control_container` and launch it as a standalone `<node>` (`autoware_shift_decider`), so it initializes Agnocast on its own.
- Set `LD_PRELOAD` (`$(var ld_preload_value)`) on the node for the Agnocast heaphook. `agnocast_env.launch.xml` is already included in this file, so `ld_preload_value` is available and no additional include is needed.
- `control_container` itself is kept for the remaining composable nodes (e.g. `vehicle_cmd_gate`); only `shift_decider` is moved out.

The node is always launched standalone (no `ENABLE_AGNOCAST` conditional branching). Zero-copy still works across processes via Agnocast, so co-locating it in a container is unnecessary. When `ENABLE_AGNOCAST` is not set or `0`, `ld_preload_value` resolves to the existing `LD_PRELOAD`, so the default behavior is preserved.

## Related PRs
- autowarefoundation/autoware_universe#12918 (node-side `agnocast_wrapper::Node` adoption for `autoware_shift_decider`)
- autowarefoundation/autoware_universe#13015 (carla-side launch standalone change)

## How was this PR tested?
- Build: `colcon build` succeeds with both `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0`.
- PSim: Confirmed the planning simulator runs to completion under both `ENABLE_AGNOCAST=0` and `ENABLE_AGNOCAST=1`, `shift_decider` launches as a standalone node (not inside a component container), and the gear command is published as expected.

## Notes for reviewers
This is a launch-side change paired with the node-side `agnocast_wrapper::Node` adoption for `autoware_shift_decider` (autowarefoundation/autoware_universe#12918). The launch-side PRs (this one and autowarefoundation/autoware_universe#13015) should be merged before the node-side PR.

## Effects on system behavior

None when `ENABLE_AGNOCAST` is not set or `0`. When `ENABLE_AGNOCAST=1`, `shift_decider` runs standalone with the Agnocast heaphook and CPU time for message serialization/deserialization is reduced.