### PR TITLE
fix(sample_designs): update map wrapper for new map loader parameters

### DIFF
--- a/autoware_sample_designs/design/wrapper/Tier4MapWrapper.node.yaml
+++ b/autoware_sample_designs/design/wrapper/Tier4MapWrapper.node.yaml
@@ -46,8 +46,12 @@ param_values:
     default: $(var map_path)/pointcloud_map_metadata.yaml
   - name: lanelet2_map_path
     default: $(var map_path)/$(var lanelet2_map_file)
+  - name: lanelet2_map_metadata_path
+    default: $(var map_path)/lanelet2_map_metadata.yaml
   - name: map_projector_info_path
     default: $(var map_path)/map_projector_info.yaml
+  - name: enable_selected_map_loading
+    default: false
   - name: use_multithread
     default: true
 


### PR DESCRIPTION
## Description

Update the `Tier4MapWrapper` node design to match the current map loader interface:

- add `lanelet2_map_metadata_path` (defaults to `$(var map_path)/lanelet2_map_metadata.yaml`)
- add `enable_selected_map_loading` (defaults to `false`)

Related: https://github.com/autowarefoundation/autoware_launch/pull/1813

## How was this PR tested?

tested by sample rosbag and logging-simulator

## Notes for reviewers

None.

## Effects on system behavior

None. `enable_selected_map_loading` defaults to `false`, so the default map loading behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
