### PR TITLE
chore(codeowners): update code owners and control launch maintainers

### DIFF
--- a/.github/CODEOWNERS-manual
+++ b/.github/CODEOWNERS-manual
@@ -1,22 +1,22 @@
 # /**
 # .github/**
 autoware_launch/** yukihiro.saito@tier4.jp ryohsuke.mitsudome@tier4.jp mfc@leodrive.ai
-autoware_launch/config/control/** takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp kosuke.takeuchi@tier4.jp yuki.takagi@tier4.jp alqudah.mohammad@tier4.jp kyoichi.sugahara@tier4.jp zulfaqar.azmi@tier4.jp maxime.clement@tier4.jp mamoru.sobue@tier4.jp yukinari.hisaki.2@tier4.jp arjun.ram@tier4.jp takumi.odashima@tier4.jp
+autoware_launch/config/control/** takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp shumpei.wakabayashi@tier4.jp kosuke.takeuchi@tier4.jp yuki.takagi@tier4.jp alqudah.mohammad@tier4.jp zulfaqar.azmi@tier4.jp maxime.clement@tier4.jp mamoru.sobue@tier4.jp yukinari.hisaki.2@tier4.jp arjun.ram@tier4.jp takumi.odashima@tier4.jp
 autoware_launch/config/localization/** masahiro.sakamoto@tier4.jp yamato.ando@tier4.jp ryu.yamamoto@tier4.jp kento.yabuuchi.2@tier4.jp shintaro.sakoda@tier4.jp taiki.yamada@tier4.jp anh.nguyen.2@tier4.jp
 autoware_launch/config/map/** masahiro.sakamoto@tier4.jp yamato.ando@tier4.jp ryu.yamamoto@tier4.jp kento.yabuuchi.2@tier4.jp shintaro.sakoda@tier4.jp taiki.yamada@tier4.jp anh.nguyen.2@tier4.jp
-autoware_launch/config/simulator/** takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp
+autoware_launch/config/simulator/** takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp shumpei.wakabayashi@tier4.jp
 autoware_launch/config/system/** fumihito.ito@tier4.jp isamu.takagi@tier4.jp
-autoware_launch/config/vehicle/** takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp mamoru.sobue@tier4.jp
-autoware_universe_launch/autoware_planning_config/config/** takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp kosuke.takeuchi@tier4.jp yuki.takagi@tier4.jp alqudah.mohammad@tier4.jp kyoichi.sugahara@tier4.jp zulfaqar.azmi@tier4.jp maxime.clement@tier4.jp mamoru.sobue@tier4.jp yukinari.hisaki.2@tier4.jp arjun.ram@tier4.jp takumi.odashima@tier4.jp
+autoware_launch/config/vehicle/** takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp shumpei.wakabayashi@tier4.jp mamoru.sobue@tier4.jp
+autoware_universe_launch/autoware_planning_config/config/** takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp shumpei.wakabayashi@tier4.jp kosuke.takeuchi@tier4.jp yuki.takagi@tier4.jp alqudah.mohammad@tier4.jp zulfaqar.azmi@tier4.jp maxime.clement@tier4.jp mamoru.sobue@tier4.jp yukinari.hisaki.2@tier4.jp arjun.ram@tier4.jp takumi.odashima@tier4.jp
 autoware_launch/launch/components/component_perception.launch.xml yoshi.ri@tier4.jp taekjin.lee@tier4.jp masato.saeki@tier4.jp lei.gu@tier4.jp
 autoware_launch/launch/components/component_traffic_light.launch.xml yoshi.ri@tier4.jp taekjin.lee@tier4.jp masato.saeki@tier4.jp lei.gu@tier4.jp
 autoware_launch/launch/components/component_sensing.launch.xml max.schmeller@tier4.jp dai.nguyen@tier4.jp taekjin.lee@tier4.jp yoshi.ri@tier4.jp
 autoware_launch/launch/components/tier4_autoware_api_component.launch.xml isamu.takagi@tier4.jp
-autoware_launch/launch/components/tier4_control_component.launch.xml takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp kosuke.takeuchi@tier4.jp yuki.takagi@tier4.jp alqudah.mohammad@tier4.jp kyoichi.sugahara@tier4.jp zulfaqar.azmi@tier4.jp maxime.clement@tier4.jp mamoru.sobue@tier4.jp yukinari.hisaki.2@tier4.jp arjun.ram@tier4.jp takumi.odashima@tier4.jp
+autoware_launch/launch/components/tier4_control_component.launch.xml takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp shumpei.wakabayashi@tier4.jp kosuke.takeuchi@tier4.jp yuki.takagi@tier4.jp alqudah.mohammad@tier4.jp zulfaqar.azmi@tier4.jp maxime.clement@tier4.jp mamoru.sobue@tier4.jp yukinari.hisaki.2@tier4.jp arjun.ram@tier4.jp takumi.odashima@tier4.jp
 autoware_launch/launch/components/tier4_localization_component.launch.xml masahiro.sakamoto@tier4.jp yamato.ando@tier4.jp ryu.yamamoto@tier4.jp kento.yabuuchi.2@tier4.jp shintaro.sakoda@tier4.jp taiki.yamada@tier4.jp anh.nguyen.2@tier4.jp
 autoware_launch/launch/components/tier4_map_component.launch.xml masahiro.sakamoto@tier4.jp yamato.ando@tier4.jp ryu.yamamoto@tier4.jp kento.yabuuchi.2@tier4.jp shintaro.sakoda@tier4.jp taiki.yamada@tier4.jp anh.nguyen.2@tier4.jp
-autoware_launch/launch/components/component_planning.launch.xml takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp kosuke.takeuchi@tier4.jp yuki.takagi@tier4.jp alqudah.mohammad@tier4.jp kyoichi.sugahara@tier4.jp zulfaqar.azmi@tier4.jp maxime.clement@tier4.jp mamoru.sobue@tier4.jp yukinari.hisaki.2@tier4.jp arjun.ram@tier4.jp takumi.odashima@tier4.jp
-autoware_launch/launch/components/tier4_simulator_component.launch.xml takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp satoshi.ota@tier4.jp shumpei.wakabayashi@tier4.jp
+autoware_launch/launch/components/component_planning.launch.xml takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp shumpei.wakabayashi@tier4.jp kosuke.takeuchi@tier4.jp yuki.takagi@tier4.jp alqudah.mohammad@tier4.jp zulfaqar.azmi@tier4.jp maxime.clement@tier4.jp mamoru.sobue@tier4.jp yukinari.hisaki.2@tier4.jp arjun.ram@tier4.jp takumi.odashima@tier4.jp
+autoware_launch/launch/components/tier4_simulator_component.launch.xml takayuki.murooka@tier4.jp fumiya.watanabe@tier4.jp shumpei.wakabayashi@tier4.jp
 autoware_launch/launch/components/tier4_system_component.launch.xml fumihito.ito@tier4.jp isamu.takagi@tier4.jp shumpei.wakabayashi@tier4.jp tomoya.kimura@tier4.jp
 autoware_launch/rviz/**  # no codeowners
 autoware_launch/rviz/image/** yukihiro.saito@tier4.jp ryohsuke.mitsudome@tier4.jp

--- a/tier4_universe_launch/tier4_control_launch/package.xml
+++ b/tier4_universe_launch/tier4_control_launch/package.xml
@@ -6,7 +6,8 @@
   <description>The tier4_control_launch package</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
-  <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
+  <maintainer email="yuki.takagi@tier4.jp">Yuki Takagi</maintainer>
+  <maintainer email="maxime.clement@tier4.jp">Maxime CLEMENT</maintainer>
   <maintainer email="takumi.odashima@tier4.jp">Takumi Odashima</maintainer>
 
   <license>Apache License 2.0</license>


### PR DESCRIPTION
## Description

Code owner and maintainer housekeeping for the planning, control and simulator launchers, split out of #1962 so that the migration PR carries only the package move.

### What was done

- `.github/CODEOWNERS-manual`: Satoshi Ota and Kyoichi Sugahara are removed from every line they appear on — `config/control`, `config/simulator`, `config/vehicle`, `autoware_planning_config/config`, and the control, planning and simulator component launchers. No other owner changes.
- `tier4_universe_launch/tier4_control_launch/package.xml`: Sugahara removed as maintainer; **Yuki Takagi** and **Maxime Clement** added. The `<author>` field is unchanged.

`.github/CODEOWNERS` is auto-generated and is left for the sync to pick up the new maintainers.

### Why these maintainers

From the commit record of the control launcher and `autoware_universe/control/`:

- Yuki Takagi is the most active author on the control parameter tree over the last two years (control_validator, pid_longitudinal_controller params) and maintains `autoware_pid_longitudinal_controller` and `autoware_control_validator`.
- Maxime Clement maintains `autoware_trajectory_follower_node` and the mpc/pid controllers.

## How was this PR tested?

Metadata only; `pre-commit run` clean.

## Notes for reviewers

#1962 (control launch migration) is rebased on this so its `CODEOWNERS-manual` diff reduces to the path rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
