### PR TITLE
fix(autoware_perception_config): add missing min_cluster_size_m to label_based_euclidean_cluster

### DIFF
--- a/autoware_universe_launch/autoware_perception_config/config/object_recognition/detection/euclidean_cluster/label_based_euclidean_cluster.param.yaml
+++ b/autoware_universe_launch/autoware_perception_config/config/object_recognition/detection/euclidean_cluster/label_based_euclidean_cluster.param.yaml
@@ -21,6 +21,15 @@
         large_cluster_max_points_per_voxel: 30
         max_voxels_per_cluster: 200
         min_cluster_size_m: 0.0
+      motorcycle:
+        tolerance_m: 0.4
+        voxel_leaf_size_m: 0.15
+        min_points_per_voxel: 1
+        min_points_per_cluster: 5
+        large_cluster_voxel_count_threshold: 5
+        large_cluster_max_points_per_voxel: 50
+        max_voxels_per_cluster: 300
+        min_cluster_size_m: 0.0
       bicycle:
         tolerance_m: 0.4
         voxel_leaf_size_m: 0.15
@@ -29,6 +38,15 @@
         large_cluster_voxel_count_threshold: 5
         large_cluster_max_points_per_voxel: 50
         max_voxels_per_cluster: 300
+        min_cluster_size_m: 0.0
+      animal:
+        tolerance_m: 0.3
+        voxel_leaf_size_m: 0.1
+        min_points_per_voxel: 1
+        min_points_per_cluster: 3
+        large_cluster_voxel_count_threshold: 5
+        large_cluster_max_points_per_voxel: 30
+        max_voxels_per_cluster: 200
         min_cluster_size_m: 0.0
       hazard:
         tolerance_m: 0.3
@@ -42,8 +60,8 @@
 
     # Post-clustering merge for confusable label pairs. Omit this block to disable.
     confusable_label_groups:
-      truck_trailer:
-        labels: ["truck", "trailer"]
+      truck_trailer_car:
+        labels: ["truck", "trailer", "car"]
         cross_label_tolerance_m: 0.5
         max_merged_size_m: 25.0
 

--- a/autoware_universe_launch/autoware_perception_config/config/object_recognition/detection/euclidean_cluster/label_based_euclidean_cluster.param.yaml
+++ b/autoware_universe_launch/autoware_perception_config/config/object_recognition/detection/euclidean_cluster/label_based_euclidean_cluster.param.yaml
@@ -20,6 +20,7 @@
         large_cluster_voxel_count_threshold: 5
         large_cluster_max_points_per_voxel: 30
         max_voxels_per_cluster: 200
+        min_cluster_size_m: 0.0
       bicycle:
         tolerance_m: 0.4
         voxel_leaf_size_m: 0.15
@@ -28,6 +29,7 @@
         large_cluster_voxel_count_threshold: 5
         large_cluster_max_points_per_voxel: 50
         max_voxels_per_cluster: 300
+        min_cluster_size_m: 0.0
       hazard:
         tolerance_m: 0.3
         voxel_leaf_size_m: 0.1
@@ -36,6 +38,7 @@
         large_cluster_voxel_count_threshold: 5
         large_cluster_max_points_per_voxel: 30
         max_voxels_per_cluster: 200
+        min_cluster_size_m: 0.0
 
     # Post-clustering merge for confusable label pairs. Omit this block to disable.
     confusable_label_groups:
@@ -46,6 +49,8 @@
 
     # Point filtering by semantic confidence
     min_probability: 0.3
+    # Minimum XY bounding-circle diameter for a clustered object (0 disables filtering).
+    min_cluster_size_m: 1.5
 
     # Semantic label selection and mapping
     # YAML declaration order is treated as the input class_id order.


### PR DESCRIPTION
## Description
- To fix missing parameter `min_cluster_size_m` added by https://github.com/autowarefoundation/autoware_universe/pull/13248
- Terminate called after throwing an instance of 'rclcpp::ParameterTypeException'
    what():  expected [double] got [not set]
When execute 'logging_simulator' with `use_semantic_segmentation_ptv3:=true`
```
ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/data/maps/ vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit use_semantic_segmentation_ptv3:=true
```
## How was this PR tested?
- Confirm with logging_simulator with `use_semantic_segmentation_ptv3:=true` as above and confirm autoware executed without error.

## Notes for reviewers

None.

## Effects on system behavior

None.
