### PR TITLE
chore(sync-params): sync diffusion_planner model path params

### DIFF
--- a/autoware_launch/config/planning/neural_net_planner/diffusion_planner.param.yaml
+++ b/autoware_launch/config/planning/neural_net_planner/diffusion_planner.param.yaml
@@ -9,7 +9,7 @@
 # 'reason' can be any single-line text without braces.
 # To keep local changes, annotate fields with '# {OVERRIDE}' or '# {OVERRIDE: reason}'.
 #
-# Source: https://github.com/autowarefoundation/autoware_universe/blob/d5ff1d71b876924815503f6f037b89d1f28ea86a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+# Source: https://github.com/autowarefoundation/autoware_universe/blob/e46ab8bd55e7b8247e521b23a9ac0c849d1d531f/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
 
 /**:
   ros__parameters:
@@ -19,13 +19,14 @@
       backend: "tensorrt" # "tensorrt" "ort_cpu" "ort_cuda" "ort_tensorrt"
       precision: "fp32"
       use_cuda_graph: false
-      args_path: $(var data_path)/diffusion_planner/v5.0/diffusion_planner.param.json
+      base_model_directory: $(var data_path)/diffusion_planner/v5.0
+      args_filename: diffusion_planner.param.json
       single_step_model:
-        onnx_model_path: $(var data_path)/diffusion_planner/v5.0/diffusion_planner.onnx
+        onnx_model_filename: diffusion_planner.onnx
       multi_step_model:
-        encoder_onnx_model_path: $(var data_path)/diffusion_planner/v5.0/diffusion_planner_encoder.onnx
-        decoder_onnx_model_path: $(var data_path)/diffusion_planner/v5.0/diffusion_planner_decoder.onnx
-        turn_indicator_onnx_model_path: $(var data_path)/diffusion_planner/v5.0/diffusion_planner_turn_indicator.onnx
+        encoder_onnx_model_filename: diffusion_planner_encoder.onnx
+        decoder_onnx_model_filename: diffusion_planner_decoder.onnx
+        turn_indicator_onnx_model_filename: diffusion_planner_turn_indicator.onnx
         dpm_solver_steps: 10
     guidance:
       start_guidance:


### PR DESCRIPTION
## Description

- Sync `diffusion_planner.param.yaml` with [autowarefoundation/autoware_universe#13148](https://github.com/autowarefoundation/autoware_universe/pull/13148).
- Replace per-file absolute ONNX/args paths with `model.base_model_directory` plus configurable filenames (`args_filename`, `*_onnx_model_filename`).
- Update the managed Source SHA to the universe PR head (`e46ab8bd`).

Companion universe PR: https://github.com/autowarefoundation/autoware_universe/pull/13148

## How was this PR tested?

- [ ] Not run locally — rely on CI
- [ ] Confirm launch-side keys match universe `diffusion_planner.param.yaml` after #13148

## Notes for reviewers

- Manual sync ahead of merge of the universe PR (sync-params cannot pick this up until that lands).
- Keep this PR and universe #13148 linked; merge ordering: universe first, then this launch sync (or land together).

## Effects on system behavior

Requires the diffusion planner node changes from universe #13148; old `*_path` keys will no longer be declared.


Made with [Cursor](https://cursor.com)