### PR TITLE
refactor(control): split control.launch.xml into data-flow units with mirrored design modules

### DIFF
--- a/autoware_sample_designs/design/system/AutowareSample.system.yaml
+++ b/autoware_sample_designs/design/system/AutowareSample.system.yaml
@@ -286,8 +286,6 @@ connections:
 remaps:
   - source: localization.publisher.initialpose3d
     topic: /initialpose3d
-  - source: control.publisher.engage
-    topic: /autoware/engage
   - source: control.publisher.is_autonomous_available
     topic: /system/operation_mode/state
   - source: control.publisher.external_emergency

--- a/autoware_sample_designs/design/system/AutowareSample.system.yaml
+++ b/autoware_sample_designs/design/system/AutowareSample.system.yaml
@@ -132,19 +132,17 @@ node_groups:
   - name: control_container
     type: ros2_component_container_mt
     nodes:
-      - /control/shift_decider
-      - /control/vehicle_cmd_gate
-      - /control/operation_mode_transition_manager
-      - /control/trajectory_follower
+      - /control/trajectory_follower/controller_node_exe
+      - /control/command_gate/shift_decider
+      - /control/command_gate/vehicle_cmd_gate
+      - /control/command_gate/autoware_operation_mode_transition_manager
   - name: control_check_container
     type: ros2_component_container_mt
     nodes:
-      - /control/lane_departure_checker
-      - /control/control_validator
-      - /control/autonomous_emergency_braking
-      - /control/collision_detector
-      # - /control/obstacle_collision_checker
-      # - /control/predicted_path_checker
+      - /control/trajectory_follower/lane_departure_checker_node
+      - /control/control_checker/control_validator
+      - /control/control_checker/autonomous_emergency_braking
+      - /control/control_checker/collision_detector
   - name: mission_planner_container
     type: ros2_component_container_mt
     nodes:

--- a/autoware_universe_launch/autoware_control_launch/README.md
+++ b/autoware_universe_launch/autoware_control_launch/README.md
@@ -4,10 +4,17 @@ Shared control launch library. The system component launcher lives in the produc
 
 ```bash
 launch/
-└── control.launch.xml              # control entry: command gate, trajectory follower, control checkers and evaluator
-design/module/                      # Autoware System Designer modules
-├── Control.module.yaml             # control component: same node set as control.launch.xml
-└── TrajectoryFollower.module.yaml  # controller + lane departure checker
+├── control.launch.xml                                    # control entry: preset, parameter paths, containers and the unit includes
+├── trajectory_follower/trajectory_follower.launch.xml    # controller and lane departure checker
+├── command_gate/command_gate.launch.xml                  # vehicle cmd gate (or control command gate), shift decider, operation mode transition manager
+├── external_command/external_command.launch.xml          # external command selector and converter
+└── control_checker/control_checker.launch.xml            # control validator, autonomous emergency braking, collision detector, optional checkers
+design/module/                                            # Autoware System Designer modules, one per launch unit
+├── Control.module.yaml
+├── TrajectoryFollower.module.yaml
+├── CommandGate.module.yaml
+├── ExternalCommand.module.yaml
+└── ControlChecker.module.yaml
 ```
 
 ## Structure
@@ -16,7 +23,13 @@ design/module/                      # Autoware System Designer modules
 
 ## Launch files
 
-- `control.launch.xml` — the entry point. It includes the module preset, resolves every parameter file, and pushes the `control` namespace. It hosts the `control_container` (vehicle cmd gate, operation mode transition manager, trajectory follower, external command selector and converter) and the `control_check_container` with the optional checkers (lane departure checker, control validator, autonomous emergency braking, collision detector, obstacle collision checker, predicted path checker), followed by the control evaluator.
+- `control.launch.xml` — the entry point. It includes the module preset, resolves every parameter file, pushes the `control` namespace and creates the two containers (`control_container` for the command path, `control_check_container` for the composable checkers), then includes one launch file per unit and the control evaluator.
+- `trajectory_follower/trajectory_follower.launch.xml` — the controller (`trajectory_follower_mode`: `trajectory_follower_node`, `smart_mpc_trajectory_follower`, `none`) and the lane departure checker on its predicted trajectory. Boundary topics are `input/*` arguments, so the unit can also drive a standalone follower container.
+- `command_gate/command_gate.launch.xml` — the vehicle cmd gate, or the control command gate with the stop mode operator when `use_control_command_gate` is set, plus the shift decider and the operation mode transition manager. `input/control_cmd` and `output/*_cmd` are its boundary topics.
+- `external_command/external_command.launch.xml` — the external command selector and converter.
+- `control_checker/control_checker.launch.xml` — the control validator, autonomous emergency braking, collision detector, obstacle collision checker and predicted path checker, each behind its `launch_*` flag.
+
+Every unit accepts `target_container`, `use_intra_process` and `ld_preload_value`, so process placement is decided by the caller; parameter files default to the `autoware_control_config` tree and are overridden by the entry point.
 
 ## Config
 

--- a/autoware_universe_launch/autoware_control_launch/design/module/CommandGate.module.yaml
+++ b/autoware_universe_launch/autoware_control_launch/design/module/CommandGate.module.yaml
@@ -1,0 +1,159 @@
+autoware_system_design_format: 0.3.1
+
+# module information
+name: CommandGate.module
+
+instances:
+  - name: shift_decider
+    entity: ShiftDecider.node
+  - name: vehicle_cmd_gate
+    entity: VehicleCmdGate.node
+  - name: autoware_operation_mode_transition_manager
+    entity: OperationModeTransitionManager.node
+  - name: stop_mode_operator
+    entity: StopModeOperator.node
+
+# interfaces
+subscribers:
+  - name: control_cmd
+  - name: trajectory
+  - name: odometry
+  - name: acceleration
+  - name: steering_status
+  - name: gear_status
+  - name: operation_mode_state
+  - name: control_mode_report
+  - name: autoware_state
+  - name: mrm_state
+  - name: route_state
+  - name: planning_turn_indicators_cmd
+  - name: hazard_lights_cmd
+
+  - name: external/control_cmd
+  - name: external/turn_indicators_cmd
+  - name: external/hazard_lights_cmd
+  - name: external/gear_cmd
+  - name: external/heartbeat
+
+  - name: emergency_control_cmd
+  - name: emergency_turn_indicators_cmd
+  - name: emergency_hazard_lights_cmd
+  - name: emergency_gear_cmd
+
+publishers:
+  - name: command/control_cmd
+  - name: command/gear_cmd
+  - name: command/turn_indicators_cmd
+  - name: command/hazard_lights_cmd
+  - name: command/emergency_cmd
+  - name: engage
+  - name: api/engage
+  - name: external_emergency
+  - name: is_autonomous_available
+  - name: gate_mode_cmd
+  - name: current_gate_mode
+
+servers:
+  - name: engage_service
+  - name: external_emergency_service
+
+connections:
+  # ShiftDecider
+  - - subscriber.control_cmd
+    - shift_decider.subscriber.trajectory_follower_control_cmd
+  - - subscriber.gear_status
+    - shift_decider.subscriber.current_gear
+  - - subscriber.autoware_state
+    - shift_decider.subscriber.autoware/state
+
+  # VehicleCmdGate
+  - - subscriber.control_cmd
+    - vehicle_cmd_gate.subscriber.auto_control_cmd
+  - - shift_decider.publisher.gear_cmd
+    - vehicle_cmd_gate.subscriber.auto_gear_cmd
+  - - subscriber.planning_turn_indicators_cmd
+    - vehicle_cmd_gate.subscriber.auto_turn_indicators_cmd
+  - - subscriber.hazard_lights_cmd
+    - vehicle_cmd_gate.subscriber.auto_hazard_lights_cmd
+  - - subscriber.external/control_cmd
+    - vehicle_cmd_gate.subscriber.external_control_cmd
+  - - subscriber.external/turn_indicators_cmd
+    - vehicle_cmd_gate.subscriber.external_turn_indicators_cmd
+  - - subscriber.external/hazard_lights_cmd
+    - vehicle_cmd_gate.subscriber.external_hazard_lights_cmd
+  - - subscriber.external/gear_cmd
+    - vehicle_cmd_gate.subscriber.external_gear_cmd
+  - - subscriber.external/heartbeat
+    - vehicle_cmd_gate.subscriber.external_emergency_stop_heartbeat
+  - - subscriber.steering_status
+    - vehicle_cmd_gate.subscriber.steering
+  - - subscriber.acceleration
+    - vehicle_cmd_gate.subscriber.acceleration
+  - - subscriber.operation_mode_state
+    - vehicle_cmd_gate.subscriber.operation_mode
+  - - subscriber.mrm_state
+    - vehicle_cmd_gate.subscriber.mrm_state
+  - - subscriber.odometry
+    - vehicle_cmd_gate.subscriber.kinematics
+  - - subscriber.emergency_control_cmd
+    - vehicle_cmd_gate.subscriber.emergency_control_cmd
+  - - subscriber.emergency_turn_indicators_cmd
+    - vehicle_cmd_gate.subscriber.emergency_turn_indicators_cmd
+  - - subscriber.emergency_hazard_lights_cmd
+    - vehicle_cmd_gate.subscriber.emergency_hazard_lights_cmd
+  - - subscriber.emergency_gear_cmd
+    - vehicle_cmd_gate.subscriber.emergency_gear_cmd
+  - - autoware_operation_mode_transition_manager.publisher.gate_mode_cmd
+    - vehicle_cmd_gate.subscriber.gate_mode
+  - - autoware_operation_mode_transition_manager.publisher.engage
+    - vehicle_cmd_gate.subscriber.engage
+
+  # OperationModeTransitionManager
+  - - subscriber.trajectory
+    - autoware_operation_mode_transition_manager.subscriber.trajectory
+  - - subscriber.control_cmd
+    - autoware_operation_mode_transition_manager.subscriber.trajectory_follower_control_cmd
+  - - vehicle_cmd_gate.publisher.control_cmd
+    - autoware_operation_mode_transition_manager.subscriber.control_cmd
+  - - vehicle_cmd_gate.publisher.operation_mode
+    - autoware_operation_mode_transition_manager.subscriber.gate_operation_mode
+  - - subscriber.odometry
+    - autoware_operation_mode_transition_manager.subscriber.kinematics
+  - - subscriber.control_mode_report
+    - autoware_operation_mode_transition_manager.subscriber.control_mode_report
+  - - vehicle_cmd_gate.publisher.engage
+    - autoware_operation_mode_transition_manager.subscriber.engage
+
+  # StopModeOperator
+  - - subscriber.route_state
+    - stop_mode_operator.subscriber.route_state
+
+  # API ports
+  - - vehicle_cmd_gate.publisher.engage
+    - publisher.api/engage
+  - - vehicle_cmd_gate.server.engage_service
+    - server.engage_service
+  - - vehicle_cmd_gate.server.external_emergency_service
+    - server.external_emergency_service
+
+  # Publishers
+  - - vehicle_cmd_gate.publisher.control_cmd
+    - publisher.command/control_cmd
+  - - vehicle_cmd_gate.publisher.gear_cmd
+    - publisher.command/gear_cmd
+  - - vehicle_cmd_gate.publisher.turn_indicators_cmd
+    - publisher.command/turn_indicators_cmd
+  - - vehicle_cmd_gate.publisher.hazard_lights_cmd
+    - publisher.command/hazard_lights_cmd
+  - - vehicle_cmd_gate.publisher.emergency_cmd
+    - publisher.command/emergency_cmd
+  - - vehicle_cmd_gate.publisher.gate_mode
+    - publisher.current_gate_mode
+  - - vehicle_cmd_gate.publisher.external_emergency
+    - publisher.external_emergency
+  - - autoware_operation_mode_transition_manager.publisher.engage
+    - publisher.engage
+  - - autoware_operation_mode_transition_manager.publisher.gate_mode_cmd
+    - publisher.gate_mode_cmd
+  - - autoware_operation_mode_transition_manager.publisher.operation_mode
+    - publisher.is_autonomous_available

--- a/autoware_universe_launch/autoware_control_launch/design/module/CommandGate.module.yaml
+++ b/autoware_universe_launch/autoware_control_launch/design/module/CommandGate.module.yaml
@@ -20,6 +20,7 @@ subscribers:
   - name: odometry
   - name: acceleration
   - name: steering_status
+  - name: velocity_status
   - name: gear_status
   - name: operation_mode_state
   - name: control_mode_report
@@ -64,6 +65,7 @@ servers:
 
 clients:
   - name: select_external_command
+  - name: control_mode_request
 
 connections:
   # ShiftDecider
@@ -134,9 +136,16 @@ connections:
   - - client.select_external_command
     - autoware_operation_mode_transition_manager.client.select_external_command
 
+  - - autoware_operation_mode_transition_manager.client.control_mode_request
+    - client.control_mode_request
+
   # StopModeOperator
   - - subscriber.route_state
     - stop_mode_operator.subscriber.route_state
+  - - subscriber.steering_status
+    - stop_mode_operator.subscriber.steering
+  - - subscriber.velocity_status
+    - stop_mode_operator.subscriber.velocity
 
   # API ports
   - - vehicle_cmd_gate.publisher.engage

--- a/autoware_universe_launch/autoware_control_launch/design/module/CommandGate.module.yaml
+++ b/autoware_universe_launch/autoware_control_launch/design/module/CommandGate.module.yaml
@@ -48,11 +48,9 @@ publishers:
   - name: command/turn_indicators_cmd
   - name: command/hazard_lights_cmd
   - name: command/emergency_cmd
-  - name: engage
   - name: api/engage
   - name: external_emergency
   - name: is_autonomous_available
-  - name: gate_mode_cmd
   - name: current_gate_mode
   - name: is_paused
   - name: is_start_requested
@@ -113,10 +111,6 @@ connections:
     - vehicle_cmd_gate.subscriber.emergency_hazard_lights_cmd
   - - subscriber.emergency_gear_cmd
     - vehicle_cmd_gate.subscriber.emergency_gear_cmd
-  - - autoware_operation_mode_transition_manager.publisher.gate_mode_cmd
-    - vehicle_cmd_gate.subscriber.gate_mode
-  - - autoware_operation_mode_transition_manager.publisher.engage
-    - vehicle_cmd_gate.subscriber.engage
 
   # OperationModeTransitionManager
   - - subscriber.trajectory
@@ -177,9 +171,5 @@ connections:
     - publisher.current_gate_mode
   - - vehicle_cmd_gate.publisher.external_emergency
     - publisher.external_emergency
-  - - autoware_operation_mode_transition_manager.publisher.engage
-    - publisher.engage
-  - - autoware_operation_mode_transition_manager.publisher.gate_mode_cmd
-    - publisher.gate_mode_cmd
   - - autoware_operation_mode_transition_manager.publisher.operation_mode
     - publisher.is_autonomous_available

--- a/autoware_universe_launch/autoware_control_launch/design/module/CommandGate.module.yaml
+++ b/autoware_universe_launch/autoware_control_launch/design/module/CommandGate.module.yaml
@@ -40,6 +40,8 @@ subscribers:
   - name: emergency_hazard_lights_cmd
   - name: emergency_gear_cmd
 
+  - name: current_selector_mode
+
 publishers:
   - name: command/control_cmd
   - name: command/gear_cmd
@@ -52,10 +54,18 @@ publishers:
   - name: is_autonomous_available
   - name: gate_mode_cmd
   - name: current_gate_mode
+  - name: is_paused
+  - name: is_start_requested
+  - name: is_stopped
 
 servers:
   - name: engage_service
   - name: external_emergency_service
+  - name: set_pause
+  - name: set_stop
+
+clients:
+  - name: select_external_command
 
 connections:
   # ShiftDecider
@@ -123,6 +133,12 @@ connections:
     - autoware_operation_mode_transition_manager.subscriber.control_mode_report
   - - vehicle_cmd_gate.publisher.engage
     - autoware_operation_mode_transition_manager.subscriber.engage
+  - - vehicle_cmd_gate.publisher.gate_mode
+    - autoware_operation_mode_transition_manager.subscriber.current_gate_mode
+  - - subscriber.current_selector_mode
+    - autoware_operation_mode_transition_manager.subscriber.current_selector_mode
+  - - client.select_external_command
+    - autoware_operation_mode_transition_manager.client.select_external_command
 
   # StopModeOperator
   - - subscriber.route_state
@@ -135,6 +151,16 @@ connections:
     - server.engage_service
   - - vehicle_cmd_gate.server.external_emergency_service
     - server.external_emergency_service
+  - - vehicle_cmd_gate.server.set_pause
+    - server.set_pause
+  - - vehicle_cmd_gate.server.set_stop
+    - server.set_stop
+  - - vehicle_cmd_gate.publisher.is_paused
+    - publisher.is_paused
+  - - vehicle_cmd_gate.publisher.is_start_requested
+    - publisher.is_start_requested
+  - - vehicle_cmd_gate.publisher.is_stopped
+    - publisher.is_stopped
 
   # Publishers
   - - vehicle_cmd_gate.publisher.control_cmd

--- a/autoware_universe_launch/autoware_control_launch/design/module/Control.module.yaml
+++ b/autoware_universe_launch/autoware_control_launch/design/module/Control.module.yaml
@@ -80,10 +80,18 @@ publishers:
   - name: control_evaluation
   - name: gate_mode_cmd
   - name: current_gate_mode
+  # official interfaces published under fixed node paths
+  - name: external_cmd_selector/current_selector_mode
+  - name: vehicle_cmd_gate/is_paused
+  - name: vehicle_cmd_gate/is_start_requested
+  - name: vehicle_cmd_gate/is_stopped
 
 servers:
   - name: engage_service
   - name: external_emergency_service
+  - name: external_cmd_selector/select_external_command
+  - name: vehicle_cmd_gate/set_pause
+  - name: vehicle_cmd_gate/set_stop
 
 connections:
   # TrajectoryFollower module
@@ -151,6 +159,10 @@ connections:
     - command_gate.subscriber.emergency_hazard_lights_cmd
   - - subscriber.emergency_gear_cmd
     - command_gate.subscriber.emergency_gear_cmd
+  - - external_command.publisher.current_selector_mode
+    - command_gate.subscriber.current_selector_mode
+  - - external_command.server.select_external_command
+    - command_gate.client.select_external_command
 
   # ExternalCommand module
   - - subscriber.external/local/pedals_cmd
@@ -249,6 +261,20 @@ connections:
     - server.engage_service
   - - command_gate.server.external_emergency_service
     - server.external_emergency_service
+  - - external_command.server.select_external_command
+    - server.external_cmd_selector/select_external_command
+  - - external_command.publisher.current_selector_mode
+    - publisher.external_cmd_selector/current_selector_mode
+  - - command_gate.server.set_pause
+    - server.vehicle_cmd_gate/set_pause
+  - - command_gate.server.set_stop
+    - server.vehicle_cmd_gate/set_stop
+  - - command_gate.publisher.is_paused
+    - publisher.vehicle_cmd_gate/is_paused
+  - - command_gate.publisher.is_start_requested
+    - publisher.vehicle_cmd_gate/is_start_requested
+  - - command_gate.publisher.is_stopped
+    - publisher.vehicle_cmd_gate/is_stopped
 
   # Publishers
   - - command_gate.publisher.command/control_cmd

--- a/autoware_universe_launch/autoware_control_launch/design/module/Control.module.yaml
+++ b/autoware_universe_launch/autoware_control_launch/design/module/Control.module.yaml
@@ -84,6 +84,9 @@ publishers:
   - name: vehicle_cmd_gate/is_start_requested
   - name: vehicle_cmd_gate/is_stopped
 
+clients:
+  - name: control_mode_request
+
 servers:
   - name: engage_service
   - name: external_emergency_service
@@ -109,6 +112,8 @@ connections:
     - trajectory_follower.subscriber.route
   - - subscriber.api_operation_mode_state
     - trajectory_follower.subscriber.api_operation_mode_state
+  - - subscriber.api_operation_mode_state
+    - control_checker.subscriber.api_operation_mode_state
   - - subscriber.steering_offset_update
     - trajectory_follower.subscriber.steering_offset_update
 
@@ -123,6 +128,8 @@ connections:
     - command_gate.subscriber.acceleration
   - - subscriber.steering_status
     - command_gate.subscriber.steering_status
+  - - subscriber.velocity_status
+    - command_gate.subscriber.velocity_status
   - - subscriber.gear_status
     - command_gate.subscriber.gear_status
   - - subscriber.operation_mode_state
@@ -295,3 +302,5 @@ connections:
     - publisher.predicted_trajectory
   - - control_evaluator.publisher.metrics
     - publisher.control_evaluation
+  - - command_gate.client.control_mode_request
+    - client.control_mode_request

--- a/autoware_universe_launch/autoware_control_launch/design/module/Control.module.yaml
+++ b/autoware_universe_launch/autoware_control_launch/design/module/Control.module.yaml
@@ -6,26 +6,14 @@ name: Control.module
 instances:
   - name: trajectory_follower
     entity: TrajectoryFollower.module
-  - name: shift_decider
-    entity: ShiftDecider.node
-  - name: vehicle_cmd_gate
-    entity: VehicleCmdGate.node
-  - name: autoware_operation_mode_transition_manager
-    entity: OperationModeTransitionManager.node
-  - name: external_cmd_selector
-    entity: ExternalCmdSelector.node
-  - name: external_cmd_converter
-    entity: ExternalCmdConverter.node
-  - name: control_validator
-    entity: ControlValidator.node
-  - name: autonomous_emergency_braking
-    entity: AutonomousEmergencyBraking.node
-  - name: collision_detector
-    entity: CollisionDetector.node
+  - name: command_gate
+    entity: CommandGate.module
+  - name: external_command
+    entity: ExternalCommand.module
+  - name: control_checker
+    entity: ControlChecker.module
   - name: control_evaluator
     entity: ControlEvaluator.node
-  - name: stop_mode_operator
-    entity: StopModeOperator.node
 
 # interfaces
 subscribers:
@@ -118,144 +106,105 @@ connections:
   - - subscriber.steering_offset_update
     - trajectory_follower.subscriber.steering_offset_update
 
-  # ShiftDecider
+  # CommandGate module
   - - trajectory_follower.publisher.control_cmd
-    - shift_decider.subscriber.trajectory_follower_control_cmd
-  - - subscriber.gear_status
-    - shift_decider.subscriber.current_gear
-  - - subscriber.autoware_state
-    - shift_decider.subscriber.autoware/state
-
-  # ExternalCmdSelector
-  - - subscriber.external/local/pedals_cmd
-    - external_cmd_selector.subscriber.local/pedals_cmd
-  - - subscriber.external/local/steering_cmd
-    - external_cmd_selector.subscriber.local/steering_cmd
-  - - subscriber.external/local/turn_indicators_cmd
-    - external_cmd_selector.subscriber.local/turn_indicators_cmd
-  - - subscriber.external/local/hazard_lights_cmd
-    - external_cmd_selector.subscriber.local/hazard_lights_cmd
-  - - subscriber.external/local/gear_cmd
-    - external_cmd_selector.subscriber.local/gear_cmd
-  - - subscriber.external/local/heartbeat
-    - external_cmd_selector.subscriber.local/heartbeat
-  - - subscriber.external/remote/pedals_cmd
-    - external_cmd_selector.subscriber.remote/pedals_cmd
-  - - subscriber.external/remote/steering_cmd
-    - external_cmd_selector.subscriber.remote/steering_cmd
-  - - subscriber.external/remote/turn_indicators_cmd
-    - external_cmd_selector.subscriber.remote/turn_indicators_cmd
-  - - subscriber.external/remote/hazard_lights_cmd
-    - external_cmd_selector.subscriber.remote/hazard_lights_cmd
-  - - subscriber.external/remote/gear_cmd
-    - external_cmd_selector.subscriber.remote/gear_cmd
-  - - subscriber.external/remote/heartbeat
-    - external_cmd_selector.subscriber.remote/heartbeat
-
-  # external_cmd_converter
-  - - external_cmd_selector.publisher.*
-    - external_cmd_converter.subscriber.*
-  - - vehicle_cmd_gate.publisher.gate_mode
-    - external_cmd_converter.subscriber.current_gate_mode
+    - command_gate.subscriber.control_cmd
+  - - subscriber.trajectory
+    - command_gate.subscriber.trajectory
   - - subscriber.odometry
-    - external_cmd_converter.subscriber.odometry
-
-  # VehicleCmdGate
-  - - trajectory_follower.publisher.control_cmd
-    - vehicle_cmd_gate.subscriber.auto_control_cmd
-  - - shift_decider.publisher.gear_cmd
-    - vehicle_cmd_gate.subscriber.auto_gear_cmd
-  - - subscriber.planning_turn_indicators_cmd
-    - vehicle_cmd_gate.subscriber.auto_turn_indicators_cmd
-  - - subscriber.hazard_lights_cmd
-    - vehicle_cmd_gate.subscriber.auto_hazard_lights_cmd
-  - - external_cmd_converter.publisher.control_cmd
-    - vehicle_cmd_gate.subscriber.external_control_cmd
-  - - external_cmd_selector.publisher.turn_indicators_cmd
-    - vehicle_cmd_gate.subscriber.external_turn_indicators_cmd
-  - - external_cmd_selector.publisher.hazard_lights_cmd
-    - vehicle_cmd_gate.subscriber.external_hazard_lights_cmd
-  - - external_cmd_selector.publisher.gear_cmd
-    - vehicle_cmd_gate.subscriber.external_gear_cmd
-  - - external_cmd_selector.publisher.heartbeat
-    - vehicle_cmd_gate.subscriber.external_emergency_stop_heartbeat
+    - command_gate.subscriber.odometry
+  - - subscriber.acceleration
+    - command_gate.subscriber.acceleration
   - - subscriber.steering_status
-    - vehicle_cmd_gate.subscriber.steering
-  - - subscriber.acceleration
-    - vehicle_cmd_gate.subscriber.acceleration
+    - command_gate.subscriber.steering_status
+  - - subscriber.gear_status
+    - command_gate.subscriber.gear_status
   - - subscriber.operation_mode_state
-    - vehicle_cmd_gate.subscriber.operation_mode
-  - - subscriber.mrm_state
-    - vehicle_cmd_gate.subscriber.mrm_state
-  - - subscriber.odometry
-    - vehicle_cmd_gate.subscriber.kinematics
-  - - subscriber.emergency_control_cmd
-    - vehicle_cmd_gate.subscriber.emergency_control_cmd
-  - - subscriber.emergency_turn_indicators_cmd
-    - vehicle_cmd_gate.subscriber.emergency_turn_indicators_cmd
-  - - subscriber.emergency_hazard_lights_cmd
-    - vehicle_cmd_gate.subscriber.emergency_hazard_lights_cmd
-  - - subscriber.emergency_gear_cmd
-    - vehicle_cmd_gate.subscriber.emergency_gear_cmd
-  - - autoware_operation_mode_transition_manager.publisher.gate_mode_cmd
-    - vehicle_cmd_gate.subscriber.gate_mode
-  - - autoware_operation_mode_transition_manager.publisher.engage
-    - vehicle_cmd_gate.subscriber.engage
-
-  # OperationModeTransitionManager
-  - - subscriber.trajectory
-    - autoware_operation_mode_transition_manager.subscriber.trajectory
-  - - trajectory_follower.publisher.control_cmd
-    - autoware_operation_mode_transition_manager.subscriber.trajectory_follower_control_cmd
-  - - vehicle_cmd_gate.publisher.control_cmd
-    - autoware_operation_mode_transition_manager.subscriber.control_cmd
-  - - vehicle_cmd_gate.publisher.operation_mode
-    - autoware_operation_mode_transition_manager.subscriber.gate_operation_mode
-  - - subscriber.odometry
-    - autoware_operation_mode_transition_manager.subscriber.kinematics
+    - command_gate.subscriber.operation_mode_state
   - - subscriber.control_mode_report
-    - autoware_operation_mode_transition_manager.subscriber.control_mode_report
-  - - vehicle_cmd_gate.publisher.engage
-    - autoware_operation_mode_transition_manager.subscriber.engage
-
-  - - subscriber.route_state
-    - stop_mode_operator.subscriber.route_state
-
-  # ControlValidator
-  - - vehicle_cmd_gate.publisher.control_cmd
-    - control_validator.subscriber.control_cmd
-  - - subscriber.operation_mode_state
-    - control_validator.subscriber.operation_mode_state
-  - - subscriber.trajectory
-    - control_validator.subscriber.trajectory
-  - - trajectory_follower.publisher.predicted_trajectory
-    - control_validator.subscriber.predicted_trajectory
-  - - subscriber.odometry
-    - control_validator.subscriber.kinematics
-  - - subscriber.acceleration
-    - control_validator.subscriber.measured_acceleration
-
-  # AutonomousEmergencyBraking
-  - - subscriber.pointcloud
-    - autonomous_emergency_braking.subscriber.pointcloud
-  - - subscriber.objects
-    - autonomous_emergency_braking.subscriber.objects
-  - - subscriber.velocity_status
-    - autonomous_emergency_braking.subscriber.velocity
-  - - subscriber.imu
-    - autonomous_emergency_braking.subscriber.imu
+    - command_gate.subscriber.control_mode_report
   - - subscriber.autoware_state
-    - autonomous_emergency_braking.subscriber.autoware/state
-  - - trajectory_follower.publisher.predicted_trajectory
-    - autonomous_emergency_braking.subscriber.predicted_trajectory
+    - command_gate.subscriber.autoware_state
+  - - subscriber.mrm_state
+    - command_gate.subscriber.mrm_state
+  - - subscriber.route_state
+    - command_gate.subscriber.route_state
+  - - subscriber.planning_turn_indicators_cmd
+    - command_gate.subscriber.planning_turn_indicators_cmd
+  - - subscriber.hazard_lights_cmd
+    - command_gate.subscriber.hazard_lights_cmd
+  - - external_command.publisher.control_cmd
+    - command_gate.subscriber.external/control_cmd
+  - - external_command.publisher.turn_indicators_cmd
+    - command_gate.subscriber.external/turn_indicators_cmd
+  - - external_command.publisher.hazard_lights_cmd
+    - command_gate.subscriber.external/hazard_lights_cmd
+  - - external_command.publisher.gear_cmd
+    - command_gate.subscriber.external/gear_cmd
+  - - external_command.publisher.heartbeat
+    - command_gate.subscriber.external/heartbeat
+  - - subscriber.emergency_control_cmd
+    - command_gate.subscriber.emergency_control_cmd
+  - - subscriber.emergency_turn_indicators_cmd
+    - command_gate.subscriber.emergency_turn_indicators_cmd
+  - - subscriber.emergency_hazard_lights_cmd
+    - command_gate.subscriber.emergency_hazard_lights_cmd
+  - - subscriber.emergency_gear_cmd
+    - command_gate.subscriber.emergency_gear_cmd
 
-  # CollisionDetector
+  # ExternalCommand module
+  - - subscriber.external/local/pedals_cmd
+    - external_command.subscriber.local/pedals_cmd
+  - - subscriber.external/local/steering_cmd
+    - external_command.subscriber.local/steering_cmd
+  - - subscriber.external/local/turn_indicators_cmd
+    - external_command.subscriber.local/turn_indicators_cmd
+  - - subscriber.external/local/hazard_lights_cmd
+    - external_command.subscriber.local/hazard_lights_cmd
+  - - subscriber.external/local/gear_cmd
+    - external_command.subscriber.local/gear_cmd
+  - - subscriber.external/local/heartbeat
+    - external_command.subscriber.local/heartbeat
+  - - subscriber.external/remote/pedals_cmd
+    - external_command.subscriber.remote/pedals_cmd
+  - - subscriber.external/remote/steering_cmd
+    - external_command.subscriber.remote/steering_cmd
+  - - subscriber.external/remote/turn_indicators_cmd
+    - external_command.subscriber.remote/turn_indicators_cmd
+  - - subscriber.external/remote/hazard_lights_cmd
+    - external_command.subscriber.remote/hazard_lights_cmd
+  - - subscriber.external/remote/gear_cmd
+    - external_command.subscriber.remote/gear_cmd
+  - - subscriber.external/remote/heartbeat
+    - external_command.subscriber.remote/heartbeat
+  - - command_gate.publisher.current_gate_mode
+    - external_command.subscriber.current_gate_mode
   - - subscriber.odometry
-    - collision_detector.subscriber.odometry
-  - - subscriber.pointcloud
-    - collision_detector.subscriber.pointcloud
+    - external_command.subscriber.odometry
+
+  # ControlChecker module
+  - - command_gate.publisher.command/control_cmd
+    - control_checker.subscriber.control_cmd
+  - - trajectory_follower.publisher.predicted_trajectory
+    - control_checker.subscriber.predicted_trajectory
+  - - subscriber.trajectory
+    - control_checker.subscriber.trajectory
+  - - subscriber.odometry
+    - control_checker.subscriber.odometry
+  - - subscriber.acceleration
+    - control_checker.subscriber.acceleration
+  - - subscriber.velocity_status
+    - control_checker.subscriber.velocity_status
+  - - subscriber.imu
+    - control_checker.subscriber.imu
+  - - subscriber.operation_mode_state
+    - control_checker.subscriber.operation_mode_state
+  - - subscriber.autoware_state
+    - control_checker.subscriber.autoware_state
   - - subscriber.objects
-    - collision_detector.subscriber.objects
+    - control_checker.subscriber.objects
+  - - subscriber.pointcloud
+    - control_checker.subscriber.pointcloud
 
   # ControlEvaluator
   - - subscriber.trajectory
@@ -293,34 +242,36 @@ connections:
   - - subscriber.walkway
     - control_evaluator.subscriber.walkway
 
-  # VehicleCmdGate API ports
-  - - vehicle_cmd_gate.publisher.engage
+  # API ports
+  - - command_gate.publisher.api/engage
     - publisher.api/engage
-  - - vehicle_cmd_gate.server.engage_service
+  - - command_gate.server.engage_service
     - server.engage_service
-  - - vehicle_cmd_gate.server.external_emergency_service
+  - - command_gate.server.external_emergency_service
     - server.external_emergency_service
 
   # Publishers
-  - - vehicle_cmd_gate.publisher.control_cmd
+  - - command_gate.publisher.command/control_cmd
     - publisher.command/control_cmd
-  - - vehicle_cmd_gate.publisher.gear_cmd
+  - - command_gate.publisher.command/gear_cmd
     - publisher.command/gear_cmd
-  - - vehicle_cmd_gate.publisher.turn_indicators_cmd
+  - - command_gate.publisher.command/turn_indicators_cmd
     - publisher.command/turn_indicators_cmd
-  - - vehicle_cmd_gate.publisher.hazard_lights_cmd
+  - - command_gate.publisher.command/hazard_lights_cmd
     - publisher.command/hazard_lights_cmd
-  - - vehicle_cmd_gate.publisher.emergency_cmd
+  - - command_gate.publisher.command/emergency_cmd
     - publisher.command/emergency_cmd
-  - - vehicle_cmd_gate.publisher.gate_mode
+  - - command_gate.publisher.current_gate_mode
     - publisher.current_gate_mode
-  - - vehicle_cmd_gate.publisher.external_emergency
+  - - command_gate.publisher.gate_mode_cmd
+    - publisher.gate_mode_cmd
+  - - command_gate.publisher.external_emergency
     - publisher.external_emergency
-  - - autoware_operation_mode_transition_manager.publisher.engage
+  - - command_gate.publisher.engage
     - publisher.engage
+  - - command_gate.publisher.is_autonomous_available
+    - publisher.is_autonomous_available
   - - trajectory_follower.publisher.predicted_trajectory
     - publisher.predicted_trajectory
-  - - autoware_operation_mode_transition_manager.publisher.operation_mode
-    - publisher.is_autonomous_available
   - - control_evaluator.publisher.metrics
     - publisher.control_evaluation

--- a/autoware_universe_launch/autoware_control_launch/design/module/Control.module.yaml
+++ b/autoware_universe_launch/autoware_control_launch/design/module/Control.module.yaml
@@ -73,12 +73,10 @@ publishers:
   - name: command/hazard_lights_cmd
   - name: command/emergency_cmd
   - name: predicted_trajectory
-  - name: engage
   - name: api/engage
   - name: external_emergency
   - name: is_autonomous_available
   - name: control_evaluation
-  - name: gate_mode_cmd
   - name: current_gate_mode
   # official interfaces published under fixed node paths
   - name: external_cmd_selector/current_selector_mode
@@ -289,12 +287,8 @@ connections:
     - publisher.command/emergency_cmd
   - - command_gate.publisher.current_gate_mode
     - publisher.current_gate_mode
-  - - command_gate.publisher.gate_mode_cmd
-    - publisher.gate_mode_cmd
   - - command_gate.publisher.external_emergency
     - publisher.external_emergency
-  - - command_gate.publisher.engage
-    - publisher.engage
   - - command_gate.publisher.is_autonomous_available
     - publisher.is_autonomous_available
   - - trajectory_follower.publisher.predicted_trajectory

--- a/autoware_universe_launch/autoware_control_launch/design/module/ControlChecker.module.yaml
+++ b/autoware_universe_launch/autoware_control_launch/design/module/ControlChecker.module.yaml
@@ -21,6 +21,7 @@ subscribers:
   - name: velocity_status
   - name: imu
   - name: operation_mode_state
+  - name: api_operation_mode_state
   - name: autoware_state
   - name: objects
   - name: pointcloud
@@ -63,3 +64,5 @@ connections:
     - collision_detector.subscriber.pointcloud
   - - subscriber.objects
     - collision_detector.subscriber.objects
+  - - subscriber.api_operation_mode_state
+    - collision_detector.subscriber.operation_mode_state

--- a/autoware_universe_launch/autoware_control_launch/design/module/ControlChecker.module.yaml
+++ b/autoware_universe_launch/autoware_control_launch/design/module/ControlChecker.module.yaml
@@ -1,0 +1,65 @@
+autoware_system_design_format: 0.3.1
+
+# module information
+name: ControlChecker.module
+
+instances:
+  - name: control_validator
+    entity: ControlValidator.node
+  - name: autonomous_emergency_braking
+    entity: AutonomousEmergencyBraking.node
+  - name: collision_detector
+    entity: CollisionDetector.node
+
+# interfaces
+subscribers:
+  - name: control_cmd
+  - name: predicted_trajectory
+  - name: trajectory
+  - name: odometry
+  - name: acceleration
+  - name: velocity_status
+  - name: imu
+  - name: operation_mode_state
+  - name: autoware_state
+  - name: objects
+  - name: pointcloud
+
+publishers: []
+
+connections:
+  # ControlValidator
+  - - subscriber.control_cmd
+    - control_validator.subscriber.control_cmd
+  - - subscriber.operation_mode_state
+    - control_validator.subscriber.operation_mode_state
+  - - subscriber.trajectory
+    - control_validator.subscriber.trajectory
+  - - subscriber.predicted_trajectory
+    - control_validator.subscriber.predicted_trajectory
+  - - subscriber.odometry
+    - control_validator.subscriber.kinematics
+  - - subscriber.acceleration
+    - control_validator.subscriber.measured_acceleration
+
+  # AutonomousEmergencyBraking
+  - - subscriber.pointcloud
+    - autonomous_emergency_braking.subscriber.pointcloud
+  - - subscriber.objects
+    - autonomous_emergency_braking.subscriber.objects
+  - - subscriber.velocity_status
+    - autonomous_emergency_braking.subscriber.velocity
+  - - subscriber.imu
+    - autonomous_emergency_braking.subscriber.imu
+  - - subscriber.autoware_state
+    - autonomous_emergency_braking.subscriber.autoware/state
+  - - subscriber.predicted_trajectory
+    - autonomous_emergency_braking.subscriber.predicted_trajectory
+
+  # CollisionDetector
+  - - subscriber.odometry
+    - collision_detector.subscriber.odometry
+  - - subscriber.pointcloud
+    - collision_detector.subscriber.pointcloud
+  - - subscriber.objects
+    - collision_detector.subscriber.objects

--- a/autoware_universe_launch/autoware_control_launch/design/module/ExternalCommand.module.yaml
+++ b/autoware_universe_launch/autoware_control_launch/design/module/ExternalCommand.module.yaml
@@ -32,6 +32,10 @@ publishers:
   - name: hazard_lights_cmd
   - name: gear_cmd
   - name: heartbeat
+  - name: current_selector_mode
+
+servers:
+  - name: select_external_command
 
 connections:
   # ExternalCmdSelector
@@ -79,3 +83,7 @@ connections:
     - publisher.gear_cmd
   - - external_cmd_selector.publisher.heartbeat
     - publisher.heartbeat
+  - - external_cmd_selector.publisher.current_selector_mode
+    - publisher.current_selector_mode
+  - - external_cmd_selector.server.select_external_command
+    - server.select_external_command

--- a/autoware_universe_launch/autoware_control_launch/design/module/ExternalCommand.module.yaml
+++ b/autoware_universe_launch/autoware_control_launch/design/module/ExternalCommand.module.yaml
@@ -1,0 +1,81 @@
+autoware_system_design_format: 0.3.1
+
+# module information
+name: ExternalCommand.module
+
+instances:
+  - name: external_cmd_selector
+    entity: ExternalCmdSelector.node
+  - name: external_cmd_converter
+    entity: ExternalCmdConverter.node
+
+# interfaces
+subscribers:
+  - name: local/gear_cmd
+  - name: local/hazard_lights_cmd
+  - name: local/heartbeat
+  - name: local/pedals_cmd
+  - name: local/steering_cmd
+  - name: local/turn_indicators_cmd
+  - name: remote/gear_cmd
+  - name: remote/hazard_lights_cmd
+  - name: remote/heartbeat
+  - name: remote/pedals_cmd
+  - name: remote/steering_cmd
+  - name: remote/turn_indicators_cmd
+  - name: current_gate_mode
+  - name: odometry
+
+publishers:
+  - name: control_cmd
+  - name: turn_indicators_cmd
+  - name: hazard_lights_cmd
+  - name: gear_cmd
+  - name: heartbeat
+
+connections:
+  # ExternalCmdSelector
+  - - subscriber.local/pedals_cmd
+    - external_cmd_selector.subscriber.local/pedals_cmd
+  - - subscriber.local/steering_cmd
+    - external_cmd_selector.subscriber.local/steering_cmd
+  - - subscriber.local/turn_indicators_cmd
+    - external_cmd_selector.subscriber.local/turn_indicators_cmd
+  - - subscriber.local/hazard_lights_cmd
+    - external_cmd_selector.subscriber.local/hazard_lights_cmd
+  - - subscriber.local/gear_cmd
+    - external_cmd_selector.subscriber.local/gear_cmd
+  - - subscriber.local/heartbeat
+    - external_cmd_selector.subscriber.local/heartbeat
+  - - subscriber.remote/pedals_cmd
+    - external_cmd_selector.subscriber.remote/pedals_cmd
+  - - subscriber.remote/steering_cmd
+    - external_cmd_selector.subscriber.remote/steering_cmd
+  - - subscriber.remote/turn_indicators_cmd
+    - external_cmd_selector.subscriber.remote/turn_indicators_cmd
+  - - subscriber.remote/hazard_lights_cmd
+    - external_cmd_selector.subscriber.remote/hazard_lights_cmd
+  - - subscriber.remote/gear_cmd
+    - external_cmd_selector.subscriber.remote/gear_cmd
+  - - subscriber.remote/heartbeat
+    - external_cmd_selector.subscriber.remote/heartbeat
+
+  # ExternalCmdConverter
+  - - external_cmd_selector.publisher.*
+    - external_cmd_converter.subscriber.*
+  - - subscriber.current_gate_mode
+    - external_cmd_converter.subscriber.current_gate_mode
+  - - subscriber.odometry
+    - external_cmd_converter.subscriber.odometry
+
+  # Publishers
+  - - external_cmd_converter.publisher.control_cmd
+    - publisher.control_cmd
+  - - external_cmd_selector.publisher.turn_indicators_cmd
+    - publisher.turn_indicators_cmd
+  - - external_cmd_selector.publisher.hazard_lights_cmd
+    - publisher.hazard_lights_cmd
+  - - external_cmd_selector.publisher.gear_cmd
+    - publisher.gear_cmd
+  - - external_cmd_selector.publisher.heartbeat
+    - publisher.heartbeat

--- a/autoware_universe_launch/autoware_control_launch/launch/command_gate/command_gate.launch.xml
+++ b/autoware_universe_launch/autoware_control_launch/launch/command_gate/command_gate.launch.xml
@@ -1,0 +1,126 @@
+<launch>
+  <!-- Command gate unit: arbitrates the controller, external and emergency commands into the vehicle command, with gear decision and operation mode transition -->
+  <!-- temporary: control_command_gate migration -->
+  <arg name="use_control_command_gate" default="false" description="control_command_gate + stop_mode_operator in place of vehicle_cmd_gate"/>
+  <arg name="check_external_emergency_heartbeat" default="false"/>
+
+  <!-- External interfaces -->
+  <arg name="input/control_cmd" default="/control/trajectory_follower/control_cmd"/>
+  <arg name="output/control_cmd" default="/control/command/control_cmd"/>
+  <arg name="output/gear_cmd" default="/control/command/gear_cmd"/>
+  <arg name="output/turn_indicators_cmd" default="/control/command/turn_indicators_cmd"/>
+  <arg name="output/hazard_lights_cmd" default="/control/command/hazard_lights_cmd"/>
+
+  <!-- Parameter paths -->
+  <let name="config_dir" value="$(find-pkg-share autoware_control_config)/config"/>
+  <arg name="nearest_search_param_path" default="$(var config_dir)/common/nearest_search.param.yaml"/>
+  <arg name="vehicle_cmd_gate_param_path" default="$(var config_dir)/vehicle_cmd_gate/vehicle_cmd_gate.param.yaml"/>
+  <arg name="control_command_gate_param_path" default="$(var config_dir)/control_command_gate/control_command_gate.param.yaml"/>
+  <arg name="operation_mode_transition_manager_param_path" default="$(var config_dir)/operation_mode_transition_manager/operation_mode_transition_manager.param.yaml"/>
+  <arg name="shift_decider_param_path" default="$(var config_dir)/shift_decider/shift_decider.param.yaml"/>
+  <arg name="vehicle_param_file" default="$(find-pkg-share sample_vehicle_description)/config/vehicle_info.param.yaml"/>
+
+  <!-- Process placement -->
+  <arg name="target_container" default="/control/control_container" description="container that hosts the gate and the transition manager"/>
+  <arg name="use_intra_process" default="false"/>
+  <arg name="ld_preload_value" default=""/>
+
+  <let name="operation_mode_transition_manager_plugin" value="AutonomousModeTransitionFlagNode" if="$(var use_control_command_gate)"/>
+  <let name="operation_mode_transition_manager_plugin" value="OperationModeTransitionManager" unless="$(var use_control_command_gate)"/>
+
+  <!-- control command gate -->
+  <group if="$(var use_control_command_gate)">
+    <include file="$(find-pkg-share autoware_control_command_gate)/launch/control_command_gate.launch.xml">
+      <arg name="config" value="$(var control_command_gate_param_path)"/>
+      <arg name="inputs/main/control" value="$(var input/control_cmd)"/>
+      <arg name="output/control" value="$(var output/control_cmd)"/>
+      <arg name="output/gear" value="$(var output/gear_cmd)"/>
+      <arg name="output/turn_indicators" value="$(var output/turn_indicators_cmd)"/>
+      <arg name="output/hazard_lights" value="$(var output/hazard_lights_cmd)"/>
+    </include>
+  </group>
+  <group if="$(var use_control_command_gate)">
+    <include file="$(find-pkg-share autoware_stop_mode_operator)/launch/stop_mode_operator.launch.xml"/>
+  </group>
+
+  <!-- shift decider -->
+  <node pkg="autoware_shift_decider" exec="autoware_shift_decider" name="autoware_shift_decider" output="screen">
+    <remap from="input/control_cmd" to="$(var input/control_cmd)"/>
+    <remap from="input/state" to="/autoware/state"/>
+    <remap from="input/current_gear" to="/vehicle/status/gear_status"/>
+    <remap from="output/gear_cmd" to="/control/shift_decider/gear_cmd"/>
+    <param from="$(var shift_decider_param_path)"/>
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+  </node>
+
+  <!-- vehicle cmd gate -->
+  <group unless="$(var use_control_command_gate)">
+    <load_composable_node target="$(var target_container)">
+      <composable_node pkg="autoware_vehicle_cmd_gate" plugin="autoware::vehicle_cmd_gate::VehicleCmdGate" name="vehicle_cmd_gate">
+        <remap from="input/steering" to="/vehicle/status/steering_status"/>
+        <remap from="input/operation_mode" to="/system/operation_mode/state"/>
+        <remap from="input/auto/control_cmd" to="$(var input/control_cmd)"/>
+        <remap from="input/auto/turn_indicators_cmd" to="/planning/turn_indicators_cmd"/>
+        <remap from="input/auto/hazard_lights_cmd" to="/planning/hazard_lights_cmd"/>
+        <remap from="input/auto/gear_cmd" to="/control/shift_decider/gear_cmd"/>
+        <remap from="input/external/control_cmd" to="/external/selected/control_cmd"/>
+        <remap from="input/external/turn_indicators_cmd" to="/external/selected/turn_indicators_cmd"/>
+        <remap from="input/external/hazard_lights_cmd" to="/external/selected/hazard_lights_cmd"/>
+        <remap from="input/external/gear_cmd" to="/external/selected/gear_cmd"/>
+        <remap from="input/external_emergency_stop_heartbeat" to="/external/selected/heartbeat"/>
+        <remap from="input/gate_mode" to="/control/gate_mode_cmd"/>
+        <remap from="input/emergency/control_cmd" to="/system/emergency/control_cmd"/>
+        <remap from="input/emergency/turn_indicators_cmd" to="/system/emergency/turn_indicators_cmd"/>
+        <remap from="input/emergency/hazard_lights_cmd" to="/system/emergency/hazard_lights_cmd"/>
+        <remap from="input/emergency/gear_cmd" to="/system/emergency/gear_cmd"/>
+        <remap from="input/mrm_state" to="/system/fail_safe/mrm_state"/>
+        <remap from="input/kinematics" to="/localization/kinematic_state"/>
+        <remap from="input/acceleration" to="/localization/acceleration"/>
+        <remap from="output/vehicle_cmd_emergency" to="/control/command/emergency_cmd"/>
+        <remap from="output/control_cmd" to="$(var output/control_cmd)"/>
+        <remap from="output/gear_cmd" to="$(var output/gear_cmd)"/>
+        <remap from="output/turn_indicators_cmd" to="$(var output/turn_indicators_cmd)"/>
+        <remap from="output/hazard_lights_cmd" to="$(var output/hazard_lights_cmd)"/>
+        <remap from="output/gate_mode" to="/control/current_gate_mode"/>
+        <remap from="output/engage" to="/api/autoware/get/engage"/>
+        <remap from="output/external_emergency" to="/api/autoware/get/emergency"/>
+        <remap from="output/operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
+        <remap from="~/service/engage" to="/api/autoware/set/engage"/>
+        <remap from="~/service/external_emergency" to="/api/autoware/set/emergency"/>
+        <!-- TODO(Takagi, Isamu): deprecated -->
+        <remap from="input/engage" to="/autoware/engage"/>
+        <remap from="~/service/external_emergency_stop" to="~/external_emergency_stop"/>
+        <remap from="~/service/clear_external_emergency_stop" to="~/clear_external_emergency_stop"/>
+        <param from="$(var vehicle_cmd_gate_param_path)"/>
+        <param from="$(var vehicle_param_file)"/>
+        <param name="check_external_emergency_heartbeat" value="$(var check_external_emergency_heartbeat)"/>
+        <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+      </composable_node>
+    </load_composable_node>
+  </group>
+
+  <!-- operation mode transition manager -->
+  <load_composable_node target="$(var target_container)">
+    <composable_node
+      pkg="autoware_operation_mode_transition_manager"
+      plugin="autoware::operation_mode_transition_manager::$(var operation_mode_transition_manager_plugin)"
+      name="autoware_operation_mode_transition_manager"
+    >
+      <!-- input -->
+      <remap from="kinematics" to="/localization/kinematic_state"/>
+      <remap from="steering" to="/vehicle/status/steering_status"/>
+      <remap from="trajectory" to="/planning/trajectory"/>
+      <remap from="control_cmd" to="$(var output/control_cmd)"/>
+      <remap from="trajectory_follower_control_cmd" to="$(var input/control_cmd)"/>
+      <remap from="control_mode_report" to="/vehicle/status/control_mode"/>
+      <remap from="gate_operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
+      <!-- output -->
+      <remap from="is_autonomous_available" to="/control/is_autonomous_available"/>
+      <remap from="control_mode_request" to="/control/control_mode_request"/>
+      <param from="$(var nearest_search_param_path)"/>
+      <param from="$(var operation_mode_transition_manager_param_path)"/>
+      <param from="$(var vehicle_param_file)"/>
+      <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+    </composable_node>
+  </load_composable_node>
+</launch>

--- a/autoware_universe_launch/autoware_control_launch/launch/control.launch.xml
+++ b/autoware_universe_launch/autoware_control_launch/launch/control.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <!-- Control pipeline: command gate, trajectory follower, optional control checkers and the evaluator, all under the control namespace -->
+  <!-- Control pipeline: trajectory follower, command gate, external command, control checkers and the evaluator, all under the control namespace -->
   <arg name="control_config_pkg" default="autoware_control_config" description="package that ships the control config/ tree; overriding it requires the same config layout"/>
   <arg name="module_preset" default="default" description="module preset that selects which control modules launch"/>
   <let name="control_config_dir" value="$(find-pkg-share $(var control_config_pkg))/config"/>
@@ -59,244 +59,86 @@
     <arg name="use_multithread" value="$(var use_multithread)"/>
   </include>
 
-  <let name="operation_mode_transition_manager_plugin" value="AutonomousModeTransitionFlagNode" if="$(var use_control_command_gate)"/>
-  <let name="operation_mode_transition_manager_plugin" value="OperationModeTransitionManager" unless="$(var use_control_command_gate)"/>
-
   <group>
     <push-ros-namespace namespace="control"/>
 
-    <group if="$(var use_control_command_gate)">
-      <include file="$(find-pkg-share autoware_control_command_gate)/launch/control_command_gate.launch.xml">
-        <arg name="config" value="$(var control_command_gate_param_path)"/>
-        <arg name="output/control" value="$(var output_control_cmd)"/>
-        <arg name="output/gear" value="$(var output_gear_cmd)"/>
-        <arg name="output/turn_indicators" value="$(var output_turn_indicators_cmd)"/>
-        <arg name="output/hazard_lights" value="$(var output_hazard_lights_cmd)"/>
+    <!-- containers: the command path and the composable checkers each share one process -->
+    <node_container pkg="$(var container_package)" exec="$(var container_executable)" name="control_container" namespace=""/>
+    <node_container pkg="$(var container_package)" exec="$(var container_executable)" name="control_check_container" namespace=""/>
+
+    <!-- trajectory follower -->
+    <group>
+      <include file="$(find-pkg-share autoware_control_launch)/launch/trajectory_follower/trajectory_follower.launch.xml">
+        <arg name="trajectory_follower_mode" value="$(var trajectory_follower_mode)"/>
+        <arg name="lateral_controller_mode" value="$(var lateral_controller_mode)"/>
+        <arg name="longitudinal_controller_mode" value="$(var longitudinal_controller_mode)"/>
+        <arg name="launch_lane_departure_checker" value="$(var launch_lane_departure_checker)"/>
+        <arg name="nearest_search_param_path" value="$(var nearest_search_param_path)"/>
+        <arg name="trajectory_follower_node_param_path" value="$(var trajectory_follower_node_param_path)"/>
+        <arg name="lat_controller_param_path" value="$(var lat_controller_param_path)"/>
+        <arg name="lon_controller_param_path" value="$(var lon_controller_param_path)"/>
+        <arg name="lane_departure_checker_param_path" value="$(var lane_departure_checker_param_path)"/>
+        <arg name="vehicle_param_file" value="$(var vehicle_param_file)"/>
+        <arg name="target_container" value="/control/control_container"/>
+        <arg name="use_intra_process" value="$(var use_intra_process)"/>
+        <arg name="ld_preload_value" value="$(var ld_preload_value)"/>
       </include>
     </group>
-    <group if="$(var use_control_command_gate)">
-      <include file="$(find-pkg-share autoware_stop_mode_operator)/launch/stop_mode_operator.launch.xml"/>
+
+    <!-- command gate -->
+    <group>
+      <include file="$(find-pkg-share autoware_control_launch)/launch/command_gate/command_gate.launch.xml">
+        <arg name="use_control_command_gate" value="$(var use_control_command_gate)"/>
+        <arg name="check_external_emergency_heartbeat" value="$(var check_external_emergency_heartbeat)"/>
+        <arg name="output/control_cmd" value="$(var output_control_cmd)"/>
+        <arg name="output/gear_cmd" value="$(var output_gear_cmd)"/>
+        <arg name="output/turn_indicators_cmd" value="$(var output_turn_indicators_cmd)"/>
+        <arg name="output/hazard_lights_cmd" value="$(var output_hazard_lights_cmd)"/>
+        <arg name="nearest_search_param_path" value="$(var nearest_search_param_path)"/>
+        <arg name="vehicle_cmd_gate_param_path" value="$(var vehicle_cmd_gate_param_path)"/>
+        <arg name="control_command_gate_param_path" value="$(var control_command_gate_param_path)"/>
+        <arg name="operation_mode_transition_manager_param_path" value="$(var operation_mode_transition_manager_param_path)"/>
+        <arg name="shift_decider_param_path" value="$(var shift_decider_param_path)"/>
+        <arg name="vehicle_param_file" value="$(var vehicle_param_file)"/>
+        <arg name="target_container" value="/control/control_container"/>
+        <arg name="use_intra_process" value="$(var use_intra_process)"/>
+        <arg name="ld_preload_value" value="$(var ld_preload_value)"/>
+      </include>
     </group>
 
+    <!-- external command -->
     <group>
-      <!-- shift decider -->
-      <node pkg="autoware_shift_decider" exec="autoware_shift_decider" name="autoware_shift_decider" output="screen">
-        <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd"/>
-        <remap from="input/state" to="/autoware/state"/>
-        <remap from="input/current_gear" to="/vehicle/status/gear_status"/>
-        <remap from="output/gear_cmd" to="/control/shift_decider/gear_cmd"/>
-        <param from="$(var shift_decider_param_path)"/>
-        <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
-      </node>
-
-      <!-- set a control container to run all required components in the same process -->
-      <node_container pkg="$(var container_package)" exec="$(var container_executable)" name="control_container" namespace="">
-        <!-- vehicle cmd gate -->
-        <composable_node pkg="autoware_vehicle_cmd_gate" plugin="autoware::vehicle_cmd_gate::VehicleCmdGate" name="vehicle_cmd_gate" unless="$(var use_control_command_gate)">
-          <remap from="input/steering" to="/vehicle/status/steering_status"/>
-          <remap from="input/operation_mode" to="/system/operation_mode/state"/>
-          <remap from="input/auto/control_cmd" to="/control/trajectory_follower/control_cmd"/>
-          <remap from="input/auto/turn_indicators_cmd" to="/planning/turn_indicators_cmd"/>
-          <remap from="input/auto/hazard_lights_cmd" to="/planning/hazard_lights_cmd"/>
-          <remap from="input/auto/gear_cmd" to="/control/shift_decider/gear_cmd"/>
-          <remap from="input/external/control_cmd" to="/external/selected/control_cmd"/>
-          <remap from="input/external/turn_indicators_cmd" to="/external/selected/turn_indicators_cmd"/>
-          <remap from="input/external/hazard_lights_cmd" to="/external/selected/hazard_lights_cmd"/>
-          <remap from="input/external/gear_cmd" to="/external/selected/gear_cmd"/>
-          <remap from="input/external_emergency_stop_heartbeat" to="/external/selected/heartbeat"/>
-          <remap from="input/gate_mode" to="/control/gate_mode_cmd"/>
-          <remap from="input/emergency/control_cmd" to="/system/emergency/control_cmd"/>
-          <remap from="input/emergency/turn_indicators_cmd" to="/system/emergency/turn_indicators_cmd"/>
-          <remap from="input/emergency/hazard_lights_cmd" to="/system/emergency/hazard_lights_cmd"/>
-          <remap from="input/emergency/gear_cmd" to="/system/emergency/gear_cmd"/>
-          <remap from="input/mrm_state" to="/system/fail_safe/mrm_state"/>
-          <remap from="input/kinematics" to="/localization/kinematic_state"/>
-          <remap from="input/acceleration" to="/localization/acceleration"/>
-          <remap from="output/vehicle_cmd_emergency" to="/control/command/emergency_cmd"/>
-          <remap from="output/control_cmd" to="$(var output_control_cmd)"/>
-          <remap from="output/gear_cmd" to="$(var output_gear_cmd)"/>
-          <remap from="output/turn_indicators_cmd" to="$(var output_turn_indicators_cmd)"/>
-          <remap from="output/hazard_lights_cmd" to="$(var output_hazard_lights_cmd)"/>
-          <remap from="output/gate_mode" to="/control/current_gate_mode"/>
-          <remap from="output/engage" to="/api/autoware/get/engage"/>
-          <remap from="output/external_emergency" to="/api/autoware/get/emergency"/>
-          <remap from="output/operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
-          <remap from="~/service/engage" to="/api/autoware/set/engage"/>
-          <remap from="~/service/external_emergency" to="/api/autoware/set/emergency"/>
-          <!-- TODO(Takagi, Isamu): deprecated -->
-          <remap from="input/engage" to="/autoware/engage"/>
-          <remap from="~/service/external_emergency_stop" to="~/external_emergency_stop"/>
-          <remap from="~/service/clear_external_emergency_stop" to="~/clear_external_emergency_stop"/>
-          <param from="$(var vehicle_cmd_gate_param_path)"/>
-          <param from="$(var vehicle_param_file)"/>
-          <param name="check_external_emergency_heartbeat" value="$(var check_external_emergency_heartbeat)"/>
-          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-        </composable_node>
-
-        <!-- operation mode transition manager -->
-        <composable_node
-          pkg="autoware_operation_mode_transition_manager"
-          plugin="autoware::operation_mode_transition_manager::$(var operation_mode_transition_manager_plugin)"
-          name="autoware_operation_mode_transition_manager"
-        >
-          <!-- input -->
-          <remap from="kinematics" to="/localization/kinematic_state"/>
-          <remap from="steering" to="/vehicle/status/steering_status"/>
-          <remap from="trajectory" to="/planning/trajectory"/>
-          <remap from="control_cmd" to="/control/command/control_cmd"/>
-          <remap from="trajectory_follower_control_cmd" to="/control/trajectory_follower/control_cmd"/>
-          <remap from="control_mode_report" to="/vehicle/status/control_mode"/>
-          <remap from="gate_operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
-          <!-- output -->
-          <remap from="is_autonomous_available" to="/control/is_autonomous_available"/>
-          <remap from="control_mode_request" to="/control/control_mode_request"/>
-          <param from="$(var nearest_search_param_path)"/>
-          <param from="$(var operation_mode_transition_manager_param_path)"/>
-          <param from="$(var vehicle_param_file)"/>
-          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-        </composable_node>
-      </node_container>
-
-      <!-- trajectory_follower_node -->
-      <group if="$(eval &quot;'$(var trajectory_follower_mode)' == 'trajectory_follower_node'&quot;)">
-        <load_composable_node target="/control/control_container">
-          <composable_node pkg="autoware_trajectory_follower_node" plugin="autoware::motion::control::trajectory_follower_node::Controller" name="controller_node_exe" namespace="trajectory_follower">
-            <remap from="~/input/reference_trajectory" to="/planning/trajectory"/>
-            <remap from="~/input/current_odometry" to="/localization/kinematic_state"/>
-            <remap from="~/input/current_steering" to="/vehicle/status/steering_status"/>
-            <remap from="~/input/current_accel" to="/localization/acceleration"/>
-            <remap from="~/input/current_operation_mode" to="/system/operation_mode/state"/>
-            <remap from="~/input/steering_offset_update" to="/vehicle/calibration/steer_offset_estimator/steering_offset_update"/>
-            <remap from="~/output/predicted_trajectory" to="lateral/predicted_trajectory"/>
-            <remap from="~/output/lateral_diagnostic" to="lateral/diagnostic"/>
-            <remap from="~/output/slope_angle" to="longitudinal/slope_angle"/>
-            <remap from="~/output/longitudinal_diagnostic" to="longitudinal/diagnostic"/>
-            <remap from="~/output/stop_reason" to="longitudinal/stop_reason"/>
-            <remap from="~/output/control_cmd" to="control_cmd"/>
-            <param name="lateral_controller_mode" value="$(var lateral_controller_mode)"/>
-            <param name="longitudinal_controller_mode" value="$(var longitudinal_controller_mode)"/>
-            <param from="$(var nearest_search_param_path)"/>
-            <param from="$(var trajectory_follower_node_param_path)"/>
-            <param from="$(var lon_controller_param_path)"/>
-            <param from="$(var lat_controller_param_path)"/>
-            <param from="$(var vehicle_param_file)"/>
-            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-          </composable_node>
-        </load_composable_node>
-      </group>
-
-      <!-- smart_mpc, under development -->
-      <group if="$(eval &quot;'$(var trajectory_follower_mode)' == 'smart_mpc_trajectory_follower'&quot;)">
-        <node pkg="autoware_smart_mpc_trajectory_follower" exec="pympc_trajectory_follower.py" name="controller_node_exe"/>
-      </group>
-
-      <!-- external cmd selector -->
-      <group if="$(var launch_external_cmd_selector)">
-        <include file="$(find-pkg-share autoware_external_cmd_selector)/launch/external_cmd_selector.launch.py">
-          <arg name="use_intra_process" value="$(var use_intra_process)"/>
-          <arg name="target_container" value="/control/control_container"/>
-          <arg name="external_cmd_selector_param_path" value="$(var external_cmd_selector_param_path)"/>
-        </include>
-      </group>
-      <!-- external cmd converter -->
-      <group if="$(var launch_external_cmd_converter)">
-        <include file="$(find-pkg-share autoware_external_cmd_converter)/launch/external_cmd_converter.launch.py">
-          <arg name="use_intra_process" value="$(var use_intra_process)"/>
-          <arg name="target_container" value="/control/control_container"/>
-        </include>
-      </group>
+      <include file="$(find-pkg-share autoware_control_launch)/launch/external_command/external_command.launch.xml">
+        <arg name="launch_external_cmd_selector" value="$(var launch_external_cmd_selector)"/>
+        <arg name="launch_external_cmd_converter" value="$(var launch_external_cmd_converter)"/>
+        <arg name="external_cmd_selector_param_path" value="$(var external_cmd_selector_param_path)"/>
+        <arg name="target_container" value="/control/control_container"/>
+        <arg name="use_intra_process" value="$(var use_intra_process)"/>
+      </include>
     </group>
 
+    <!-- control checkers -->
     <group>
-      <!-- set a control check container to run all control checker components in the same process -->
-      <node_container pkg="$(var container_package)" exec="$(var container_executable)" name="control_check_container" namespace=""/>
-
-      <!-- lane departure checker -->
-      <group if="$(var launch_lane_departure_checker)">
-        <node pkg="autoware_lane_departure_checker" exec="lane_departure_checker_node" name="lane_departure_checker_node" namespace="trajectory_follower" output="screen">
-          <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
-          <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-          <remap from="~/input/lanelet_map_bin" to="/map/vector_map"/>
-          <remap from="~/input/route" to="/planning/mission_planning/route"/>
-          <remap from="~/input/reference_trajectory" to="/planning/trajectory"/>
-          <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-          <param from="$(var nearest_search_param_path)"/>
-          <param from="$(var lane_departure_checker_param_path)"/>
-          <param from="$(var vehicle_param_file)"/>
-        </node>
-      </group>
-
-      <!-- control validator checker -->
-      <group if="$(var launch_control_validator)">
-        <node pkg="autoware_control_validator" exec="autoware_control_validator_node" name="control_validator" output="screen">
-          <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
-          <remap from="~/input/control_cmd" to="/control/command/control_cmd"/>
-          <remap from="~/input/kinematics" to="/localization/kinematic_state"/>
-          <remap from="~/input/operational_mode_state" to="/api/operation_mode/state"/>
-          <remap from="~/input/measured_acceleration" to="/localization/acceleration"/>
-          <remap from="~/input/reference_trajectory" to="/planning/trajectory"/>
-          <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-          <remap from="~/output/validation_status" to="~/validation_status"/>
-          <param from="$(var control_validator_param_path)"/>
-        </node>
-      </group>
-
-      <!-- autonomous emergency braking -->
-      <group if="$(var launch_autonomous_emergency_braking)">
-        <node pkg="autoware_autonomous_emergency_braking" exec="autoware_autonomous_emergency_braking" name="autonomous_emergency_braking" output="screen">
-          <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
-          <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>
-          <remap from="~/input/velocity" to="/vehicle/status/velocity_status"/>
-          <remap from="~/input/imu" to="/sensing/imu/imu_data"/>
-          <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
-          <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-          <param from="$(var aeb_param_path)"/>
-          <param name="check_autoware_state" value="$(var use_aeb_autoware_state_check)"/>
-        </node>
-      </group>
-
-      <!-- collision detector-->
-      <group if="$(var launch_collision_detector)">
-        <node pkg="autoware_collision_detector" exec="autoware_collision_detector_node" name="collision_detector" output="screen">
-          <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
-          <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-          <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>
-          <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
-          <param from="$(var collision_detector_param_path)"/>
-        </node>
-      </group>
-
-      <!-- obstacle collision checker -->
-      <group if="$(var launch_obstacle_collision_checker)">
-        <load_composable_node target="/control/control_check_container">
-          <composable_node pkg="autoware_obstacle_collision_checker" plugin="autoware::obstacle_collision_checker::ObstacleCollisionCheckerNode" name="obstacle_collision_checker">
-            <remap from="input/lanelet_map_bin" to="/map/vector_map"/>
-            <remap from="input/obstacle_pointcloud" to="$(var input_pointcloud_topic_name)"/>
-            <remap from="input/reference_trajectory" to="/planning/trajectory"/>
-            <remap from="input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-            <remap from="input/odometry" to="/localization/kinematic_state"/>
-            <param from="$(var obstacle_collision_checker_param_path)"/>
-            <param from="$(var vehicle_param_file)"/>
-            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-          </composable_node>
-        </load_composable_node>
-      </group>
-
-      <!-- predicted path checker -->
-      <group if="$(var launch_predicted_path_checker)">
-        <load_composable_node target="/control/control_check_container">
-          <composable_node pkg="autoware_predicted_path_checker" plugin="autoware::predicted_path_checker::PredictedPathCheckerNode" name="predicted_path_checker">
-            <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
-            <remap from="~/input/reference_trajectory" to="/planning/trajectory"/>
-            <remap from="~/input/current_accel" to="/localization/acceleration"/>
-            <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-            <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-            <param from="$(var vehicle_param_file)"/>
-            <param from="$(var predicted_path_checker_param_path)"/>
-            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-          </composable_node>
-        </load_composable_node>
-      </group>
+      <include file="$(find-pkg-share autoware_control_launch)/launch/control_checker/control_checker.launch.xml">
+        <arg name="launch_control_validator" value="$(var launch_control_validator)"/>
+        <arg name="launch_autonomous_emergency_braking" value="$(var launch_autonomous_emergency_braking)"/>
+        <arg name="launch_collision_detector" value="$(var launch_collision_detector)"/>
+        <arg name="launch_obstacle_collision_checker" value="$(var launch_obstacle_collision_checker)"/>
+        <arg name="launch_predicted_path_checker" value="$(var launch_predicted_path_checker)"/>
+        <arg name="use_aeb_autoware_state_check" value="$(var use_aeb_autoware_state_check)"/>
+        <arg name="input/objects" value="$(var input_objects_topic_name)"/>
+        <arg name="input/pointcloud" value="$(var input_pointcloud_topic_name)"/>
+        <arg name="input/control_cmd" value="$(var output_control_cmd)"/>
+        <arg name="control_validator_param_path" value="$(var control_validator_param_path)"/>
+        <arg name="aeb_param_path" value="$(var aeb_param_path)"/>
+        <arg name="collision_detector_param_path" value="$(var collision_detector_param_path)"/>
+        <arg name="obstacle_collision_checker_param_path" value="$(var obstacle_collision_checker_param_path)"/>
+        <arg name="predicted_path_checker_param_path" value="$(var predicted_path_checker_param_path)"/>
+        <arg name="vehicle_param_file" value="$(var vehicle_param_file)"/>
+        <arg name="target_container" value="/control/control_check_container"/>
+        <arg name="use_intra_process" value="$(var use_intra_process)"/>
+        <arg name="ld_preload_value" value="$(var ld_preload_value)"/>
+      </include>
     </group>
 
     <!-- control evaluator -->

--- a/autoware_universe_launch/autoware_control_launch/launch/control_checker/control_checker.launch.xml
+++ b/autoware_universe_launch/autoware_control_launch/launch/control_checker/control_checker.launch.xml
@@ -1,0 +1,105 @@
+<launch>
+  <!-- Control checker unit: optional monitors of the output command and of the predicted trajectory against the surroundings -->
+  <arg name="launch_control_validator" default="true"/>
+  <arg name="launch_autonomous_emergency_braking" default="true"/>
+  <arg name="launch_collision_detector" default="true"/>
+  <arg name="launch_obstacle_collision_checker" default="false"/>
+  <arg name="launch_predicted_path_checker" default="false"/>
+  <arg name="use_aeb_autoware_state_check" default="true"/>
+
+  <!-- External interfaces -->
+  <arg name="input/objects" default="/perception/object_recognition/objects"/>
+  <arg name="input/pointcloud" default="/perception/obstacle_segmentation/pointcloud"/>
+  <arg name="input/trajectory" default="/planning/trajectory"/>
+  <arg name="input/predicted_trajectory" default="/control/trajectory_follower/lateral/predicted_trajectory"/>
+  <arg name="input/control_cmd" default="/control/command/control_cmd"/>
+  <arg name="input/odometry" default="/localization/kinematic_state"/>
+  <arg name="input/acceleration" default="/localization/acceleration"/>
+  <arg name="input/lanelet_map_bin" default="/map/vector_map"/>
+
+  <!-- Parameter paths -->
+  <let name="config_dir" value="$(find-pkg-share autoware_control_config)/config"/>
+  <arg name="control_validator_param_path" default="$(var config_dir)/control_validator/control_validator.param.yaml"/>
+  <arg name="aeb_param_path" default="$(var config_dir)/autoware_autonomous_emergency_braking/autonomous_emergency_braking.param.yaml"/>
+  <arg name="collision_detector_param_path" default="$(var config_dir)/autoware_collision_detector/collision_detector.param.yaml"/>
+  <arg name="obstacle_collision_checker_param_path" default="$(var config_dir)/obstacle_collision_checker/obstacle_collision_checker.param.yaml"/>
+  <arg name="predicted_path_checker_param_path" default="$(var config_dir)/predicted_path_checker/predicted_path_checker.param.yaml"/>
+  <arg name="vehicle_param_file" default="$(find-pkg-share sample_vehicle_description)/config/vehicle_info.param.yaml"/>
+
+  <!-- Process placement -->
+  <arg name="target_container" default="/control/control_check_container" description="container that hosts the composable checkers"/>
+  <arg name="use_intra_process" default="false"/>
+  <arg name="ld_preload_value" default=""/>
+
+  <!-- control validator -->
+  <group if="$(var launch_control_validator)">
+    <node pkg="autoware_control_validator" exec="autoware_control_validator_node" name="control_validator" output="screen">
+      <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+      <remap from="~/input/control_cmd" to="$(var input/control_cmd)"/>
+      <remap from="~/input/kinematics" to="$(var input/odometry)"/>
+      <remap from="~/input/operational_mode_state" to="/api/operation_mode/state"/>
+      <remap from="~/input/measured_acceleration" to="$(var input/acceleration)"/>
+      <remap from="~/input/reference_trajectory" to="$(var input/trajectory)"/>
+      <remap from="~/input/predicted_trajectory" to="$(var input/predicted_trajectory)"/>
+      <remap from="~/output/validation_status" to="~/validation_status"/>
+      <param from="$(var control_validator_param_path)"/>
+    </node>
+  </group>
+
+  <!-- autonomous emergency braking -->
+  <group if="$(var launch_autonomous_emergency_braking)">
+    <node pkg="autoware_autonomous_emergency_braking" exec="autoware_autonomous_emergency_braking" name="autonomous_emergency_braking" output="screen">
+      <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+      <remap from="~/input/pointcloud" to="$(var input/pointcloud)"/>
+      <remap from="~/input/velocity" to="/vehicle/status/velocity_status"/>
+      <remap from="~/input/imu" to="/sensing/imu/imu_data"/>
+      <remap from="~/input/objects" to="$(var input/objects)"/>
+      <remap from="~/input/predicted_trajectory" to="$(var input/predicted_trajectory)"/>
+      <param from="$(var aeb_param_path)"/>
+      <param name="check_autoware_state" value="$(var use_aeb_autoware_state_check)"/>
+    </node>
+  </group>
+
+  <!-- collision detector -->
+  <group if="$(var launch_collision_detector)">
+    <node pkg="autoware_collision_detector" exec="autoware_collision_detector_node" name="collision_detector" output="screen">
+      <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+      <remap from="~/input/odometry" to="$(var input/odometry)"/>
+      <remap from="~/input/pointcloud" to="$(var input/pointcloud)"/>
+      <remap from="~/input/objects" to="$(var input/objects)"/>
+      <param from="$(var collision_detector_param_path)"/>
+    </node>
+  </group>
+
+  <!-- obstacle collision checker -->
+  <group if="$(var launch_obstacle_collision_checker)">
+    <load_composable_node target="$(var target_container)">
+      <composable_node pkg="autoware_obstacle_collision_checker" plugin="autoware::obstacle_collision_checker::ObstacleCollisionCheckerNode" name="obstacle_collision_checker">
+        <remap from="input/lanelet_map_bin" to="$(var input/lanelet_map_bin)"/>
+        <remap from="input/obstacle_pointcloud" to="$(var input/pointcloud)"/>
+        <remap from="input/reference_trajectory" to="$(var input/trajectory)"/>
+        <remap from="input/predicted_trajectory" to="$(var input/predicted_trajectory)"/>
+        <remap from="input/odometry" to="$(var input/odometry)"/>
+        <param from="$(var obstacle_collision_checker_param_path)"/>
+        <param from="$(var vehicle_param_file)"/>
+        <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+      </composable_node>
+    </load_composable_node>
+  </group>
+
+  <!-- predicted path checker -->
+  <group if="$(var launch_predicted_path_checker)">
+    <load_composable_node target="$(var target_container)">
+      <composable_node pkg="autoware_predicted_path_checker" plugin="autoware::predicted_path_checker::PredictedPathCheckerNode" name="predicted_path_checker">
+        <remap from="~/input/objects" to="$(var input/objects)"/>
+        <remap from="~/input/reference_trajectory" to="$(var input/trajectory)"/>
+        <remap from="~/input/current_accel" to="$(var input/acceleration)"/>
+        <remap from="~/input/odometry" to="$(var input/odometry)"/>
+        <remap from="~/input/predicted_trajectory" to="$(var input/predicted_trajectory)"/>
+        <param from="$(var vehicle_param_file)"/>
+        <param from="$(var predicted_path_checker_param_path)"/>
+        <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+      </composable_node>
+    </load_composable_node>
+  </group>
+</launch>

--- a/autoware_universe_launch/autoware_control_launch/launch/external_command/external_command.launch.xml
+++ b/autoware_universe_launch/autoware_control_launch/launch/external_command/external_command.launch.xml
@@ -1,0 +1,28 @@
+<launch>
+  <!-- External command unit: selects the local/remote operator command and converts it into a control command for the gate -->
+  <arg name="launch_external_cmd_selector" default="true"/>
+  <arg name="launch_external_cmd_converter" default="true"/>
+
+  <!-- Parameter paths -->
+  <arg name="external_cmd_selector_param_path" default="$(find-pkg-share autoware_control_config)/config/external_cmd_selector/external_cmd_selector.param.yaml"/>
+
+  <!-- Process placement -->
+  <arg name="target_container" default="/control/control_container"/>
+  <arg name="use_intra_process" default="false"/>
+
+  <!-- external cmd selector -->
+  <group if="$(var launch_external_cmd_selector)">
+    <include file="$(find-pkg-share autoware_external_cmd_selector)/launch/external_cmd_selector.launch.py">
+      <arg name="use_intra_process" value="$(var use_intra_process)"/>
+      <arg name="target_container" value="$(var target_container)"/>
+      <arg name="external_cmd_selector_param_path" value="$(var external_cmd_selector_param_path)"/>
+    </include>
+  </group>
+  <!-- external cmd converter -->
+  <group if="$(var launch_external_cmd_converter)">
+    <include file="$(find-pkg-share autoware_external_cmd_converter)/launch/external_cmd_converter.launch.py">
+      <arg name="use_intra_process" value="$(var use_intra_process)"/>
+      <arg name="target_container" value="$(var target_container)"/>
+    </include>
+  </group>
+</launch>

--- a/autoware_universe_launch/autoware_control_launch/launch/trajectory_follower/trajectory_follower.launch.xml
+++ b/autoware_universe_launch/autoware_control_launch/launch/trajectory_follower/trajectory_follower.launch.xml
@@ -1,0 +1,80 @@
+<launch>
+  <!-- Trajectory follower unit: the controller and the lane departure checker that watches its predicted trajectory -->
+  <arg name="trajectory_follower_mode" default="trajectory_follower_node" description="options: `trajectory_follower_node`, `smart_mpc_trajectory_follower`, `none`"/>
+  <arg name="lateral_controller_mode" default="mpc" description="lateral controller; options: `mpc`, `pure_pursuit`"/>
+  <arg name="longitudinal_controller_mode" default="pid" description="longitudinal controller; options: `pid`"/>
+  <arg name="launch_lane_departure_checker" default="true"/>
+
+  <!-- External interfaces -->
+  <arg name="input/trajectory" default="/planning/trajectory"/>
+  <arg name="input/odometry" default="/localization/kinematic_state"/>
+  <arg name="input/acceleration" default="/localization/acceleration"/>
+  <arg name="input/steering" default="/vehicle/status/steering_status"/>
+  <arg name="input/operation_mode" default="/system/operation_mode/state"/>
+  <arg name="input/steering_offset_update" default="/vehicle/calibration/steer_offset_estimator/steering_offset_update"/>
+  <arg name="input/lanelet_map_bin" default="/map/vector_map"/>
+  <arg name="input/route" default="/planning/mission_planning/route"/>
+  <arg name="input/predicted_trajectory" default="/control/trajectory_follower/lateral/predicted_trajectory" description="controller predicted trajectory as seen by the checker"/>
+
+  <!-- Parameter paths -->
+  <let name="config_dir" value="$(find-pkg-share autoware_control_config)/config"/>
+  <arg name="nearest_search_param_path" default="$(var config_dir)/common/nearest_search.param.yaml"/>
+  <arg name="trajectory_follower_node_param_path" default="$(var config_dir)/trajectory_follower/trajectory_follower_node.param.yaml"/>
+  <arg name="lat_controller_param_path" default="$(var config_dir)/trajectory_follower/lateral/$(var lateral_controller_mode).param.yaml"/>
+  <arg name="lon_controller_param_path" default="$(var config_dir)/trajectory_follower/longitudinal/$(var longitudinal_controller_mode).param.yaml"/>
+  <arg name="lane_departure_checker_param_path" default="$(var config_dir)/lane_departure_checker/lane_departure_checker.param.yaml"/>
+  <arg name="vehicle_param_file" default="$(find-pkg-share sample_vehicle_description)/config/vehicle_info.param.yaml"/>
+
+  <!-- Process placement -->
+  <arg name="target_container" default="/control/control_container" description="container that hosts the controller"/>
+  <arg name="use_intra_process" default="false"/>
+  <arg name="ld_preload_value" default=""/>
+
+  <!-- controller -->
+  <group if="$(eval &quot;'$(var trajectory_follower_mode)' == 'trajectory_follower_node'&quot;)">
+    <load_composable_node target="$(var target_container)">
+      <composable_node pkg="autoware_trajectory_follower_node" plugin="autoware::motion::control::trajectory_follower_node::Controller" name="controller_node_exe" namespace="trajectory_follower">
+        <remap from="~/input/reference_trajectory" to="$(var input/trajectory)"/>
+        <remap from="~/input/current_odometry" to="$(var input/odometry)"/>
+        <remap from="~/input/current_steering" to="$(var input/steering)"/>
+        <remap from="~/input/current_accel" to="$(var input/acceleration)"/>
+        <remap from="~/input/current_operation_mode" to="$(var input/operation_mode)"/>
+        <remap from="~/input/steering_offset_update" to="$(var input/steering_offset_update)"/>
+        <remap from="~/output/predicted_trajectory" to="lateral/predicted_trajectory"/>
+        <remap from="~/output/lateral_diagnostic" to="lateral/diagnostic"/>
+        <remap from="~/output/slope_angle" to="longitudinal/slope_angle"/>
+        <remap from="~/output/longitudinal_diagnostic" to="longitudinal/diagnostic"/>
+        <remap from="~/output/stop_reason" to="longitudinal/stop_reason"/>
+        <remap from="~/output/control_cmd" to="control_cmd"/>
+        <param name="lateral_controller_mode" value="$(var lateral_controller_mode)"/>
+        <param name="longitudinal_controller_mode" value="$(var longitudinal_controller_mode)"/>
+        <param from="$(var nearest_search_param_path)"/>
+        <param from="$(var trajectory_follower_node_param_path)"/>
+        <param from="$(var lon_controller_param_path)"/>
+        <param from="$(var lat_controller_param_path)"/>
+        <param from="$(var vehicle_param_file)"/>
+        <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+      </composable_node>
+    </load_composable_node>
+  </group>
+
+  <!-- smart_mpc, under development -->
+  <group if="$(eval &quot;'$(var trajectory_follower_mode)' == 'smart_mpc_trajectory_follower'&quot;)">
+    <node pkg="autoware_smart_mpc_trajectory_follower" exec="pympc_trajectory_follower.py" name="controller_node_exe"/>
+  </group>
+
+  <!-- lane departure checker -->
+  <group if="$(var launch_lane_departure_checker)">
+    <node pkg="autoware_lane_departure_checker" exec="lane_departure_checker_node" name="lane_departure_checker_node" namespace="trajectory_follower" output="screen">
+      <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+      <remap from="~/input/odometry" to="$(var input/odometry)"/>
+      <remap from="~/input/lanelet_map_bin" to="$(var input/lanelet_map_bin)"/>
+      <remap from="~/input/route" to="$(var input/route)"/>
+      <remap from="~/input/reference_trajectory" to="$(var input/trajectory)"/>
+      <remap from="~/input/predicted_trajectory" to="$(var input/predicted_trajectory)"/>
+      <param from="$(var nearest_search_param_path)"/>
+      <param from="$(var lane_departure_checker_param_path)"/>
+      <param from="$(var vehicle_param_file)"/>
+    </node>
+  </group>
+</launch>

--- a/autoware_universe_launch/autoware_control_launch/package.xml
+++ b/autoware_universe_launch/autoware_control_launch/package.xml
@@ -31,6 +31,7 @@
   <exec_depend>autoware_stop_mode_operator</exec_depend>
   <exec_depend>autoware_trajectory_follower_node</exec_depend>
   <exec_depend>autoware_vehicle_cmd_gate</exec_depend>
+  <exec_depend>sample_vehicle_description</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>


### PR DESCRIPTION
## Description

Part of #1939 (control item), supporting
[discussion #7111](https://github.com/orgs/autowarefoundation/discussions/7111) and #1848.

Stacked on #1962 (control launch migration), which should merge first; until then its diff shows up here.
The cluster split itself is the last 3 commits (11 files).

Splits `control.launch.xml` into four launch units, one per cluster of the control data-flow graph, and
mirrors them as Autoware System Designer modules. Node names, namespaces, topics and parameters are
unchanged; the resolved launch tree is identical to #1962.

### What was done

1. **Launch units**: `control.launch.xml` keeps the preset include, the parameter path block, the
   `control` namespace and the two containers, then includes one file per unit:
   - `trajectory_follower/trajectory_follower.launch.xml` — controller (`trajectory_follower_node`,
     `smart_mpc_trajectory_follower`, `none`) and lane departure checker
   - `command_gate/command_gate.launch.xml` — vehicle cmd gate or control command gate (+ stop mode
     operator), shift decider, operation mode transition manager
   - `external_command/external_command.launch.xml` — external command selector and converter
   - `control_checker/control_checker.launch.xml` — control validator, AEB, collision detector,
     obstacle collision checker, predicted path checker, each behind its `launch_*` flag

   Each unit exposes its boundary topics as `input/*` / `output/*` arguments and takes
   `target_container`, `use_intra_process` and `ld_preload_value`, so process placement is decided by
   the caller. Parameter paths default to the `autoware_control_config` tree and are overridden by the
   entry point.
2. **Design modules**: `CommandGate`, `ExternalCommand` and `ControlChecker` module designs are added
   next to the existing `TrajectoryFollower`; `Control.module.yaml` instantiates the four units and the
   evaluator. Node instance names are unchanged.
3. **Fixed-name interfaces as `Control.module` ports**: the selector mode topic/service and the gate
   pause/stop interfaces are consumed by fixed names (`/control/external_cmd_selector/*`,
   `/control/vehicle_cmd_gate/*`). They are exposed as module ports under those names, so the exported
   topics stay stable while the nodes sit in nested unit modules. The operation mode transition
   manager's legacy inputs are connected explicitly. `/control/gate_mode_cmd` and `/autoware/engage`
   have publishers outside the design (API adaptor, joy controller, RViz), so they are `global:` on the
   node designs and are not module ports or system remaps. The node-design side of this is
   autowarefoundation/autoware_universe#13281, which must merge for the sample system export to wire
   `current_selector_mode`.
4. **Sample system**: `AutowareSample.system.yaml` node_groups address the nested instance paths; the
   `operation_mode_transition_manager` and `lane_departure_checker` entries previously matched nothing.


### Before After
* Before - flat structure: all node are under control, except `trajectory_follower`

<img width="1210" height="1318" alt="Screenshot from 2026-08-28 14-44-39" src="https://github.com/user-attachments/assets/6d4780ed-2044-45a5-b970-83280fe9d293" />


* After - clustered to `trajectory_follower`, `command_gate`, `external_command`, and `control_checker` 

<img width="2433" height="2118" alt="Screenshot from 2026-08-31 10-55-56" src="https://github.com/user-attachments/assets/f4d1d5d8-fbb5-47d5-961c-5c69b58dcde9" />



### Related PRs

- #1962 — control launch migration (base of this stack)
- autowarefoundation/autoware_universe#13281 — declares the compatibility ports in the control node
  designs (counterpart of item 3)

### Breaking changes

None beyond #1962. The unit launch files are new entry points; `control.launch.xml` keeps its argument
surface.

## How was this PR tested?

- Launch-resolution diff against #1962 is empty for the `default`, `dlr_control_validator`,
  `use_control_command_gate:=true`, `lateral_controller_mode:=pure_pursuit`, optional-checker,
  `smart_mpc` and `trajectory_follower_mode:=none` variants: node set, container set, composable node
  set, remaps and resolved parameter paths are identical.
- `autoware_sample_designs` builds with the nested `Control.module`; the export remaps
  `~/output/current_selector_mode` → `/control/external_cmd_selector/current_selector_mode` and the
  gate pause/stop interfaces to `/control/vehicle_cmd_gate/*` (with autoware_universe#13281).
- E2E simulation (AWSIM, `AutowareSample` export): `/api/operation_mode/state` reaches AUTONOMOUS with
  `is_autonomous_mode_available: true`.
- `pre-commit run` clean.

## Notes for reviewers

| Area | Files | What to review |
|---|---|---|
| Entry point | `launch/control.launch.xml` | what stays at the entry (preset, param paths, containers) vs. what moves into a unit; the boundary-topic arguments passed to each include |
| Units | `launch/{trajectory_follower,command_gate,external_command,control_checker}/*.launch.xml` | one cluster per file; `target_container` placement; `launch_*` flags |
| Design modules | `design/module/*.module.yaml` | mirrored port names; the fixed-name ports on `Control.module` |
| Sample system | `autoware_sample_designs/design/system/AutowareSample.system.yaml` | nested instance paths in node_groups |

Known gotcha: `if`/`unless` on a `composable_node` inside `load_composable_node` is ignored by ROS 2 launch; the units use the flag on the `load_composable_node` element instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

