### PR TITLE
refactor(autoware_sample_designs): compose the map component from a design module

### DIFF
--- a/autoware_sample_designs/design/module/map/Map.module.yaml
+++ b/autoware_sample_designs/design/module/map/Map.module.yaml
@@ -1,0 +1,69 @@
+autoware_system_design_format: 0.3.1
+
+# module information
+# Map loading: pointcloud and Lanelet2 maps, projector info, viewer TF and the map hash API.
+name: Map.module
+
+instances:
+  - name: pointcloud_map_loader
+    entity: PointcloudMapLoader.node
+  - name: lanelet2_map_loader
+    entity: Lanelet2MapLoader.node
+  - name: lanelet2_map_visualization
+    entity: Lanelet2MapVisualizer.node
+  - name: vector_map_tf_generator
+    entity: VectorMapTfGenerator.node
+  - name: map_hash_generator
+    entity: MapHashGenerator.node
+  - name: map_projection_loader
+    entity: MapProjectionLoader.node
+
+# interfaces
+subscribers: []
+
+publishers:
+  - name: pointcloud_map
+  - name: pointcloud_map_metadata
+  - name: vector_map
+  - name: vector_map_metadata
+  - name: vector_map_marker
+  - name: map_projector_info
+
+servers:
+  - name: get_partial_pointcloud_map
+  - name: get_differential_pointcloud_map
+  - name: get_selected_pointcloud_map
+  - name: get_selected_vector_map
+
+connections:
+  # projector info drives the lanelet2 map loading
+  - - map_projection_loader.publisher.map_projector_info
+    - lanelet2_map_loader.subscriber.map_projector_info
+
+  # vector map distribution inside the module
+  - - lanelet2_map_loader.publisher.lanelet2_map
+    - lanelet2_map_visualization.subscriber.lanelet2_map
+  - - lanelet2_map_loader.publisher.lanelet2_map
+    - vector_map_tf_generator.subscriber.vector_map
+
+  # outputs
+  - - pointcloud_map_loader.publisher.pointcloud_map
+    - publisher.pointcloud_map
+  - - pointcloud_map_loader.publisher.pointcloud_map_metadata
+    - publisher.pointcloud_map_metadata
+  - - lanelet2_map_loader.publisher.lanelet2_map
+    - publisher.vector_map
+  - - lanelet2_map_loader.publisher.lanelet2_map_metadata
+    - publisher.vector_map_metadata
+  - - lanelet2_map_visualization.publisher.lanelet2_map_marker
+    - publisher.vector_map_marker
+  - - map_projection_loader.publisher.map_projector_info
+    - publisher.map_projector_info
+  - - pointcloud_map_loader.server.get_partial_pcd_map
+    - server.get_partial_pointcloud_map
+  - - pointcloud_map_loader.server.get_differential_pcd_map
+    - server.get_differential_pointcloud_map
+  - - pointcloud_map_loader.server.get_selected_pcd_map
+    - server.get_selected_pointcloud_map
+  - - lanelet2_map_loader.server.get_selected_lanelet2_map
+    - server.get_selected_vector_map

--- a/autoware_sample_designs/design/module/map/Map.module.yaml
+++ b/autoware_sample_designs/design/module/map/Map.module.yaml
@@ -12,7 +12,7 @@ instances:
   - name: lanelet2_map_visualization
     entity: Lanelet2MapVisualization.node
   - name: vector_map_tf_generator
-    entity: VectorMapTfGenerator.node
+    entity: VectorMapTFGenerator.node
   - name: map_hash_generator
     entity: MapHashGenerator.node
   - name: map_projection_loader

--- a/autoware_sample_designs/design/module/map/Map.module.yaml
+++ b/autoware_sample_designs/design/module/map/Map.module.yaml
@@ -28,12 +28,14 @@ publishers:
   - name: vector_map_metadata
   - name: vector_map_marker
   - name: map_projector_info
+  - name: map_hash
 
 servers:
   - name: get_partial_pointcloud_map
   - name: get_differential_pointcloud_map
   - name: get_selected_pointcloud_map
   - name: get_selected_vector_map
+  - name: get_vector_map_xml
 
 connections:
   # projector info drives the lanelet2 map loading
@@ -59,6 +61,8 @@ connections:
     - publisher.vector_map_marker
   - - map_projection_loader.publisher.map_projector_info
     - publisher.map_projector_info
+  - - map_hash_generator.publisher.map_hash
+    - publisher.map_hash
   - - pointcloud_map_loader.server.get_partial_pcd_map
     - server.get_partial_pointcloud_map
   - - pointcloud_map_loader.server.get_differential_pcd_map
@@ -67,3 +71,5 @@ connections:
     - server.get_selected_pointcloud_map
   - - lanelet2_map_loader.server.get_selected_lanelet2_map
     - server.get_selected_vector_map
+  - - map_hash_generator.server.get_lanelet_xml
+    - server.get_vector_map_xml

--- a/autoware_sample_designs/design/module/map/Map.module.yaml
+++ b/autoware_sample_designs/design/module/map/Map.module.yaml
@@ -6,11 +6,11 @@ name: Map.module
 
 instances:
   - name: pointcloud_map_loader
-    entity: PointcloudMapLoader.node
+    entity: PointCloudMapLoader.node
   - name: lanelet2_map_loader
     entity: Lanelet2MapLoader.node
   - name: lanelet2_map_visualization
-    entity: Lanelet2MapVisualizer.node
+    entity: Lanelet2MapVisualization.node
   - name: vector_map_tf_generator
     entity: VectorMapTfGenerator.node
   - name: map_hash_generator

--- a/autoware_sample_designs/design/parameter_set/universe_map.parameter_set.yaml
+++ b/autoware_sample_designs/design/parameter_set/universe_map.parameter_set.yaml
@@ -1,0 +1,37 @@
+autoware_system_design_format: 0.3.0
+
+name: universe_map.parameter_set
+parameters:
+  - node: /map/pointcloud_map_loader
+    param_files:
+      - param_file: $(find-pkg-share autoware_launch)/config/map/pointcloud_map_loader.param.yaml
+    param_values:
+      - name: pcd_paths_or_directory
+        value: [$(var map_path)/$(var pointcloud_map_file)]
+      - name: pcd_metadata_path
+        value: $(var map_path)/pointcloud_map_metadata.yaml
+  - node: /map/lanelet2_map_loader
+    param_files:
+      - param_file: $(find-pkg-share autoware_launch)/config/map/lanelet2_map_loader.param.yaml
+    param_values:
+      - name: lanelet2_map_path
+        value: $(var map_path)/$(var lanelet2_map_file)
+      - name: lanelet2_map_metadata_path
+        value: $(var map_path)/lanelet2_map_metadata.yaml
+  - node: /map/map_projection_loader
+    param_files:
+      - param_file: $(find-pkg-share autoware_launch)/config/map/map_projection_loader.param.yaml
+    param_values:
+      - name: map_projector_info_path
+        value: $(var map_path)/map_projector_info.yaml
+      - name: lanelet2_map_path
+        value: $(var map_path)/$(var lanelet2_map_file)
+  - node: /map/vector_map_tf_generator
+    param_files:
+      - param_file: $(find-pkg-share autoware_launch)/config/map/map_tf_generator.param.yaml
+  - node: /map/map_hash_generator
+    param_values:
+      - name: lanelet2_map_path
+        value: $(var map_path)/$(var lanelet2_map_file)
+      - name: pointcloud_map_path
+        value: $(var map_path)/$(var pointcloud_map_file)

--- a/autoware_sample_designs/design/system/AutowareSample.system.yaml
+++ b/autoware_sample_designs/design/system/AutowareSample.system.yaml
@@ -287,6 +287,10 @@ connections:
 remaps:
   - source: localization.publisher.initialpose3d
     topic: /initialpose3d
+  - source: map.publisher.map_hash
+    topic: /api/autoware/get/map/info/hash
+  - source: map.server.get_vector_map_xml
+    topic: /api/autoware/get/map/lanelet/xml
   - source: control.publisher.is_autonomous_available
     topic: /system/operation_mode/state
   - source: control.publisher.external_emergency

--- a/autoware_sample_designs/design/system/AutowareSample.system.yaml
+++ b/autoware_sample_designs/design/system/AutowareSample.system.yaml
@@ -67,8 +67,9 @@ components:
 
   # MAP/LOCALIZATION
   - name: map
-    entity: Tier4MapWrapper.node
+    entity: Map.module
     compute_unit: main_ecu
+    parameter_set: universe_map.parameter_set
   - name: localization
     entity: Localization.module
     compute_unit: main_ecu


### PR DESCRIPTION
## Description

Part of #1939. `AutowareSample.system.yaml` still ran map as `Tier4MapWrapper.node`, a designer node wrapping the whole `tier4_map_launch/launch/map.launch.xml`. Sensing, perception, planning (#1967), control (#1962 / #1965) and localization (#1968) already moved (or are moving) to `*.module.yaml` trees; this PR does the same for map.

<img width="1389" height="770" alt="Screenshot from 2026-08-31 11-54-03" src="https://github.com/user-attachments/assets/91c84bfd-a900-489a-8bd2-4f865003e098" />


### Module — `autoware_sample_designs/design/module/map/Map.module.yaml`

One flat module with six instances, named after the launch node names so every node keeps its path:

```
/map/pointcloud_map_loader      PointCloudMapLoader.node   (autoware_map_loader)
/map/lanelet2_map_loader        Lanelet2MapLoader.node     (autoware_map_loader)
/map/lanelet2_map_visualization Lanelet2MapVisualization.node (autoware_lanelet2_map_visualizer)
/map/vector_map_tf_generator    VectorMapTfGenerator.node  (autoware_map_tf_generator)
/map/map_hash_generator         MapHashGenerator.node      (autoware_map_loader)
/map/map_projection_loader      MapProjectionLoader.node   (autoware_map_projection_loader)
```

The module keeps the wrapper's external ports (`vector_map`, `pointcloud_map`, `get_differential_pointcloud_map`, `get_partial_pointcloud_map`) and adds the remaining official interfaces as ports (`pointcloud_map_metadata`, `vector_map_metadata`, `vector_map_marker`, `map_projector_info`, `get_selected_pointcloud_map`, `get_selected_vector_map`), so the system connections are untouched.

### Parameters

`universe_map.parameter_set.yaml`: one entry per node path, pointing at `autoware_launch/config/map/…` (paths unchanged until the `tier4_map_launch → autoware_map_launch` migration), with the map file paths pinned as `$(var map_path)`-based `param_values` (`pcd_paths_or_directory`, `pcd_metadata_path`, `lanelet2_map_path`, `lanelet2_map_metadata_path`, `map_projector_info_path`, and the two `map_hash_generator` paths). The E2ESimulation `map_path` override resolves into the exported values as before.

`Tier4MapWrapper.node.yaml` stays in place unreferenced, as with the planning/control/localization precedent. The wrapper-only args `use_multithread` and `enable_selected_map_loading` were already dead (`map.launch.xml` never declared them) and have no counterpart.

## Related links

- #1939 (tracking)
- Depends on autowarefoundation/autoware_core#1413 (PointCloudMapLoader, Lanelet2MapLoader, MapHashGenerator, Lanelet2MapVisualizer, MapProjectionLoader node designs)
- Depends on autowarefoundation/autoware_universe#13297 (VectorMapTfGenerator node design)
- autowarefoundation/autoware_universe#13312 (CollisionDetector `operation_mode_state` remap target; clears the pre-existing `E_PORT_MISSING` on `control_checker` that the `autoware_sample_designs` build on current `main` reports as non-fatal stderr — not introduced by this PR)

## How was this PR tested?

- `pre-commit run` on all changed files (`lint-system-design-format` passes).
- Baseline export on `main` vs this branch (`colcon build --packages-select autoware_sample_designs`), all four modes:
  - Node set identical to `tier4_map_launch` (6 nodes), and all official topic/service names identical: `/map/vector_map`, `/map/pointcloud_map`, `/map/pointcloud_map_metadata`, `/map/vector_map_metadata`, `/map/vector_map_marker`, `/map/map_projector_info`, `/map/get_{partial,differential,selected}_pointcloud_map`, `/map/get_selected_vector_map`, `/api/autoware/get/map/info/hash`, `/api/autoware/get/map/lanelet/xml`, `/tf_static`. Parameter values identical per mode (E2ESimulation gets the nishishinjuku paths).
  - No other component's exported launcher changed (byte-identical outside `map/`), so the cross-component wiring is untouched.
  - Expected deltas only: `output` both→screen; no `LD_PRELOAD` env from `agnocast_env.launch.xml` (same as every other composed node); the debug-only, disabled-by-default downsampled map topic gets a designer-style name (`/map/pointcloud_map_loader/downsampled_pointcloud_map` instead of `/map/output/debug/downsampled_pointcloud_map`); the dead `output/lanelet2_map → vector_map` remap is gone (the loader publishes the absolute interface name).
- Designer warnings: +2 per mode (8 total), all `Undefined variable: $(var pointcloud_map_path|pointcloud_map_metadata_path)` from `autoware_launch/config/map/pointcloud_map_loader.param.yaml`, whose `{OVERRIDE}` lines use the `tier4_map_launch` arg names. The exported values are still correct (the parameter set pins them). Renaming those vars to the core names has to wait for the `tier4_map_launch` migration, since the classic launcher still consumes the file.
- Logging simulator, E2E simulator tested

## Interface changes

None for topics/services consumed outside map. The debug downsampled-map topic name changes as listed above.

## Effects on system behavior

None intended.


