### PR TITLE
feat(map): default pointcloud map loader to differential-service delivery

### DIFF
--- a/autoware_launch/config/map/pointcloud_map_loader.param.yaml
+++ b/autoware_launch/config/map/pointcloud_map_loader.param.yaml
@@ -13,7 +13,7 @@
 
 /**:
   ros__parameters:
-    enable_whole_load: true
+    enable_whole_load: false # {OVERRIDE: whole-load is debug-only; cross-container delivery uses the differential service (see map.launch.xml service/get_differential_pcd_map remap). Map-module health is signalled by the latched /map/pointcloud_map_metadata topic, not by this raw map topic.}
     enable_downsampled_whole_load: false
     enable_partial_load: true
     enable_selected_load: false

--- a/autoware_launch/config/system/component_state_monitor/topics.yaml
+++ b/autoware_launch/config/system/component_state_monitor/topics.yaml
@@ -11,13 +11,17 @@
     error_rate: 0.0
     timeout: 0.0
 
+# The PCD map now reaches its consumers through the differential/partial services, so
+# /map/pointcloud_map is no longer advertised and cannot signal map-module health. The latched
+# metadata topic is published as soon as the PCD map is loaded, independently of the delivery
+# mechanism, so it is what proves the map module is alive.
 - module: map
   mode: [online, logging_simulation]
   type: launch
   args:
-    node_name_suffix: pointcloud_map
-    topic: /map/pointcloud_map
-    topic_type: sensor_msgs/msg/PointCloud2
+    node_name_suffix: pointcloud_map_metadata
+    topic: /map/pointcloud_map_metadata
+    topic_type: autoware_map_msgs/msg/PointCloudMapMetaData
     best_effort: false
     transient_local: true
     warn_rate: 0.0

--- a/autoware_launch/config/system/diagnostics/dummy_diag_publisher.param.yaml
+++ b/autoware_launch/config/system/diagnostics/dummy_diag_publisher.param.yaml
@@ -15,8 +15,8 @@
   ros__parameters:
     required_diags:
       # map
-      ## /autoware/map/topic_rate_check/pointcloud_map
-      "topic_state_monitor_pointcloud_map: map_topic_status": default
+      ## /autoware/map/topic_rate_check/pointcloud_map_metadata
+      "topic_state_monitor_pointcloud_map_metadata: map_topic_status": default
 
       # localization
       ## /autoware/localization/scan_matching_status

--- a/autoware_launch/config/system/diagnostics/map.yaml
+++ b/autoware_launch/config/system/diagnostics/map.yaml
@@ -3,14 +3,14 @@ units:
     type: and
     list:
       - { type: link, link: /autoware/map/topic_rate_check/vector_map }
-      - { type: link, link: /autoware/map/topic_rate_check/pointcloud_map }
+      - { type: link, link: /autoware/map/topic_rate_check/pointcloud_map_metadata }
 
   - path: /autoware/map/topic_rate_check/vector_map
     type: diag
     node: topic_state_monitor_vector_map
     name: map_topic_status
 
-  - path: /autoware/map/topic_rate_check/pointcloud_map
+  - path: /autoware/map/topic_rate_check/pointcloud_map_metadata
     type: diag
-    node: topic_state_monitor_pointcloud_map
+    node: topic_state_monitor_pointcloud_map_metadata
     name: map_topic_status


### PR DESCRIPTION
## Description

Flips `enable_whole_load` from `true` to `false` in `autoware_launch/config/map/pointcloud_map_loader.param.yaml` so the map loader no longer advertises the whole-load `/map/pointcloud_map` topic by default. This confines the raw (unfiltered, full-map) pointcloud wire to the debug case, leaving the differential service as the only cross-container map delivery path by default. `tier4_universe_launch/tier4_perception_launch/launch/object_recognition/detection/filter/pointcloud_map_filter.launch.py` remaps `map_loader_service` to `/map/get_differential_pointcloud_map`, `tier4_universe_launch/tier4_localization_launch/launch/pose_twist_estimator/ndt_scan_matcher.launch.xml` sets `client_map_loader` to the same topic, and `tier4_universe_launch/tier4_map_launch/launch/map.launch.xml` remaps the loader's `service/get_differential_pcd_map` to `/map/get_differential_pointcloud_map` — so both functional consumers (compare-map filter and NDT scan matcher) already run on the differential service regardless of this flag; the only thing whole-load default drove was RViz full-map visualization and static-mode fallback, which remain available by re-enabling the flag. This file carries a `sync-params`-managed header requiring local deviations to be tagged `# {OVERRIDE: reason}`, so the changed line is annotated per that convention rather than committed as a silent diff from the upstream default.

Retiring the whole-load topic also retires the map module's liveness signal used by diagnostics, so this PR repoints it at one that survives the flip. `component_state_monitor` and the diagnostics graph previously watched `/map/pointcloud_map`; `topic_state_monitor` evaluates `isNotReceived()` before any rate or timeout threshold, so a never-published topic is a hard ERROR regardless of zeroed thresholds, and `/autoware/map` is an `and` over that link in `[online, logging_simulation]`. Left as-is, the map component would never leave ERROR and `/autoware/modes/autonomous` could never become OK. Both monitors now watch `/map/pointcloud_map_metadata`, which the map loader publishes latched as soon as the PCD metadata is parsed, independently of the delivery mechanism.

The diagnostics rename (`topic_state_monitor_pointcloud_map` → `topic_state_monitor_pointcloud_map_metadata` in `config/system/diagnostics/map.yaml`) also requires updating `config/system/diagnostics/dummy_diag_publisher.param.yaml`, which still faked the old diag-unit name. In `planning_simulation` (where `dummy_diag_publisher` is on by default and the real `topic_state_monitor` is not launched), the renamed diag unit would otherwise never receive a status, leaving `/autoware/map` permanently stale and blocking autonomous mode.

## Landing-order dependency

This PR depends on `autowarefoundation/autoware_core#1316` ("always publish the pointcloud map metadata"), which **has merged** (2026-08-01). That fix makes the map loader publish `/map/pointcloud_map_metadata` unconditionally, independent of `enable_whole_load`/`enable_selected_load`, which is what lets the diagnostics rewiring in this PR observe a real liveness signal instead of a topic that only exists behind other feature flags. With core#1316 merged, the landing-order dependency is satisfied and this PR is unblocked.

## How was this PR tested?

Verified on the Open AD Kit logging-simulation deployment: before this change, `/autoware/map` fell OK -> ERROR with only the `enable_whole_load` param flip (the raw map topic no longer existing starved the old liveness check); after adding the diagnostics/component_state_monitor rewiring to the metadata topic plus the `dummy_diag_publisher` rename follow-up, `/autoware/map` is OK with the raw map topic absent.

Static verification also performed:
- YAML parses cleanly for all four changed files.
- `pre-commit run --from-ref origin/main --to-ref HEAD` passes (check-yaml, yamllint, prettier, trailing-whitespace, etc.).
- Grep-based grounding of the differential-service wiring in `tier4_universe_launch/**` launch files, confirmed directly rather than assumed.

## Notes for reviewers

`enable_partial_load: true` is retained (the differential-service backend depends on it) and `enable_downsampled_whole_load`/`enable_selected_load` remain `false` — this PR does not touch the other loading-mode flags, only `enable_whole_load` plus the diagnostics/monitor follow-through needed to keep `/autoware/map` reporting correctly once the raw topic stops being advertised.

**Out of scope**: the raw `obstacle_segmentation/pointcloud` link cut is a separate, independent change and is not part of this PR.

## Effects on system behavior

`/map/pointcloud_map` (the whole-load raw pointcloud map topic) is no longer advertised by default; `/map/get_differential_pointcloud_map` remains the cross-container map delivery path used by `pointcloud_map_filter` and `ndt_scan_matcher`, unaffected by this change. Re-enable `enable_whole_load: true` locally for RViz full-map visualization or static-mode debugging. The map-module diagnostics/component_state_monitor now watch `/map/pointcloud_map_metadata` instead of `/map/pointcloud_map`, and `dummy_diag_publisher.param.yaml` (used in `planning_simulation`) fakes the renamed diag unit so autonomous-mode availability is unaffected there too.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## youtalk fork CI

Re-cut and re-verified on the youtalk fork ahead of this submission: https://github.com/youtalk/autoware_launch/pull/5 (base `civ/ci-base` = `origin/main` + two fork-only CI commits — one routing fork CI onto faster runners, one allowlisting that runner's name for the spell checker; neither is part of this diff).