### PR TITLE
feat(MPC): add option to get feed-forward steering from input trajectory

### DIFF
--- a/autoware_launch/config/control/trajectory_follower/lateral/mpc.param.yaml
+++ b/autoware_launch/config/control/trajectory_follower/lateral/mpc.param.yaml
@@ -17,6 +17,7 @@
     traj_resample_dist: 0.1         # path resampling interval [m]
     use_steer_prediction: false     # flag for using steer prediction (do not use steer measurement)
     use_delayed_initial_state: true # flag to use x0_delayed as initial state for predicted trajectory
+    use_trajectory_steering_for_feedforward: false # Use temporal trajectory steering for Uref when at least one input steering value is nonzero.
     # This default file is for MPC-specific parameters only
 
     # -- path smoothing --


### PR DESCRIPTION
## Description

This PR adds the option to directly use steering values from the input trajectory message for its feed forward steering.
Required for https://github.com/autowarefoundation/autoware_universe/pull/13121

## How was this PR tested?

Psim

## Notes for reviewers

None.

## Effects on system behavior

None.
