### PR TITLE
feat(map_based_prediction): add per-class object deceleration parameters

### DIFF
--- a/autoware_universe_launch/autoware_perception_launch/config/object_recognition/prediction/map_based_prediction.param.yaml
+++ b/autoware_universe_launch/autoware_perception_launch/config/object_recognition/prediction/map_based_prediction.param.yaml
@@ -66,6 +66,13 @@
 
     reference_path_resolution: 0.5 #[m]
 
+    behavior_model:
+      object_deceleration:
+        base: -3.0 # [m/ss]
+        pedestrian: -0.5
+        bicycle: -1.0
+        motorcycle: -2.0
+
     # debug parameters
     publish_processing_time: true # {OVERRIDE}
     publish_processing_time_detail: true # {OVERRIDE}


### PR DESCRIPTION
## Description

Add the `behavior_model.object_deceleration` block introduced in autowarefoundation/autoware_universe#13203.

`map_based_prediction` declares `behavior_model.object_deceleration.base` without a built-in default, so the node fails to start without this entry once that change is merged. The remaining object classes fall back to `base`, so only the ones that deviate are listed here.

```yaml
    behavior_model:
      object_deceleration:
        base: -3.0 # [m/ss]
        pedestrian: -0.5
        bicycle: -1.0
        motorcycle: -2.0
```

## Related links

- autowarefoundation/autoware_universe#13203

## How was this PR tested?

None.

## Notes for reviewers

None.

## Effects on system behavior

None on its own. Once autoware_universe#13203 is merged, these values decide the deceleration each object class is assumed to be able to apply when judging whether it can stop before a line its predicted path crosses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)