### PR TITLE
feat(tier4_control_launch): take the AEB yaw rate from kinematic state

### DIFF
--- a/autoware_launch/config/control/autoware_autonomous_emergency_braking/autonomous_emergency_braking.param.yaml
+++ b/autoware_launch/config/control/autoware_autonomous_emergency_braking/autonomous_emergency_braking.param.yaml
@@ -25,6 +25,11 @@
     imu_path_lat_dev_threshold: 1.75
     min_generated_imu_path_length: 0.5
     max_generated_imu_path_length: 10.0
+    # Kinematic-state (yaw-rate) watchdog tolerance [s]: the twist stamp must lie within +/- this of
+    # the node clock. Too old (stale localization) or implausibly ahead (clock skew) makes the
+    # IMU-path yaw source unavailable (the path is skipped), never a usable/zero-yaw estimate.
+    # Initial conservative value, not calibrated against measured on-vehicle jitter.
+    kinematic_state_timeout_sec: 0.5
     imu_prediction_time_horizon: 1.5
     imu_prediction_time_interval: 0.1
     mpc_prediction_time_horizon: 4.5

--- a/tier4_universe_launch/tier4_control_launch/launch/control.launch.xml
+++ b/tier4_universe_launch/tier4_control_launch/launch/control.launch.xml
@@ -248,6 +248,7 @@
           <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>
           <remap from="~/input/velocity" to="/vehicle/status/velocity_status"/>
           <remap from="~/input/imu" to="/sensing/imu/imu_data"/>
+          <remap from="~/input/kinematic_state" to="/localization/kinematic_state"/>
           <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
           <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
           <param from="$(var aeb_param_path)"/>


### PR DESCRIPTION
## Description

> [!IMPORTANT]
> **This PR is purely additive and safe to merge on its own.** It adds a new `~/input/kinematic_state` remap alongside the existing `~/input/imu` remap (kept, not replaced) and a new `kinematic_state_timeout_sec` parameter, without removing or changing anything AEB currently uses — so today's AEB keeps working unchanged once this merges. The paired `autoware_universe` change to `autoware_autonomous_emergency_braking` (which moves the AEB IMU-path yaw rate from `~/input/imu` to `~/input/kinematic_state`) is autowarefoundation/autoware_universe#13175, and it should merge **after** this PR, once both pieces below are already in place. A one-line follow-up then removes the now-unused `~/input/imu` remap once nothing subscribes to it.

The integrated stack does not use `autoware_autonomous_emergency_braking`'s own launch file — nothing includes it. AEB is spawned from this repository, at `tier4_universe_launch/tier4_control_launch/launch/control.launch.xml:246-257`, with this repository's own remaps and its own copy of the parameter file. This PR adds both pieces the paired universe change will need, ahead of that change landing:

1. **`tier4_universe_launch/tier4_control_launch/launch/control.launch.xml:250-251`** — adds `<remap from="~/input/kinematic_state" to="/localization/kinematic_state"/>` immediately after the existing `<remap from="~/input/imu" to="/sensing/imu/imu_data"/>`, which this PR keeps rather than replaces. `rcl` resolves an unmatched remap rule lazily at name resolution rather than raising an error, so keeping `~/input/imu` costs nothing: today's node still subscribes to it and keeps working unchanged, while the new `~/input/kinematic_state` remap sits ready and unused until the universe PR's node actually declares that subscription.
2. **`autoware_launch/config/control/autoware_autonomous_emergency_braking/autonomous_emergency_braking.param.yaml`** — gains `kinematic_state_timeout_sec: 0.5`. The node in the paired universe PR declares that parameter with no default (`declare_parameter<double>("kinematic_state_timeout_sec")`, the same convention the package already uses for `t_response`), so if that PR merges before this one, AEB would raise `NoParameterOverrideProvided` and **fail to construct at all**. Landing this PR first means the override already exists by the time the universe PR needs it.

Landing this PR first, before the universe PR, avoids both failure modes described above without requiring a simultaneous merge: the remap addition is inert until the universe node subscribes to `~/input/kinematic_state`, and the parameter addition means the universe node's undefaulted `declare_parameter` call already has an override waiting when it starts checking for one.

The parameter file is a `sync-params`-managed copy of the package's default file, so the new entry is added exactly as the generator would emit it: same value, same position (between `max_generated_imu_path_length` and `imu_prediction_time_horizon`), and the source file's comment block verbatim. It deliberately carries **no** `# {OVERRIDE}` marker — it is not a local deviation but the upstream default, so annotating it would wrongly pin it as a permanent variant override (and, mechanically, `sync_params.py` reports an `{OVERRIDE}` on a key that is absent from the pinned source as a stale override rather than accepting it). See the note on `check-params` below.

**Codeowners: please hold nightly `control` param-sync PRs until this PR and the paired universe PR have both landed.** `.github/workflows/sync-params.yaml` runs nightly per category and opens an automated PR from `sync_params.py <category>`. Because `kinematic_state_timeout_sec` is absent from the pinned universe revision until the paired PR merges, a `control` sync PR opened in the interval would propose deleting the key this PR just added — and merging that sync PR would re-arm the `NoParameterOverrideProvided` construction failure. Holding `control` sync PRs during the window between the two merges avoids that.

## How was this PR tested?

- `pre-commit run --from-ref origin/main --to-ref HEAD`: every hook passes (`check xml`, `check yaml`, `prettier`, `prettier launch.xml`, `yamllint`, `trim trailing whitespace`, `fix end of files`, `mixed line ending`), no files modified.
- Parameter key-set diff against the package's own `control/autoware_autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml` on the paired universe branch: before this change, `kinematic_state_timeout_sec` was the **only** key present in the package file and missing here (37 keys vs. 38, identical order); after it, the two key sets and their order are identical, and the body of this file below the `sync-params` header is byte-identical to the package file.
- `python .github/scripts/sync_params.py --check control` run locally to confirm that the only drift this change introduces is the five added lines in this one file, and that no other `control` variant is affected (`variants_changed=1`).
- Fork CI on youtalk/autoware_launch, including both differential builds — see below.

## Notes for reviewers

**`check-params-per-category (control)` is expected to be red on this PR, and only because of this change.** `sync_params.py --check` compares each variant against the source revision pinned in the variant's own header, and `kinematic_state_timeout_sec` does not exist in `autoware_universe` `main` until the paired PR merges. The reported drift is exactly the five lines this PR adds and nothing else, and the `check-params` aggregate job is red only as the roll-up of that. Once the paired universe PR is merged and `sync-params` re-runs against the new revision, the drift disappears and the header's `# Source:` pin advances on its own. If the project would rather not merge a knowingly-red `check-params`, merging the universe PR first and then re-running `sync-params` produces this file's content automatically — but that ordering leaves AEB unable to construct in the interval, which is why this PR should land first, not simultaneously with the universe PR.

This change does not touch the other AEB remaps or any other parameter. `~/input/pointcloud`, `~/input/velocity`, `~/input/objects` and `~/input/predicted_trajectory` are unchanged, and the new remap follows the same one-line form as its siblings (`autoware_collision_detector` in the same file already remaps its odometry input to `/localization/kinematic_state`, so the topic is available at this point in the launch tree).

Not addressed here, deliberately: the silent-degradation class above is only visible at `INFO` level, because the AEB node logs a missing or stale yaw source with a throttled `RCLCPP_INFO` rather than publishing a diagnostic. Raising it to a diagnostic is a follow-up in the universe package (it has its own codeowners), noted in the paired PR as well.

## Effects on system behavior

Once paired with the universe change, AEB's IMU-path yaw rate comes from `/localization/kinematic_state` (localization-fused twist in `base_link`, no TF lookup) instead of `/sensing/imu/imu_data`, and a stale or implausibly future-stamped twist makes that yaw source unavailable for the cycle (the IMU path is skipped) rather than being used or treated as zero yaw. AEB is not otherwise reconfigured: no threshold, no rate, and no other input changes.

## Related links

**Parent Issue:** https://github.com/autowarefoundation/autoware/issues/7210

## youtalk fork CI

Verified on the youtalk fork before this submission: https://github.com/youtalk/autoware_launch/pull/6 (draft, head `91dc0a27`, base `civ/ci-base` = upstream `main` plus two fork-only CI commits — Ubicloud runner routing and a `.cspell.json` allowlist for the runner name — so the head branch itself carries zero fork-only content and the differential comparison is exactly upstream `main`).