### PR TITLE
feat(lane_change): add overhang_tolerance param for stop point planning

### DIFF
--- a/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
+++ b/autoware_launch/config/planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/lane_change/lane_change.param.yaml
@@ -7,6 +7,7 @@
       backward_length_buffer_for_blocking_object: 3.0 # [m]
       backward_length_from_intersection: 5.0 # [m]
       enable_stopped_vehicle_buffer: true
+      overhang_tolerance: 0.3 # [m]
 
       # turn signal
       min_length_for_turn_signal_activation: 10.0 # [m]


### PR DESCRIPTION
## Description

Add `overhang_tolerance` parameter to the lane change launch configuration.

This parameter controls the tolerance for ego footprint overlow outside the lane polygon during stop point planning, defaulting to `0.3`.

Corresponding Universe PR:
- https://github.com/autowarefoundation/autoware_universe/pull/13079

## How was this PR tested?

Tested under Universe PR.

## Notes for reviewers

None.

## Effects on system behavior

If ego exceeds lanelet, it will be able to compensated with the new parameter.
