### PR TITLE
refactor(autoware_sample_designs): compose localization from design modules

### DIFF
--- a/autoware_sample_designs/design/module/localization/Localization.module.yaml
+++ b/autoware_sample_designs/design/module/localization/Localization.module.yaml
@@ -1,0 +1,108 @@
+autoware_system_design_format: 0.3.1
+
+# module information
+# NDT pose estimation with gyro odometry twist, fused by the EKF.
+name: Localization.module
+
+instances:
+  - name: pose_estimator
+    entity: PoseEstimatorNdt.module
+  - name: twist_estimator
+    entity: TwistEstimatorGyroOdometer.module
+  - name: pose_twist_fusion_filter
+    entity: PoseTwistFusionFilter.module
+  - name: util
+    entity: LocalizationUtil.module
+  - name: localization_error_monitor
+    entity: LocalizationErrorMonitor.node
+
+# interfaces
+subscribers:
+  - name: lanelet_map
+  - name: pointcloud_map
+  - name: pointcloud
+  - name: imu
+  - name: twist
+  - name: gnss_pose_with_covariance
+
+publishers:
+  - name: kinematic_state
+  - name: pose_with_covariance
+  - name: acceleration
+  - name: initialization_state
+  - name: initialpose3d
+  - name: pose_estimator/pose_with_covariance
+
+servers:
+  - name: initialize
+
+clients:
+  - name: get_differential_pointcloud_map
+  - name: get_partial_pointcloud_map
+
+connections:
+  # util
+  - - subscriber.pointcloud
+    - util.subscriber.pointcloud
+  - - subscriber.twist
+    - util.subscriber.stop_check_twist
+  - - subscriber.gnss_pose_with_covariance
+    - util.subscriber.gnss_pose_cov
+  - - subscriber.pointcloud_map
+    - util.subscriber.pointcloud_map
+  - - subscriber.lanelet_map
+    - util.subscriber.vector_map
+
+  # pose_estimator
+  - - util.publisher.downsample/pointcloud
+    - pose_estimator.subscriber.pointcloud
+  - - pose_twist_fusion_filter.publisher.biased_pose_with_covariance
+    - pose_estimator.subscriber.initial_pose_with_covariance
+  - - subscriber.gnss_pose_with_covariance
+    - pose_estimator.subscriber.regularization_pose_with_covariance
+
+  # twist_estimator
+  - - subscriber.twist
+    - twist_estimator.subscriber.vehicle_twist_with_covariance
+  - - subscriber.imu
+    - twist_estimator.subscriber.imu
+
+  # pose_twist_fusion_filter
+  - - pose_estimator.publisher.pose_with_covariance
+    - pose_twist_fusion_filter.subscriber.pose_with_covariance
+  - - twist_estimator.publisher.twist_with_covariance
+    - pose_twist_fusion_filter.subscriber.twist_with_covariance
+  - - util.publisher.pose_reset
+    - pose_twist_fusion_filter.subscriber.initialpose
+
+  # localization_error_monitor
+  - - pose_twist_fusion_filter.publisher.filtered_kinematic_state
+    - localization_error_monitor.subscriber.odom
+
+  # initialization services
+  - - util.client.ndt_align
+    - pose_estimator.server.ndt_align_srv
+  - - util.client.ndt_trigger_node
+    - pose_estimator.server.trigger_node
+  - - util.client.ekf_trigger_node
+    - pose_twist_fusion_filter.server.trigger_node
+
+  # outputs
+  - - pose_twist_fusion_filter.publisher.filtered_kinematic_state
+    - publisher.kinematic_state
+  - - pose_twist_fusion_filter.publisher.pose_with_covariance
+    - publisher.pose_with_covariance
+  - - pose_twist_fusion_filter.publisher.acceleration
+    - publisher.acceleration
+  - - util.publisher.initialization_state
+    - publisher.initialization_state
+  - - util.publisher.pose_reset
+    - publisher.initialpose3d
+  - - pose_estimator.publisher.pose_with_covariance
+    - publisher.pose_estimator/pose_with_covariance
+  - - util.server.initialize
+    - server.initialize
+  - - pose_estimator.client.map_loader
+    - client.get_differential_pointcloud_map
+  - - util.client.partial_map_load
+    - client.get_partial_pointcloud_map

--- a/autoware_sample_designs/design/module/localization/pose_twist_estimator/PoseEstimatorNdt.module.yaml
+++ b/autoware_sample_designs/design/module/localization/pose_twist_estimator/PoseEstimatorNdt.module.yaml
@@ -1,0 +1,44 @@
+autoware_system_design_format: 0.3.1
+
+# module information
+name: PoseEstimatorNdt.module
+
+instances:
+  - name: ndt_scan_matcher
+    entity: NdtScanMatcher.node
+
+# interfaces
+subscribers:
+  - name: pointcloud
+  - name: initial_pose_with_covariance
+  - name: regularization_pose_with_covariance
+
+publishers:
+  - name: pose
+  - name: pose_with_covariance
+
+servers:
+  - name: trigger_node
+  - name: ndt_align_srv
+
+clients:
+  - name: map_loader
+
+connections:
+  - - subscriber.pointcloud
+    - ndt_scan_matcher.subscriber.pointcloud
+  - - subscriber.initial_pose_with_covariance
+    - ndt_scan_matcher.subscriber.initial_pose_with_covariance
+  - - subscriber.regularization_pose_with_covariance
+    - ndt_scan_matcher.subscriber.regularization_pose_with_covariance
+
+  - - ndt_scan_matcher.publisher.pose
+    - publisher.pose
+  - - ndt_scan_matcher.publisher.pose_with_covariance
+    - publisher.pose_with_covariance
+  - - ndt_scan_matcher.server.trigger_node
+    - server.trigger_node
+  - - ndt_scan_matcher.server.ndt_align
+    - server.ndt_align_srv
+  - - ndt_scan_matcher.client.map_loader
+    - client.map_loader

--- a/autoware_sample_designs/design/module/localization/pose_twist_estimator/TwistEstimatorGyroOdometer.module.yaml
+++ b/autoware_sample_designs/design/module/localization/pose_twist_estimator/TwistEstimatorGyroOdometer.module.yaml
@@ -1,0 +1,28 @@
+autoware_system_design_format: 0.3.1
+
+# module information
+name: TwistEstimatorGyroOdometer.module
+
+instances:
+  - name: gyro_odometer
+    entity: GyroOdometer.node
+
+# interfaces
+subscribers:
+  - name: vehicle_twist_with_covariance
+  - name: imu
+
+publishers:
+  - name: twist_with_covariance
+  - name: twist_with_covariance_raw
+
+connections:
+  - - subscriber.vehicle_twist_with_covariance
+    - gyro_odometer.subscriber.vehicle_twist_with_covariance
+  - - subscriber.imu
+    - gyro_odometer.subscriber.imu
+
+  - - gyro_odometer.publisher.twist_with_covariance
+    - publisher.twist_with_covariance
+  - - gyro_odometer.publisher.twist_with_covariance_raw
+    - publisher.twist_with_covariance_raw

--- a/autoware_sample_designs/design/module/localization/pose_twist_fusion_filter/PoseTwistFusionFilter.module.yaml
+++ b/autoware_sample_designs/design/module/localization/pose_twist_fusion_filter/PoseTwistFusionFilter.module.yaml
@@ -1,0 +1,74 @@
+autoware_system_design_format: 0.3.1
+
+# module information
+name: PoseTwistFusionFilter.module
+
+instances:
+  - name: ekf_localizer
+    entity: EkfLocalizer.node
+  - name: stop_filter
+    entity: StopFilter.node
+  - name: twist2accel
+    entity: Twist2Accel.node
+  - name: pose_instability_detector
+    entity: PoseInstabilityDetector.node
+
+# interfaces
+subscribers:
+  - name: pose_with_covariance
+  - name: twist_with_covariance
+  - name: initialpose
+
+publishers:
+  # ekf estimate
+  - name: kinematic_state
+  - name: pose
+  - name: pose_with_covariance
+  - name: biased_pose_with_covariance
+  # stop-filtered estimate
+  - name: filtered_kinematic_state
+  - name: acceleration
+
+servers:
+  - name: trigger_node
+
+connections:
+  # ekf_localizer
+  - - subscriber.pose_with_covariance
+    - ekf_localizer.subscriber.pose_with_covariance
+  - - subscriber.twist_with_covariance
+    - ekf_localizer.subscriber.twist_with_covariance
+  - - subscriber.initialpose
+    - ekf_localizer.subscriber.initialpose
+
+  # stop_filter
+  - - ekf_localizer.publisher.odom
+    - stop_filter.subscriber.odom
+
+  # twist2accel
+  - - stop_filter.publisher.odom
+    - twist2accel.subscriber.odom
+  - - subscriber.twist_with_covariance
+    - twist2accel.subscriber.twist
+
+  # pose_instability_detector
+  - - stop_filter.publisher.odom
+    - pose_instability_detector.subscriber.odometry
+  - - subscriber.twist_with_covariance
+    - pose_instability_detector.subscriber.twist
+
+  # outputs
+  - - ekf_localizer.publisher.odom
+    - publisher.kinematic_state
+  - - ekf_localizer.publisher.pose
+    - publisher.pose
+  - - ekf_localizer.publisher.pose_with_covariance
+    - publisher.pose_with_covariance
+  - - ekf_localizer.publisher.biased_pose_with_covariance
+    - publisher.biased_pose_with_covariance
+  - - stop_filter.publisher.odom
+    - publisher.filtered_kinematic_state
+  - - twist2accel.publisher.accel
+    - publisher.acceleration
+  - - ekf_localizer.server.trigger_node
+    - server.trigger_node

--- a/autoware_sample_designs/design/module/localization/util/LocalizationUtil.module.yaml
+++ b/autoware_sample_designs/design/module/localization/util/LocalizationUtil.module.yaml
@@ -1,0 +1,82 @@
+autoware_system_design_format: 0.3.1
+
+# module information
+name: LocalizationUtil.module
+
+instances:
+  - name: pose_initializer
+    entity: PoseInitializer.node
+  - name: automatic_pose_initializer
+    entity: AutomaticPoseInitializer.node
+  # ndt input pointcloud downsampling
+  - name: crop_box_filter_measurement_range
+    entity: CropBoxFilter.node
+  - name: voxel_grid_downsample_filter
+    entity: VoxelGridDownsampleFilter.node
+  - name: random_downsample_filter
+    entity: RandomDownsampleFilter.node
+
+# interfaces
+subscribers:
+  - name: pointcloud
+  - name: stop_check_twist
+  - name: gnss_pose_cov
+  - name: pointcloud_map
+  - name: vector_map
+
+publishers:
+  - name: measurement_range/pointcloud
+  - name: voxel_grid_downsample/pointcloud
+  - name: downsample/pointcloud
+  - name: pose_reset
+  - name: initialization_state
+
+servers:
+  - name: initialize
+
+clients:
+  - name: ndt_align
+  - name: ekf_trigger_node
+  - name: ndt_trigger_node
+  - name: partial_map_load
+
+connections:
+  # pose_initializer
+  - - subscriber.stop_check_twist
+    - pose_initializer.subscriber.stop_check_twist
+  - - subscriber.gnss_pose_cov
+    - pose_initializer.subscriber.gnss_pose_cov
+  - - subscriber.pointcloud_map
+    - pose_initializer.subscriber.pointcloud_map
+  - - subscriber.vector_map
+    - pose_initializer.subscriber.vector_map
+
+  # pointcloud downsampling chain
+  - - subscriber.pointcloud
+    - crop_box_filter_measurement_range.subscriber.input
+  - - crop_box_filter_measurement_range.publisher.output
+    - voxel_grid_downsample_filter.subscriber.input
+  - - voxel_grid_downsample_filter.publisher.output
+    - random_downsample_filter.subscriber.input
+
+  # outputs
+  - - crop_box_filter_measurement_range.publisher.output
+    - publisher.measurement_range/pointcloud
+  - - voxel_grid_downsample_filter.publisher.output
+    - publisher.voxel_grid_downsample/pointcloud
+  - - random_downsample_filter.publisher.output
+    - publisher.downsample/pointcloud
+  - - pose_initializer.publisher.pose_reset
+    - publisher.pose_reset
+  - - pose_initializer.publisher.pub_state
+    - publisher.initialization_state
+  - - pose_initializer.server.initialize
+    - server.initialize
+  - - pose_initializer.client.ndt_align
+    - client.ndt_align
+  - - pose_initializer.client.ekf_trigger_node
+    - client.ekf_trigger_node
+  - - pose_initializer.client.ndt_trigger_node
+    - client.ndt_trigger_node
+  - - pose_initializer.client.partial_map_load
+    - client.partial_map_load

--- a/autoware_sample_designs/design/parameter_set/e2e_simulation.parameter_set.yaml
+++ b/autoware_sample_designs/design/parameter_set/e2e_simulation.parameter_set.yaml
@@ -7,11 +7,11 @@ parameters:
     param_values:
       - name: use_sim_time
         value: true
-  - node: /localization
+  - node: /localization/util/pose_initializer
     param_files: []
     param_values:
-      - name: system_run_mode
-        value: online
+      - name: stop_check_enabled
+        value: true
   - node: /global_parameter_loader
     param_files: []
     param_values:

--- a/autoware_sample_designs/design/parameter_set/logging_simulation.parameter_set.yaml
+++ b/autoware_sample_designs/design/parameter_set/logging_simulation.parameter_set.yaml
@@ -7,11 +7,11 @@ parameters:
     param_values:
       - name: use_sim_time
         value: true
-  - node: /localization
+  - node: /localization/util/pose_initializer
     param_files: []
     param_values:
-      - name: system_run_mode
-        value: logging_simulation
+      - name: stop_check_enabled
+        value: false
   - node: /global_parameter_loader
     param_files: []
     param_values:

--- a/autoware_sample_designs/design/parameter_set/universe_localization.parameter_set.yaml
+++ b/autoware_sample_designs/design/parameter_set/universe_localization.parameter_set.yaml
@@ -1,0 +1,53 @@
+autoware_system_design_format: 0.3.0
+
+name: universe_localization.parameter_set
+parameters:
+  - node: /localization/pose_estimator/ndt_scan_matcher
+    param_files:
+      - param_file: $(find-pkg-share autoware_launch)/config/localization/ndt_scan_matcher/ndt_scan_matcher.param.yaml
+  - node: /localization/pose_twist_fusion_filter/ekf_localizer
+    param_files:
+      - param_file: $(find-pkg-share autoware_launch)/config/localization/ekf_localizer.param.yaml
+  - node: /localization/pose_twist_fusion_filter/stop_filter
+    param_files:
+      - param_path: $(find-pkg-share autoware_launch)/config/localization/stop_filter.param.yaml
+  - node: /localization/pose_twist_fusion_filter/twist2accel
+    param_files:
+      - param_file: $(find-pkg-share autoware_launch)/config/localization/twist2accel.param.yaml
+  - node: /localization/pose_twist_fusion_filter/pose_instability_detector
+    param_files:
+      - pose_instability_detector_param: $(find-pkg-share autoware_launch)/config/localization/pose_instability_detector.param.yaml
+  - node: /localization/localization_error_monitor
+    param_files:
+      - localization_error_monitor_param: $(find-pkg-share autoware_launch)/config/localization/localization_error_monitor.param.yaml
+  - node: /localization/util/pose_initializer
+    param_files:
+      - config_file: $(find-pkg-share autoware_launch)/config/localization/pose_initializer.param.yaml
+    param_values:
+      - name: user_defined_initial_pose.enable
+        value: false
+      - name: user_defined_initial_pose.pose
+        value: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]
+      - name: ndt_enabled
+        value: true
+      - name: gnss_enabled
+        value: true
+      - name: ekf_enabled
+        value: true
+      - name: yabloc_enabled
+        value: false
+      - name: stop_check_enabled
+        value: true
+      - name: map_height_fitter.map_loader_name
+        value: /map/pointcloud_map_loader
+      - name: map_height_fitter.target
+        value: pointcloud_map
+  - node: /localization/util/crop_box_filter_measurement_range
+    param_files:
+      - crop_box_filter_param_file: $(find-pkg-share autoware_launch)/config/localization/ndt_scan_matcher/pointcloud_preprocessor/crop_box_filter_measurement_range.param.yaml
+  - node: /localization/util/voxel_grid_downsample_filter
+    param_files:
+      - voxel_grid_downsample_filter_param_file: $(find-pkg-share autoware_launch)/config/localization/ndt_scan_matcher/pointcloud_preprocessor/voxel_grid_filter.param.yaml
+  - node: /localization/util/random_downsample_filter
+    param_files:
+      - param_file: $(find-pkg-share autoware_launch)/config/localization/ndt_scan_matcher/pointcloud_preprocessor/random_downsample_filter.param.yaml

--- a/autoware_sample_designs/design/system/AutowareSample.system.yaml
+++ b/autoware_sample_designs/design/system/AutowareSample.system.yaml
@@ -70,8 +70,9 @@ components:
     entity: Tier4MapWrapper.node
     compute_unit: main_ecu
   - name: localization
-    entity: Tier4LocalizationWrapper.node
+    entity: Localization.module
     compute_unit: main_ecu
+    parameter_set: universe_localization.parameter_set
 
   # PERCEPTION
   - name: perception
@@ -105,6 +106,9 @@ node_groups:
     type: ros2_component_container_mt_ipc
     nodes:
       - /sensing/lidar/concatenate_and_time_sync
+      - /localization/util/crop_box_filter_measurement_range
+      - /localization/util/voxel_grid_downsample_filter
+      - /localization/util/random_downsample_filter
       - /perception/occupancy_grid_map/occupancy_grid_map_node
   - name: lidar_top_container
     type: ros2_component_container_mt_ipc
@@ -187,8 +191,10 @@ connections:
     - localization.subscriber.twist
   - - sensing.publisher.gnss/pose_with_covariance
     - localization.subscriber.gnss_pose_with_covariance
-  - - api.publisher.localization/initialization_state
-    - localization.subscriber.initialization_state
+  - - map.server.get_differential_pointcloud_map
+    - localization.client.get_differential_pointcloud_map
+  - - map.server.get_partial_pointcloud_map
+    - localization.client.get_partial_pointcloud_map
 
   - - planning.publisher.mission_planning/route
     - perception.subscriber.route
@@ -280,6 +286,8 @@ connections:
     - api.client.routing/clear_route
 
 remaps:
+  - source: localization.publisher.initialpose3d
+    topic: /initialpose3d
   - source: control.publisher.engage
     topic: /autoware/engage
   - source: control.publisher.is_autonomous_available
@@ -375,6 +383,9 @@ E2ESimulation:
         type: ros2_component_container_mt_ipc
         nodes:
           - /sensing/lidar/concatenate_and_time_sync
+          - /localization/util/crop_box_filter_measurement_range
+          - /localization/util/voxel_grid_downsample_filter
+          - /localization/util/random_downsample_filter
           - /perception/obstacle_segmentation/crop_box_filter
           - /perception/obstacle_segmentation/common_ground_filter
           - /perception/obstacle_segmentation/pointcloud_map_filter/voxel_grid_downsample_filter


### PR DESCRIPTION
## Description

Part of #1939. `AutowareSample.system.yaml` still ran localization as `Tier4LocalizationWrapper.node`, a designer node wrapping the whole `tier4_localization_launch/launch/localization.launch.xml` with ~25 `*_param_path` values. Planning (#1967) and control (#1962 / #1965) already moved to `*.module.yaml` trees; this PR does the same for localization.

<img width="3180" height="1225" alt="Screenshot from 2026-08-28 16-50-30" src="https://github.com/user-attachments/assets/4a4bdc97-d8df-4257-ac0d-82c25ed05108" />



### Modules — `autoware_sample_designs/design/module/localization/`

```
Localization.module.yaml                 # NDT + gyro_odom
pose_twist_estimator/
  PoseEstimatorNdt.module.yaml
  TwistEstimatorGyroOdometer.module.yaml
pose_twist_fusion_filter/PoseTwistFusionFilter.module.yaml   # ekf, stop_filter, twist2accel, pose_instability_detector
util/LocalizationUtil.module.yaml        # pose_initializer, automatic_pose_initializer, 3 NDT preprocessing filters
```

Instance names equal the launch namespaces, so every node keeps its path (`/localization/pose_estimator/ndt_scan_matcher`, `/localization/util/pose_initializer`, …). The module's external interface keeps the wrapper's port names, so the system connections are untouched apart from:

- dropped `api.publisher.localization/initialization_state → localization.subscriber.initialization_state` (the only consumer, `AutomaticPoseInitializer`, is `global:` and the topic is published inside the module — it was a no-op),
- new `map.server.get_{differential,partial}_pointcloud_map → localization.client.*` connections (NDT map update and map-height fitting),
- `remaps: localization.publisher.initialpose3d → /initialpose3d` (as PlanningSimulation already pins).

### Parameters

- `universe_localization.parameter_set.yaml`: one entry per node path, pointing at `autoware_launch/config/localization/…` (paths unchanged until the `tier4_localization_launch → autoware_localization_launch` rename PR). `gyro_odometer` has no file there (the wrapper used the package default too).
- `e2e_simulation` / `logging_simulation` parameter sets: `system_run_mode` becomes the `stop_check_enabled` override on `/localization/util/pose_initializer` — that is all `system_run_mode` ever did.
- `node_groups.pointcloud_container` gains the three NDT preprocessing filters (Runtime and E2ESimulation).

`Tier4LocalizationWrapper.node.yaml` stays in place unreferenced, as with the planning/control precedent.

## Related links

- #1939 (tracking)
- Depends on autowarefoundation/autoware_core#1409 (new node designs: NdtScanMatcher, EkfLocalizer, GyroOdometer, StopFilter, Twist2Accel; PoseInitializer ports)

## How was this PR tested?

- `pre-commit run` on all changed files (`lint-system-design-format` passes).
- Baseline export on `main` vs this branch (`colcon build --packages-select autoware_sample_designs`): the Runtime / E2ESimulation / LoggingSimulation `localization.launch.xml` exports were compared with a `launch` monkeypatch dump (`Node.execute` / `LoadComposableNodes.execute` recorded, tmp param files inlined) — the wrapper→`tier4_localization_launch` graph vs the generated one.
  - Node set identical: ndt_scan_matcher, gyro_odometer, ekf_localizer, stop_filter, twist2accel, pose_instability_detector, localization_error_monitor, pose_initializer, automatic_pose_initializer + the 3 filters loaded into `/pointcloud_container`.
  - All cross-node topics and services identical (`/localization/util/downsample/pointcloud`, `/localization/pose_estimator/pose_with_covariance`, `/localization/pose_twist_fusion_filter/{kinematic_state,pose,biased_pose_with_covariance,trigger_node}`, `/localization/kinematic_state`, `/localization/acceleration`, `/initialpose3d`, `/localization/pose_estimator/{trigger_node,ndt_align_srv}`, `/map/get_*_pointcloud_map`, …). Mode overrides come out as before (`stop_check_enabled` True/False, `use_sim_time`).
  - Expected deltas only: internal debug/unused outputs get designer-style names (`ekf_localizer/{twist,biased_pose,processing_time_ms}`, `gyro_odometer/twist{,_raw}`, `pose_instability_detector/diff_pose`, `stop_filter/stop_flag`, `localization_error_monitor/ellipse_marker`); `automatic_pose_initializer` runs at `/localization/util/` instead of `/localization/util/default_adapi/helpers/`; the `yabloc_align` client is unremapped (it is never created with `yabloc_enabled: false`); no `LD_PRELOAD` env from `agnocast_env.launch.xml` (same as every other composed node).
- Designer warnings: 21 on `main` → 33 here. All 12 new ones are `Undefined variable: $(var user_defined_initial_pose/{enable,pose})` from `pose_initializer.param.yaml` (pre-existing in the PlanningSimulation export; the file itself uses `$(var)`). Values are still correct in the export because the parameter sets pin `user_defined_initial_pose.enable/pose`. Fix belongs in `autoware_core`'s config (literal defaults), noted on the core PR.
- Not run here: AWSIM E2E (`/localization/kinematic_state`, `/localization/initialization_state`, `is_autonomous_mode_available`).

## Interface changes

None for ROS topics/services consumed outside localization. Internal debug topic names change as listed above.

## Effects on system behavior

None intended. `pose_initializer` no longer receives `system_run_mode`; `stop_check_enabled` is set directly per mode.



Scope note: only the default NDT + gyro-odometry composition is covered; YabLoc / Eagleye / AR-tag / lidar-marker compositions stay launch-only for now.
