### PR TITLE
refactor(autoware_sample_designs): migrate Parking module design from autoware_universe

### DIFF
--- a/autoware_sample_designs/design/module/planning/Parking.module.yaml
+++ b/autoware_sample_designs/design/module/planning/Parking.module.yaml
@@ -1,0 +1,48 @@
+autoware_system_design_format: 0.3.0
+
+# module information
+name: Parking.module
+
+instances:
+  - name: costmap_generator
+    entity: CostmapGenerator.node
+  - name: freespace_planner
+    entity: FreespacePlanner.node
+
+# interfaces
+subscribers:
+  - name: objects
+  - name: points_no_ground
+  - name: vector_map
+  - name: scenario
+  - name: route
+  - name: odometry
+
+publishers:
+  - name: trajectory
+  - name: is_completed
+  - name: grid_map
+
+connections:
+  - - subscriber.objects
+    - costmap_generator.subscriber.objects
+  - - subscriber.points_no_ground
+    - costmap_generator.subscriber.points_no_ground
+  - - subscriber.vector_map
+    - costmap_generator.subscriber.vector_map
+  - - subscriber.scenario
+    - costmap_generator.subscriber.scenario
+  - - costmap_generator.publisher.occupancy_grid
+    - freespace_planner.subscriber.occupancy_grid
+  - - subscriber.route
+    - freespace_planner.subscriber.route
+  - - subscriber.scenario
+    - freespace_planner.subscriber.scenario
+  - - subscriber.odometry
+    - freespace_planner.subscriber.odometry
+  - - freespace_planner.publisher.trajectory
+    - publisher.trajectory
+  - - freespace_planner.publisher.is_completed
+    - publisher.is_completed
+  - - costmap_generator.publisher.grid_map
+    - publisher.grid_map


### PR DESCRIPTION
## Description

Migrates `Parking.module.yaml` from `autoware_universe` (`common/autoware_universe_designs`) into `autoware_sample_designs`, **content-unchanged**:

- `autoware_sample_designs/design/module/planning/Parking.module.yaml`

`ScenarioPlanning.module.yaml` in the same directory already references `entity: Parking.module` (instance `parking`) — the parent module lives here while the child was orphaned in universe. It was the only `.module.yaml` left in all of `autoware_universe`; module designs belong with the sample design set. Its two child nodes (`CostmapGenerator.node`, `FreespacePlanner.node`) stay in universe with their packages, which already carry their in-package design files.

The universe-side deletion happens in the final PR of the parent issue, after this PR merges.

## Related links

**Parent Issue:**

- autowarefoundation/autoware_universe#13093

## How was this PR tested?

- The added file is byte-identical to its source in `autoware_universe` `common/autoware_universe_designs/design/planning/parking/` (verified with `diff`).
- `pre-commit run lint-system-design-format --files autoware_sample_designs/design/module/planning/Parking.module.yaml` passes.

## Notes for reviewers

Add-only change; no file in this repository is modified.

## Effects on system behavior

None.
