### PR TITLE
feat(autoware_perception_launch): update the centerpoint model bundle stub to v4.1

### DIFF
--- a/.github/assets/autoware_data/ml_models/README.md
+++ b/.github/assets/autoware_data/ml_models/README.md
@@ -24,8 +24,8 @@ Then copy only the files that a launch file names into this tree. Remove the `.c
 
 ## lidar_centerpoint
 
-Tag `v4.0` holds one folder per variant (`base`, `tiny`, `sigma`, `short_range`). Each folder holds a manifest with the fixed name `ml_package.param.yaml`.
+Tag `v4.1` holds one folder per variant (`base`, `tiny`, `sigma`, `short_range`). Each folder holds a manifest with the fixed name `ml_package.param.yaml`.
 
-The default arguments select `tiny`, so only `tiny/ml_package.param.yaml` is here. A resolve run with `use_short_range_detection:=true` also needs `short_range/ml_package.param.yaml`.
+The default arguments select `base`, so only `base/ml_package.param.yaml` is here. A resolve run with `use_short_range_detection:=true` also needs `short_range/ml_package.param.yaml`.
 
 `detection_class_remapper.param.yaml` is not here, because no launch file names it. The node gets the path of that file from the manifest, then opens the file at run time.

--- a/.github/assets/autoware_data/ml_models/lidar_centerpoint/base/ml_package.param.yaml
+++ b/.github/assets/autoware_data/ml_models/lidar_centerpoint/base/ml_package.param.yaml
@@ -1,5 +1,7 @@
 /**:
   ros__parameters:
+    # model bundle version, checked against the range the node supports
+    version: v4.1
     # model files, relative to model_path
     encoder_onnx_path: pts_voxel_encoder.onnx
     encoder_engine_path: pts_voxel_encoder.engine
@@ -13,10 +15,11 @@
       max_voxel_size: 40000
       point_cloud_range: [-76.8, -76.8, -4.0, 76.8, 76.8, 6.0]
       voxel_size: [0.32, 0.32, 10.0]
-      downsample_factor: 2
+      downsample_factor: 1
       encoder_in_feature_size: 9
       has_variance: false
       has_twist: false
+      yaw_norm_thresholds: [0.3, 0.3, 0.3, 0.3, 0.0]
       detection_score_thresholds:
         # Upper bound of radial distance of 3d center_x and center_y in bounding boxes, and starting from 0
         # [0-50m), [50.0-90m), [90.0-121.0m), [121.0-200.0m), set a very high number for the last one to be safe


### PR DESCRIPTION
## Description

The launch CI stub bundle for `lidar_centerpoint` follows the v4.1 manifest layout: it carries the bundle `version` and the per-class `model_params.yaw_norm_thresholds`. Without it, the launch tests abort on the version check introduced in autowarefoundation/autoware_universe#13211.

## Related PRs

- universe: autowarefoundation/autoware_universe#13211
- ansible: autowarefoundation/autoware#7274
- data: [AutowareFoundation/lidar_centerpoint PR #2](https://huggingface.co/AutowareFoundation/lidar_centerpoint/discussions/2) (tag `v4.1`)

## Notes for reviewers

`config/object_recognition/detection/lidar_model/centerpoint_common.param.yaml` still lists `yaw_norm_thresholds`; the sync-params workflow drops it once the universe PR merges. The stale, unreferenced `autoware_sample_designs/config/perception/object_recognition/detection/centerpoint.param.yaml` predates the manifest split and is left alone here.
