### PR TITLE
feat: launch voxel_grid_downsample_filter as standalone node when agnocast

### DIFF
--- a/tier4_universe_launch/tier4_localization_launch/launch/util/util.launch.xml
+++ b/tier4_universe_launch/tier4_localization_launch/launch/util/util.launch.xml
@@ -8,6 +8,19 @@
   <!-- whether use intra-process -->
   <arg name="use_intra_process" default="true" description="use ROS 2 component container communication"/>
 
+  <!-- voxel_grid_downsample_filter needs the standalone main under agnocast -->
+  <let name="use_agnocast" value="$(env ENABLE_AGNOCAST 0)"/>
+
+  <group if="$(eval &quot;'$(var use_agnocast)' == '1'&quot;)">
+    <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+    <node pkg="autoware_pointcloud_preprocessor" exec="voxel_grid_downsample_filter_node" name="voxel_grid_downsample_filter" namespace="" output="screen">
+      <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+      <param from="$(var ndt_scan_matcher/pointcloud_preprocessor/voxel_grid_downsample_filter_param_path)"/>
+      <remap from="input" to="measurement_range/pointcloud"/>
+      <remap from="output" to="voxel_grid_downsample/pointcloud"/>
+    </node>
+  </group>
+
   <load_composable_node target="$(var localization_pointcloud_container_name)">
     <composable_node pkg="autoware_pointcloud_preprocessor" plugin="autoware::pointcloud_preprocessor::CropBoxFilterComponent" name="crop_box_filter_measurement_range">
       <param from="$(var ndt_scan_matcher/pointcloud_preprocessor/crop_box_filter_measurement_range_param_path)"/>
@@ -16,17 +29,19 @@
       <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
     </composable_node>
 
-    <composable_node pkg="autoware_pointcloud_preprocessor" plugin="autoware::pointcloud_preprocessor::VoxelGridDownsampleFilterComponent" name="voxel_grid_downsample_filter">
-      <param from="$(var ndt_scan_matcher/pointcloud_preprocessor/voxel_grid_downsample_filter_param_path)"/>
-      <remap from="input" to="measurement_range/pointcloud"/>
-      <remap from="output" to="voxel_grid_downsample/pointcloud"/>
-      <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-    </composable_node>
-
     <composable_node pkg="autoware_pointcloud_preprocessor" plugin="autoware::pointcloud_preprocessor::RandomDownsampleFilterComponent" name="random_downsample_filter">
       <param from="$(var ndt_scan_matcher/pointcloud_preprocessor/random_downsample_filter_param_path)"/>
       <remap from="input" to="voxel_grid_downsample/pointcloud"/>
       <remap from="output" to="$(var output/pointcloud)"/>
+      <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+    </composable_node>
+  </load_composable_node>
+
+  <load_composable_node target="$(var localization_pointcloud_container_name)" unless="$(eval &quot;'$(var use_agnocast)' == '1'&quot;)">
+    <composable_node pkg="autoware_pointcloud_preprocessor" plugin="autoware::pointcloud_preprocessor::VoxelGridDownsampleFilterComponent" name="voxel_grid_downsample_filter">
+      <param from="$(var ndt_scan_matcher/pointcloud_preprocessor/voxel_grid_downsample_filter_param_path)"/>
+      <remap from="input" to="measurement_range/pointcloud"/>
+      <remap from="output" to="voxel_grid_downsample/pointcloud"/>
       <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
     </composable_node>
   </load_composable_node>

--- a/tier4_universe_launch/tier4_localization_launch/package.xml
+++ b/tier4_universe_launch/tier4_localization_launch/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <exec_depend>autoware_agnocast_wrapper</exec_depend>
   <exec_depend>autoware_ar_tag_based_localizer</exec_depend>
   <exec_depend>autoware_automatic_pose_initializer</exec_depend>
   <exec_depend>autoware_ekf_localizer</exec_depend>

--- a/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/filter/pointcloud_map_filter.launch.py
+++ b/tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/filter/pointcloud_map_filter.launch.py
@@ -21,6 +21,7 @@ from launch.conditions import IfCondition
 from launch.conditions import UnlessCondition
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import LoadComposableNodes
+from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode
 import yaml
 
@@ -36,6 +37,14 @@ class PointcloudMapFilterPipeline:
             self.pointcloud_map_filter_param = yaml.safe_load(f)["/**"]["ros__parameters"]
         self.voxel_size = self.pointcloud_map_filter_param["down_sample_voxel_size"]
         self.use_pointcloud_map = LaunchConfiguration("use_pointcloud_map").perform(context)
+        # voxel_grid_downsample_filter derives from autoware::agnocast_wrapper::Node. Under
+        # ENABLE_AGNOCAST=1 its AgnocastOnly executor only starts in a process that called
+        # agnocast::init(), which the generated standalone main does and a component container
+        # does not, so it has to leave the container in that mode.
+        self.use_agnocast = os.environ.get("ENABLE_AGNOCAST", "0") == "1"
+        self.down_sample_topic = (
+            "/perception/obstacle_segmentation/pointcloud_map_filtered/downsampled/pointcloud"
+        )
 
     def create_pipeline(self):
         if self.use_pointcloud_map == "true":
@@ -68,32 +77,58 @@ class PointcloudMapFilterPipeline:
         )
         return components
 
+    def create_voxel_grid_standalone_node(self):
+        """Return the standalone voxel_grid_downsample_filter action, or None when not needed."""
+        if not (self.use_agnocast and self.use_pointcloud_map == "true"):
+            return None
+        heaphook = os.path.join(
+            "/opt/ros", os.environ.get("ROS_DISTRO", "humble"), "lib/libagnocast_heaphook.so"
+        )
+        ld_preload = ":".join(filter(None, [heaphook, os.environ.get("LD_PRELOAD", "")]))
+        return Node(
+            package="autoware_pointcloud_preprocessor",
+            executable="voxel_grid_downsample_filter_node",
+            name="voxel_grid_downsample_filter",
+            output="screen",
+            additional_env={"LD_PRELOAD": ld_preload},
+            remappings=[
+                ("input", LaunchConfiguration("input_topic")),
+                ("output", self.down_sample_topic),
+            ],
+            parameters=[
+                {
+                    "voxel_size_x": self.voxel_size,
+                    "voxel_size_y": self.voxel_size,
+                    "voxel_size_z": self.voxel_size,
+                }
+            ],
+        )
+
     def create_compare_map_pipeline(self):
         components = []
-        down_sample_topic = (
-            "/perception/obstacle_segmentation/pointcloud_map_filtered/downsampled/pointcloud"
-        )
-        components.append(
-            ComposableNode(
-                package="autoware_pointcloud_preprocessor",
-                plugin="autoware::pointcloud_preprocessor::VoxelGridDownsampleFilterComponent",
-                name="voxel_grid_downsample_filter",
-                remappings=[
-                    ("input", LaunchConfiguration("input_topic")),
-                    ("output", down_sample_topic),
-                ],
-                parameters=[
-                    {
-                        "voxel_size_x": self.voxel_size,
-                        "voxel_size_y": self.voxel_size,
-                        "voxel_size_z": self.voxel_size,
-                    }
-                ],
-                extra_arguments=[
-                    {"use_intra_process_comms": LaunchConfiguration("use_intra_process")}
-                ],
-            ),
-        )
+        down_sample_topic = self.down_sample_topic
+        if not self.use_agnocast:
+            components.append(
+                ComposableNode(
+                    package="autoware_pointcloud_preprocessor",
+                    plugin="autoware::pointcloud_preprocessor::VoxelGridDownsampleFilterComponent",
+                    name="voxel_grid_downsample_filter",
+                    remappings=[
+                        ("input", LaunchConfiguration("input_topic")),
+                        ("output", down_sample_topic),
+                    ],
+                    parameters=[
+                        {
+                            "voxel_size_x": self.voxel_size,
+                            "voxel_size_y": self.voxel_size,
+                            "voxel_size_z": self.voxel_size,
+                        }
+                    ],
+                    extra_arguments=[
+                        {"use_intra_process_comms": LaunchConfiguration("use_intra_process")}
+                    ],
+                ),
+            )
         components.append(
             ComposableNode(
                 package="autoware_compare_map_segmentation",
@@ -128,7 +163,11 @@ def launch_setup(context, *args, **kwargs):
         composable_node_descriptions=components,
         target_container=LaunchConfiguration("pointcloud_container_name"),
     )
-    return [pointcloud_container_loader]
+    actions = [pointcloud_container_loader]
+    standalone_voxel_grid = pipeline.create_voxel_grid_standalone_node()
+    if standalone_voxel_grid is not None:
+        actions.append(standalone_voxel_grid)
+    return actions
 
 
 def generate_launch_description():


### PR DESCRIPTION
## Description

Launch `voxel_grid_downsample_filter` as a standalone node when `ENABLE_AGNOCAST=1`, and keep it as a composable node otherwise.

`VoxelGridDownsampleFilterComponent` now derives from `agnocast_wrapper::Node` (autowarefoundation/autoware_universe#13072), so under `ENABLE_AGNOCAST=1` it runs on an `AgnocastOnlyCallbackIsolatedExecutor`. That executor only starts in a process that called `agnocast::init()`, which the wrapper-generated standalone main does and a component container does not. Loaded into `pointcloud_container` it fails with `Failed to register shutdown eventfd with signal handler` and `exit(EXIT_FAILURE)`, which kills the container and takes the rest of the pointcloud pipeline (crop box filters, lidar_centerpoint, …) down with it.

Two launch sites load this component and are switched here:

- `tier4_localization_launch` `util.launch.xml` — the NDT input downsampler.
- `tier4_perception_launch` `pointcloud_map_filter.launch.py` — the compare-map pipeline downsampler.

`tier4_localization_launch` gains an `autoware_agnocast_wrapper` `exec_depend` because `util.launch.xml` now includes `agnocast_env.launch.xml` for `ld_preload_value`.

Note: `ground_segmentation.launch.py` loads the same component as `elevation_map/voxel_grid_filter`. It is only reached with the elevation-map based outlier filter, which this setup does not exercise, so it is left untouched rather than changed unverified.

## Related Links

- https://github.com/autowarefoundation/autoware_universe/pull/13072
- https://github.com/autowarefoundation/autoware/issues/7007

## How was this PR tested?

`logging_simulator` with `perception_mode:=camera_lidar_fusion` on `sample-map-rosbag` + `sample-rosbag`, built with `ENABLE_AGNOCAST=1`.

- Before: `pointcloud_container` (`agnocast_component_container_cie`) died with `exit code 1` the moment `VoxelGridDownsampleFilterComponent` was instantiated.
- After: both instances come up as standalone nodes, `ros2 node list_agnocast` reports them as `(Agnocast enabled)`, no process dies, and `/localization/util/voxel_grid_downsample/pointcloud` flows during bag replay so NDT initializes.

## Effects on system behavior

None at `ENABLE_AGNOCAST=0`: the composable node path is unchanged.
