### PR TITLE
fix(detection.launch.xml): remove trailing space in lidar_ml/objects arg

### DIFF
--- a/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
+++ b/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
@@ -538,7 +538,7 @@
     <let name="input/lidar_cluster/objects" value="$(var lidar_rule_detector/output/objects)" unless="$(var use_semantic_segmentation_ptv3)"/>
     <let name="input/lidar_cluster/objects" value="$(var lidar_cluster/output/objects)" if="$(var use_semantic_segmentation_ptv3)"/>
     <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/detection/merger/lidar_merger.launch.xml">
-      <arg name="input/lidar_ml/objects " value="$(var object_merger/input/ml_detected_objects)"/>
+      <arg name="input/lidar_ml/objects" value="$(var object_merger/input/ml_detected_objects)"/>
       <arg name="input/lidar_cluster/objects" value="$(var input/lidar_cluster/objects)"/>
       <arg name="input/detection_by_tracker/objects" value="$(var tracker_based_detector/output/objects)"/>
       <arg name="output/objects" value="$(var output/objects)"/>


### PR DESCRIPTION
## Description

The `input/lidar_ml/objects` argument passed to the lidar object merger (lidar mode) in `detection.launch.xml` had a trailing space in its name (`input/lidar_ml/objects `). Because the arg name did not match the one declared in `lidar_merger.launch.xml`, the value was silently ignored and the ML detected objects input fell back to its default topic instead of the intended one.

This fixes the typo so the argument is correctly forwarded. The three other `lidar_merger` include blocks in the same file already use the correct name without the trailing space.

## Tests performed

Tested after the fix: the module now launches and works properly.

## Effects on system behavior

The lidar object merger now receives the intended `input/lidar_ml/objects` topic in lidar-only mode.

## Notes for reviewers

None.

## Interface changes

None.
