### PR TITLE
feat(euclidean_cluster): use ordered class_names list for label_based…

### DIFF
--- a/autoware_launch/config/perception/object_recognition/detection/euclidean_cluster/label_based_euclidean_cluster.param.yaml
+++ b/autoware_launch/config/perception/object_recognition/detection/euclidean_cluster/label_based_euclidean_cluster.param.yaml
@@ -47,25 +47,26 @@
     # Point filtering by semantic confidence
     min_probability: 0.3
 
-    # Semantic label selection and mapping
-    # YAML declaration order is treated as the input class_id order.
+    # Semantic label selection and mapping.
+    # The list index is treated as the input class_id (order matters).
+    # Inline comments record the source model class name for each index.
     # cspell:ignore pullable
     class_names: # {OVERRIDE}
-      car: car
-      truck: truck
-      bus: bus
-      bicycle: bicycle
-      pedestrian: pedestrian
-      traffic_cone: hazard
-      barrier: hazard
-      debris: hazard
-      drivable_flat: ignore
-      non_drivable_flat: ignore
-      vegetation: ignore
-      building: ignore
-      vertical_thin: hazard
-      static_clutter: ignore
-      noise: ignore
+      - car  # 0: car
+      - truck  # 1: truck
+      - bus  # 2: bus
+      - bicycle  # 3: bicycle
+      - pedestrian  # 4: pedestrian
+      - hazard  # 5: traffic_cone
+      - hazard  # 6: barrier
+      - hazard  # 7: debris
+      - ignore  # 8: drivable_flat
+      - ignore  # 9: non_drivable_flat
+      - ignore  # 10: vegetation
+      - ignore  # 11: building
+      - hazard  # 12: vertical_thin
+      - ignore  # 13: static_clutter
+      - ignore  # 14: noise
 
     # Shape estimation behavior
     use_shape_estimation_corrector: false


### PR DESCRIPTION
> Must be merged together with https://github.com/autowarefoundation/autoware_universe/pull/13082. See "Notes for reviewers".

## Description

Migrate the `label_based_euclidean_cluster` configuration to the new ordered `class_names` list.

`autoware_euclidean_cluster` changes `class_names` from a nested mapping to an ordered list of target labels whose index is the input `class_id`. This PR updates the corresponding parameter file in `autoware_launch` to the new form, keeping the same `class_id` to target-label mapping. The original model class name for each index is kept as an inline comment so the mapping stays reviewable.

Only one file is changed: `autoware_launch/config/perception/object_recognition/detection/euclidean_cluster/label_based_euclidean_cluster.param.yaml`.

## Related links

- Node-side PR: https://github.com/autowarefoundation/autoware_universe/pull/13082

## How was this PR tested?

- **Ordering**: Cross-checked the 15 entries against the `class_names` array in `autoware_ptv3/config/ml_package_ptv3_seg3d_head.param.yaml`, which is the producer of this node's input point cloud — 15/15 match.
- **Runtime (LSim)**: On an autoware-based product, confirmed with the logging simulator that `label_based_euclidean_cluster` starts with this configuration and publishes detected objects with the expected labels.

## Notes for reviewers

- **Why the format changes**: As a standalone node, `--params-file` contents do not appear in `rclcpp::NodeOptions::parameter_overrides()`, so the node can no longer recover the input `class_id` from YAML declaration order. The index-based list makes the mapping explicit. This is also the mainstream Autoware convention (centerpoint, transfusion, bevfusion, pointpainting, bevdet, camera_streampetr, frnet, ptv3), and it now matches the producer `autoware_ptv3` in both form and order. The rationale is described in the node-side PR.
- **Merge order**: This PR and the node-side PR above change the same parameter format on both sides and **must be merged as a pair**. If only one of them lands, `label_based_euclidean_cluster` fails to start. The affected path is opt-in (`use_semantic_segmentation_ptv3` defaults to `false`), so the default pipeline is unaffected in the meantime.

## Interface changes

- `class_names` is now an ordered list of target labels instead of a mapping. The mapping content is unchanged; only its representation changes.

## Effects on system behavior

None. The `class_id` to target-label mapping is identical to the previous configuration.
