### PR TITLE
feat(autoware_launch): make the dummy vehicle and dummy perception to…

### DIFF
--- a/autoware_launch/launch/planning_simulator.launch.xml
+++ b/autoware_launch/launch/planning_simulator.launch.xml
@@ -30,6 +30,10 @@
   <arg name="scenario_simulation" default="false" description="use scenario simulation"/>
   <arg name="launch_fault_injection" default="$(var scenario_simulation)" description="launch fault injection"/>
   <arg name="fault_injection_output_diagnostics" default="/diagnostics/fault_injection"/>
+  <let name="launch_dummy_modules" value="false" if="$(var scenario_simulation)"/>
+  <let name="launch_dummy_modules" value="true" unless="$(var scenario_simulation)"/>
+  <arg name="launch_dummy_vehicle" default="$(var launch_dummy_modules)" description="launch the simple planning simulator as the vehicle"/>
+  <arg name="launch_dummy_perception" default="$(var launch_dummy_modules)" description="launch dummy perception publisher as the detection stage"/>
 
   <!-- Tools -->
   <arg name="rviz" default="true" description="launch rviz"/>
@@ -90,8 +94,6 @@
 
   <!-- Simulator -->
   <group>
-    <let name="launch_dummy_vehicle" value="false" if="$(var scenario_simulation)"/>
-    <let name="launch_dummy_vehicle" value="true" unless="$(var scenario_simulation)"/>
     <let name="launch_scenario_simulator_v2_adapter" value="$(var scenario_simulation)"/>
 
     <include file="$(find-pkg-share autoware_launch)/launch/components/tier4_simulator_component.launch.xml">
@@ -109,8 +111,6 @@
 
   <!-- Simulated perception -->
   <group>
-    <let name="launch_dummy_perception" value="false" if="$(var scenario_simulation)"/>
-    <let name="launch_dummy_perception" value="true" unless="$(var scenario_simulation)"/>
     <let name="launch_occupancy_grid_map" value="false" if="$(var scenario_simulation)"/>
     <let name="launch_occupancy_grid_map" value="true" unless="$(var scenario_simulation)"/>
 


### PR DESCRIPTION
## Description

`planning_simulator.launch.xml` derives `launch_dummy_vehicle` and `launch_dummy_perception` from
`scenario_simulation` using group-local `<let>`, so neither can be overridden from the command line.
This declares them as `<arg>` with the same derived default instead.

In a co-simulation, an external simulator supplies part of what the planning simulator
normally fakes, and the rest of the simulated stack still has to run. Concretely: with
`launch_dummy_vehicle:=false` the simple planning simulator stops publishing the ego state, so an
external simulator can own it, while dummy perception and the occupancy grid map stay up and
planning keeps working. Today that combination cannot be expressed, because the only handle on
either toggle is `scenario_simulation`, which moves both at once and turns off other things besides.

**Paired pull request.** 
autowarefoundation/autoware_universe#13321 adds ground truth object
publishing to `autoware_carla_interface`. Together with this change, a CARLA co-simulation can feed
Autoware both the ego pose and the surrounding vehicles from simulator truth. Neither PR depends on
the other to build or to be useful on its own.

## How was this PR tested?

pre-commit passes.

`ros2 launch autoware_launch planning_simulator.launch.xml --show-args` now lists both arguments,
with their defaults shown as the shared `launch_dummy_modules` value.

Run against a live CARLA 0.9.16 server with `autoware_carla_interface`, on Town01 and on the
Kashiwanoha map, launching with:

```bash
ros2 launch autoware_launch planning_simulator.launch.xml \
  map_path:=... vehicle_model:=sample_vehicle sensor_model:=carla_sensor_kit \
  use_sim_time:=true launch_dummy_vehicle:=false launch_dummy_perception:=true rviz:=false
```

| Check | Result |
| --- | --- |
| `launch_dummy_vehicle:=false` takes effect | `/localization/kinematic_state` has 0 publishers; the simple planning simulator is not launched |
| The external source can then own the ego state | `carla_state_publisher` publishes it, 1 publisher, 0.000 m from CARLA's own pose at rest |
| The rest of the simulated stack survives | Dummy perception still publishes; `/perception/occupancy_grid_map/map` still has 1 publisher |
| Planning still works | Route accepted, `is_autonomous_mode_available` true, engaged and drove to the goal |

**Defaults unchanged.** Launching without either new argument starts the same nodes as before.

## Notes for reviewers

This is a paired request with autowarefoundation/autoware_universe#13311.

## Effects on system behavior

None by default. Both arguments keep the values they had, derived from `scenario_simulation` exactly
as before, so a launch that does not pass them starts the same nodes it always did.

## AI assistance

I used Claude Opus 5 / Fable 5 to check, modify, and review the code.
I conducted thorough functional testing across two maps, and I have personally reviewed the entire content of this PR.

https://github.com/user-attachments/assets/f2719e74-4e4b-4d74-b2bc-0f8e8e40cf49