### PR TITLE
chore: update package maintainer

### DIFF
--- a/tier4_universe_launch/tier4_control_launch/package.xml
+++ b/tier4_universe_launch/tier4_control_launch/package.xml
@@ -7,10 +7,11 @@
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="takumi.odashima@tier4.jp">Takumi Odashima</maintainer>
 
   <license>Apache License 2.0</license>
+
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/tier4_universe_launch/tier4_planning_launch/package.xml
+++ b/tier4_universe_launch/tier4_planning_launch/package.xml
@@ -15,10 +15,8 @@
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
   <!-- avoidance module -->
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <!-- turn signal decider -->
   <maintainer email="zulfaqar.azmi@tier4.jp">Zulfaqar Azmi</maintainer>
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
   <!-- drivable area generation-->
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
@@ -27,7 +25,6 @@
   <!-- intersection module -->
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
   <!-- crosswalk module -->
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <!-- detection area module -->
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
   <!-- occlusion spot module -->
@@ -35,7 +32,6 @@
   <!-- no stopping area module -->
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>
   <!-- traffic light module -->
-  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <!-- blind spot module -->
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
   <!-- stop line module -->
@@ -53,6 +49,8 @@
   <maintainer email="shumpei.wakabayashi@tier4.jp">Shumpei Wakabayashi</maintainer>
 
   <license>Apache License 2.0</license>
+
+  <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>


### PR DESCRIPTION
## Description

This pull request updates package metadata in `autoware_launch` by moving package ownership information from maintainer entries to a grouped author entry where appropriate. This keeps active maintainers and historical authorship represented separately. The most important changes are:

- Removes the target maintainer entries from affected `package.xml` files.
- Adds a grouped author entry in affected launch packages.
- Consolidates repeated ownership entries into a single author entry per package.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- `PRE_COMMIT_HOME=/tmp/pre-commit-cache /home/satoshi/.local/bin/pre-commit run --files tier4_universe_launch/tier4_control_launch/package.xml tier4_universe_launch/tier4_planning_launch/package.xml`

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
