### PR TITLE
fix(control, planning): connect the module inputs left without a source

### DIFF
--- a/autoware_sample_designs/design/module/sensing/SampleSensorKit.module.yaml
+++ b/autoware_sample_designs/design/module/sensing/SampleSensorKit.module.yaml
@@ -17,6 +17,7 @@ subscribers:
   - name: odometry
   - name: twist
   - name: pose_ndt
+  - name: map_projector_info
 
 publishers:
   - name: imu/imu_data
@@ -39,6 +40,8 @@ connections:
   - - imu.publisher.imu_data
     - publisher.imu/imu_data
   # GNSS
+  - - subscriber.map_projector_info
+    - gnss.subscriber.map_projector_info
   - - gnss.publisher.pose
     - publisher.gnss/pose
   - - gnss.publisher.pose_with_covariance

--- a/autoware_sample_designs/design/module/sensing/SampleSensorKitGnss.module.yaml
+++ b/autoware_sample_designs/design/module/sensing/SampleSensorKitGnss.module.yaml
@@ -10,6 +10,7 @@ instances:
 
 subscribers:
   - name: orientation
+  - name: map_projector_info
 publishers:
   - name: pose
   - name: pose_with_covariance
@@ -17,6 +18,8 @@ publishers:
 connections:
   - - subscriber.orientation
     - gnss_poser.subscriber.autoware_orientation
+  - - subscriber.map_projector_info
+    - gnss_poser.subscriber.map_projector_info
   - - ublox.publisher.nav_sat_fix
     - gnss_poser.subscriber.fix
   - - gnss_poser.publisher.gnss_pose

--- a/autoware_sample_designs/design/node/simulation/SampleAWSIM.node.yaml
+++ b/autoware_sample_designs/design/node/simulation/SampleAWSIM.node.yaml
@@ -65,6 +65,10 @@ publishers:
   - name: vehicle/status/velocity_status
     message_type: autoware_vehicle_msgs/msg/VelocityReport
 
+servers:
+  - name: control/control_mode_request
+    message_type: autoware_vehicle_msgs/srv/ControlModeCommand
+
 # parameters
 param_values: []
 

--- a/autoware_sample_designs/design/system/AutowareSample.system.yaml
+++ b/autoware_sample_designs/design/system/AutowareSample.system.yaml
@@ -91,6 +91,12 @@ components:
     compute_unit: main_ecu
     parameter_set: universe_control.parameter_set
 
+  # VEHICLE
+  - name: vehicle
+    entity: SampleSystemVehicleWrapper.node
+    path: /
+    compute_unit: main_ecu
+
   # SYSTEM
   - name: system
     entity: Tier4SystemWrapper.node
@@ -284,6 +290,42 @@ connections:
   - - system.publisher.emergency/gear_cmd
     - control.subscriber.emergency_gear_cmd
 
+  - - control.publisher.command/control_cmd
+    - vehicle.subscriber.control/command/control_cmd
+  - - control.publisher.command/emergency_cmd
+    - vehicle.subscriber.control/command/emergency_cmd
+  - - control.publisher.command/gear_cmd
+    - vehicle.subscriber.control/command/gear_cmd
+  - - control.publisher.command/hazard_lights_cmd
+    - vehicle.subscriber.control/command/hazard_lights_cmd
+  - - control.publisher.command/turn_indicators_cmd
+    - vehicle.subscriber.control/command/turn_indicators_cmd
+  - - vehicle.server.control/control_mode_request
+    - control.client.control_mode_request
+
+  - - vehicle.publisher.vehicle/status/control_mode
+    - control.subscriber.control_mode_report
+  - - vehicle.publisher.vehicle/status/control_mode
+    - system.subscriber.control_mode
+  - - vehicle.publisher.vehicle/status/gear_status
+    - control.subscriber.gear_status
+  - - vehicle.publisher.vehicle/status/gear_status
+    - api.subscriber.vehicle/status/gear_status
+  - - vehicle.publisher.vehicle/status/hazard_lights_status
+    - api.subscriber.vehicle/status/hazard_lights_status
+  - - vehicle.publisher.vehicle/status/steering_status
+    - control.subscriber.steering_status
+  - - vehicle.publisher.vehicle/status/steering_status
+    - planning.subscriber.steering_status
+  - - vehicle.publisher.vehicle/status/steering_status
+    - api.subscriber.vehicle/status/steering_status
+  - - vehicle.publisher.vehicle/status/turn_indicators_status
+    - api.subscriber.vehicle/status/turn_indicators_status
+  - - vehicle.publisher.vehicle/status/velocity_status
+    - control.subscriber.velocity_status
+  - - vehicle.publisher.vehicle/status/velocity_status
+    - sensing.subscriber.velocity_status
+
   - - planning.server.clear_route
     - api.client.routing/clear_route
 
@@ -329,6 +371,9 @@ remaps:
 
 # mode configurations
 LoggingSimulation:
+  remove:
+    components:
+      - name: vehicle
   override:
     parameter_sets:
       - logging_simulation.parameter_set
@@ -476,6 +521,8 @@ E2ESimulation:
         topic: /control/control_mode_request
 
   remove:
+    components:
+      - name: vehicle
     connections:
       - - map.publisher.map_projector_info
         - sensing.subscriber.map_projector_info
@@ -490,6 +537,7 @@ PlanningSimulation:
       - name: sensing
       - name: perception
       - name: localization
+      - name: vehicle
     node_groups:
       - name: pointcloud_container
   override:

--- a/autoware_sample_designs/design/system/AutowareSample.system.yaml
+++ b/autoware_sample_designs/design/system/AutowareSample.system.yaml
@@ -262,6 +262,24 @@ connections:
     - control.subscriber.vector_map
   - - perception.publisher.object_recognition/objects
     - control.subscriber.objects
+  - - planning.publisher.planning_factors/blind_spot
+    - control.subscriber.blind_spot
+  - - planning.publisher.planning_factors/crosswalk
+    - control.subscriber.crosswalk
+  - - planning.publisher.planning_factors/detection_area
+    - control.subscriber.detection_area
+  - - planning.publisher.planning_factors/intersection
+    - control.subscriber.intersection
+  - - planning.publisher.planning_factors/no_stopping_area
+    - control.subscriber.no_stopping_area
+  - - planning.publisher.planning_factors/stop_line
+    - control.subscriber.stop_line
+  - - planning.publisher.planning_factors/traffic_light
+    - control.subscriber.traffic_light
+  - - planning.publisher.planning_factors/virtual_traffic_light
+    - control.subscriber.virtual_traffic_light
+  - - planning.publisher.planning_factors/walkway
+    - control.subscriber.walkway
   - - perception.publisher.obstacle_segmentation/pointcloud
     - control.subscriber.pointcloud
   - - sensing.publisher.imu/imu_data

--- a/autoware_sample_designs/design/system/AutowareSample.system.yaml
+++ b/autoware_sample_designs/design/system/AutowareSample.system.yaml
@@ -176,6 +176,8 @@ connections:
     - perception.subscriber.concatenated_pointcloud
   - - map.publisher.vector_map
     - perception.subscriber.vector_map
+  - - map.publisher.map_projector_info
+    - sensing.subscriber.map_projector_info
 
   - - map.publisher.vector_map
     - localization.subscriber.lanelet_map
@@ -277,6 +279,8 @@ connections:
     - control.subscriber.emergency_turn_indicators_cmd
   - - system.publisher.emergency/hazard_lights_cmd
     - control.subscriber.emergency_hazard_lights_cmd
+  - - system.publisher.emergency/hazard_lights_cmd
+    - planning.subscriber.system_hazard_lights_cmd
   - - system.publisher.emergency/gear_cmd
     - control.subscriber.emergency_gear_cmd
 
@@ -420,6 +424,10 @@ E2ESimulation:
         - control.subscriber.velocity_status
       - - awsim.publisher.vehicle/status/steering_status
         - control.subscriber.steering_status
+      - - awsim.publisher.vehicle/status/steering_status
+        - planning.subscriber.steering_status
+      - - awsim.server.control/control_mode_request
+        - control.client.control_mode_request
       - - awsim.publisher.vehicle/status/gear_status
         - control.subscriber.gear_status
       - - awsim.publisher.vehicle/status/control_mode
@@ -464,9 +472,13 @@ E2ESimulation:
         topic: /vehicle/status/turn_indicators_status
       - source: awsim.publisher.vehicle/status/velocity_status
         topic: /vehicle/status/velocity_status
+      - source: awsim.server.control/control_mode_request
+        topic: /control/control_mode_request
 
   remove:
     connections:
+      - - map.publisher.map_projector_info
+        - sensing.subscriber.map_projector_info
       - - sensing.publisher.gnss
         - localization.subscriber.gnss_pose_with_covariance
       - - sensing.publisher.gnss/pose_with_covariance
@@ -545,6 +557,10 @@ PlanningSimulation:
         - vehicle.subscriber.steering
       - - simulator.publisher.vehicle/status/steering_status
         - control.subscriber.steering_status
+      - - simulator.publisher.vehicle/status/steering_status
+        - planning.subscriber.steering_status
+      - - simulator.server.control/control_mode_request
+        - control.client.control_mode_request
       - - simulator.publisher.vehicle/status/actuation_status
         - vehicle.subscriber.actuation_status
       - - system.publisher.operation_mode/state
@@ -615,7 +631,7 @@ PlanningSimulation:
         topic: /vehicle/status/control_mode
       - source: simulator.publisher.vehicle/status/actuation_status
         topic: /vehicle/status/actuation_status
-      - source: simulator.publisher.control/control_mode_request
+      - source: simulator.server.control/control_mode_request
         topic: /control/control_mode_request
-      - source: simulator.publisher.api/simulator/set/pose
+      - source: simulator.server.api/simulator/set/pose
         topic: /api/simulator/set/pose

--- a/autoware_sample_designs/design/wrapper/SampleSystemVehicleWrapper.node.yaml
+++ b/autoware_sample_designs/design/wrapper/SampleSystemVehicleWrapper.node.yaml
@@ -1,0 +1,57 @@
+autoware_system_design_format: 0.3.0
+
+name: SampleSystemVehicleWrapper.node
+
+package:
+  name: autoware_sample_designs
+  provider: autoware
+
+launch:
+  ros2_launch_file: sample_system_vehicle_wrapper.launch.xml
+
+# interfaces
+subscribers:
+  - name: control/command/control_cmd
+    message_type: autoware_control_msgs/msg/Control
+  - name: control/command/emergency_cmd
+    message_type: tier4_vehicle_msgs/msg/VehicleEmergencyStamped
+  - name: control/command/gear_cmd
+    message_type: autoware_vehicle_msgs/msg/GearCommand
+  - name: control/command/hazard_lights_cmd
+    message_type: autoware_vehicle_msgs/msg/HazardLightsCommand
+  - name: control/command/turn_indicators_cmd
+    message_type: autoware_vehicle_msgs/msg/TurnIndicatorsCommand
+
+publishers:
+  - name: vehicle/status/control_mode
+    message_type: autoware_vehicle_msgs/msg/ControlModeReport
+  - name: vehicle/status/gear_status
+    message_type: autoware_vehicle_msgs/msg/GearReport
+  - name: vehicle/status/hazard_lights_status
+    message_type: autoware_vehicle_msgs/msg/HazardLightsReport
+  - name: vehicle/status/steering_status
+    message_type: autoware_vehicle_msgs/msg/SteeringReport
+  - name: vehicle/status/turn_indicators_status
+    message_type: autoware_vehicle_msgs/msg/TurnIndicatorsReport
+  - name: vehicle/status/velocity_status
+    message_type: autoware_vehicle_msgs/msg/VelocityReport
+
+servers:
+  - name: control/control_mode_request
+    message_type: autoware_vehicle_msgs/srv/ControlModeCommand
+
+# parameters
+param_files: []
+
+param_values:
+  - name: vehicle_model
+    default: sample_vehicle
+  - name: vehicle_id
+    default: $(env VEHICLE_ID default)
+  - name: initial_engage_state
+    default: false
+  - name: raw_vehicle_cmd_converter_param_path
+    default: $(find-pkg-share autoware_raw_vehicle_cmd_converter)/config/raw_vehicle_cmd_converter.param.yaml
+
+# processes
+processes: []

--- a/autoware_sample_designs/design/wrapper/Tier4MapWrapper.node.yaml
+++ b/autoware_sample_designs/design/wrapper/Tier4MapWrapper.node.yaml
@@ -23,6 +23,11 @@ publishers:
     qos:
       reliability: reliable
       durability: transient_local
+  - name: map_projector_info
+    message_type: autoware_map_msgs/msg/MapProjectorInfo
+    qos:
+      reliability: reliable
+      durability: transient_local
 
 servers:
   - name: get_differential_pointcloud_map
@@ -72,3 +77,4 @@ processes:
     outcomes:
       - to_output: vector_map
       - to_output: pointcloud_map
+      - to_output: map_projector_info

--- a/autoware_sample_designs/launch/sample_system_vehicle_wrapper.launch.xml
+++ b/autoware_sample_designs/launch/sample_system_vehicle_wrapper.launch.xml
@@ -1,0 +1,15 @@
+<launch>
+  <arg name="vehicle_model" default="sample_vehicle" description="vehicle model name"/>
+  <arg name="vehicle_id" default="$(env VEHICLE_ID default)" description="vehicle specific ID"/>
+  <arg name="initial_engage_state" default="false" description="/vehicle/engage state after starting Autoware"/>
+  <arg name="raw_vehicle_cmd_converter_param_path" default="$(find-pkg-share autoware_raw_vehicle_cmd_converter)/config/raw_vehicle_cmd_converter.param.yaml"/>
+
+  <!-- vehicle interface -->
+  <group>
+    <include file="$(find-pkg-share $(var vehicle_model)_launch)/launch/vehicle_interface.launch.xml">
+      <arg name="vehicle_id" value="$(var vehicle_id)"/>
+      <arg name="raw_vehicle_cmd_converter_param_path" value="$(var raw_vehicle_cmd_converter_param_path)"/>
+      <arg name="initial_engage_state" value="$(var initial_engage_state)"/>
+    </include>
+  </group>
+</launch>

--- a/autoware_sample_designs/package.xml
+++ b/autoware_sample_designs/package.xml
@@ -19,6 +19,7 @@
   <exec_depend>autoware_default_adapi_universe</exec_depend>
   <exec_depend>autoware_global_parameter_loader</exec_depend>
   <exec_depend>autoware_launch</exec_depend>
+  <exec_depend>autoware_raw_vehicle_cmd_converter</exec_depend>
   <exec_depend>sample_sensor_kit_description</exec_depend>
   <exec_depend>sample_sensor_kit_launch</exec_depend>
   <exec_depend>sample_vehicle_description</exec_depend>

--- a/autoware_universe_launch/autoware_planning_launch/design/module/Planning.module.yaml
+++ b/autoware_universe_launch/autoware_planning_launch/design/module/Planning.module.yaml
@@ -28,6 +28,7 @@ subscribers:
   - name: traffic_signals
   - name: control_cmd
   - name: predicted_trajectory
+  - name: system_hazard_lights_cmd
 
 publishers:
   - name: trajectory
@@ -41,6 +42,7 @@ publishers:
 
 servers:
   - name: clear_route
+  - name: set_preferred_lane
   - name: set_lanelet_route
   - name: set_waypoint_route
 
@@ -68,6 +70,8 @@ connections:
     - scenario_planning.subscriber.operation_mode_state
   - - subscriber.api_operation_mode_state
     - scenario_planning.subscriber.api_operation_mode_state
+  - - subscriber.system_hazard_lights_cmd
+    - scenario_planning.subscriber.system_hazard_lights_cmd
   - - subscriber.objects
     - scenario_planning.subscriber.objects
   - - subscriber.pointcloud
@@ -136,6 +140,8 @@ connections:
     - publisher.hazard_lights_cmd
   - - planning_validator.publisher.validation_status
     - publisher.validation_status
+  - - mission_planning.server.set_preferred_lane
+    - server.set_preferred_lane
   - - mission_planning.server.clear_route
     - server.clear_route
   - - mission_planning.server.set_lanelet_route

--- a/autoware_universe_launch/autoware_planning_launch/design/module/Planning.module.yaml
+++ b/autoware_universe_launch/autoware_planning_launch/design/module/Planning.module.yaml
@@ -20,6 +20,7 @@ subscribers:
   - name: vector_map
   - name: odometry
   - name: acceleration
+  - name: steering_status
   - name: operation_mode_state
   - name: api_operation_mode_state
   - name: objects
@@ -66,6 +67,8 @@ connections:
     - scenario_planning.subscriber.odometry
   - - subscriber.acceleration
     - scenario_planning.subscriber.acceleration
+  - - subscriber.steering_status
+    - scenario_planning.subscriber.steering_status
   - - subscriber.operation_mode_state
     - scenario_planning.subscriber.operation_mode_state
   - - subscriber.api_operation_mode_state

--- a/autoware_universe_launch/autoware_planning_launch/design/module/Planning.module.yaml
+++ b/autoware_universe_launch/autoware_planning_launch/design/module/Planning.module.yaml
@@ -117,6 +117,8 @@ connections:
     - remaining_distance_time_calculator.subscriber.map
   - - scenario_planning.publisher.scenario
     - remaining_distance_time_calculator.subscriber.scenario
+  - - scenario_planning.publisher.current_max_velocity
+    - remaining_distance_time_calculator.subscriber.planning_velocity
 
   - - planning_validator.publisher.trajectory
     - publisher.trajectory

--- a/autoware_universe_launch/autoware_planning_launch/design/module/Planning.module.yaml
+++ b/autoware_universe_launch/autoware_planning_launch/design/module/Planning.module.yaml
@@ -34,6 +34,15 @@ subscribers:
 publishers:
   - name: trajectory
   - name: path_with_lane_id
+  - name: planning_factors/blind_spot
+  - name: planning_factors/crosswalk
+  - name: planning_factors/detection_area
+  - name: planning_factors/intersection
+  - name: planning_factors/no_stopping_area
+  - name: planning_factors/stop_line
+  - name: planning_factors/traffic_light
+  - name: planning_factors/virtual_traffic_light
+  - name: planning_factors/walkway
   - name: route
   - name: mission_planning/route
   - name: route_state
@@ -131,6 +140,24 @@ connections:
     - publisher.trajectory
   - - scenario_planning.publisher.path_with_lane_id
     - publisher.path_with_lane_id
+  - - scenario_planning.publisher.planning_factors/blind_spot
+    - publisher.planning_factors/blind_spot
+  - - scenario_planning.publisher.planning_factors/crosswalk
+    - publisher.planning_factors/crosswalk
+  - - scenario_planning.publisher.planning_factors/detection_area
+    - publisher.planning_factors/detection_area
+  - - scenario_planning.publisher.planning_factors/intersection
+    - publisher.planning_factors/intersection
+  - - scenario_planning.publisher.planning_factors/no_stopping_area
+    - publisher.planning_factors/no_stopping_area
+  - - scenario_planning.publisher.planning_factors/stop_line
+    - publisher.planning_factors/stop_line
+  - - scenario_planning.publisher.planning_factors/traffic_light
+    - publisher.planning_factors/traffic_light
+  - - scenario_planning.publisher.planning_factors/virtual_traffic_light
+    - publisher.planning_factors/virtual_traffic_light
+  - - scenario_planning.publisher.planning_factors/walkway
+    - publisher.planning_factors/walkway
   - - mission_planning.publisher.mission_planning/route
     - publisher.mission_planning/route
   - - mission_planning.publisher.route

--- a/autoware_universe_launch/autoware_planning_launch/design/module/mission_planning/MissionPlanning.module.yaml
+++ b/autoware_universe_launch/autoware_planning_launch/design/module/mission_planning/MissionPlanning.module.yaml
@@ -29,6 +29,7 @@ publishers:
 
 servers:
   - name: clear_route
+  - name: set_preferred_lane
   - name: set_lanelet_route
   - name: set_waypoint_route
 
@@ -63,6 +64,14 @@ connections:
     - manual_lane_change_handler.subscriber.odometry
   - - subscriber.vector_map
     - manual_lane_change_handler.subscriber.vector_map
+  - - subscriber.reroute_availability
+    - manual_lane_change_handler.subscriber.reroute_availability
+  - - mission_planner.server.set_preferred_primitive
+    - manual_lane_change_handler.client.set_preferred_primitive
+  - - manual_lane_change_handler.server.set_preferred_lane
+    - server.set_preferred_lane
+  - - mission_planner.publisher.route_marker
+    - publisher.route_marker
 
   - - mission_planner.server.clear_route
     - route_selector.client.planner_clear_route

--- a/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/LaneDriving.module.yaml
+++ b/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/LaneDriving.module.yaml
@@ -31,6 +31,15 @@ subscribers:
 publishers:
   - name: trajectory
   - name: path_with_lane_id
+  - name: planning_factors/blind_spot
+  - name: planning_factors/crosswalk
+  - name: planning_factors/detection_area
+  - name: planning_factors/intersection
+  - name: planning_factors/no_stopping_area
+  - name: planning_factors/stop_line
+  - name: planning_factors/traffic_light
+  - name: planning_factors/virtual_traffic_light
+  - name: planning_factors/walkway
   - name: turn_indicators_cmd
   - name: hazard_lights_cmd
   - name: modified_goal
@@ -93,6 +102,24 @@ connections:
     - publisher.trajectory
   - - behavior_planning.publisher.path_with_lane_id
     - publisher.path_with_lane_id
+  - - behavior_planning.publisher.planning_factors/blind_spot
+    - publisher.planning_factors/blind_spot
+  - - behavior_planning.publisher.planning_factors/crosswalk
+    - publisher.planning_factors/crosswalk
+  - - behavior_planning.publisher.planning_factors/detection_area
+    - publisher.planning_factors/detection_area
+  - - behavior_planning.publisher.planning_factors/intersection
+    - publisher.planning_factors/intersection
+  - - behavior_planning.publisher.planning_factors/no_stopping_area
+    - publisher.planning_factors/no_stopping_area
+  - - behavior_planning.publisher.planning_factors/stop_line
+    - publisher.planning_factors/stop_line
+  - - behavior_planning.publisher.planning_factors/traffic_light
+    - publisher.planning_factors/traffic_light
+  - - behavior_planning.publisher.planning_factors/virtual_traffic_light
+    - publisher.planning_factors/virtual_traffic_light
+  - - behavior_planning.publisher.planning_factors/walkway
+    - publisher.planning_factors/walkway
   - - behavior_planning.publisher.turn_indicators_cmd
     - publisher.turn_indicators_cmd
   - - behavior_planning.publisher.hazard_lights_cmd

--- a/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/LaneDriving.module.yaml
+++ b/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/LaneDriving.module.yaml
@@ -21,6 +21,7 @@ subscribers:
   - name: traffic_signals
   - name: odometry
   - name: accel
+  - name: steering_status
   - name: external_velocity_limit_mps
   - name: operation_mode_state
   - name: api_operation_mode_state
@@ -70,6 +71,8 @@ connections:
     - motion_planning.subscriber.odometry
   - - subscriber.accel
     - motion_planning.subscriber.accel
+  - - subscriber.steering_status
+    - motion_planning.subscriber.steering_status
   - - subscriber.objects
     - motion_planning.subscriber.objects
   - - subscriber.no_ground_pointcloud

--- a/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/LaneDriving.module.yaml
+++ b/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/LaneDriving.module.yaml
@@ -34,6 +34,7 @@ publishers:
   - name: hazard_lights_cmd
   - name: modified_goal
   - name: velocity_limit
+  - name: clear_velocity_limit
   - name: reroute_availability
 
 connections:
@@ -99,3 +100,5 @@ connections:
     - publisher.reroute_availability
   - - motion_planning.publisher.velocity_limit
     - publisher.velocity_limit
+  - - motion_planning.publisher.clear_velocity_limit
+    - publisher.clear_velocity_limit

--- a/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/Parking.module.yaml
+++ b/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/Parking.module.yaml
@@ -22,6 +22,7 @@ publishers:
   - name: trajectory
   - name: is_completed
   - name: grid_map
+  - name: occupancy_grid
 
 connections:
   - - subscriber.objects
@@ -34,6 +35,8 @@ connections:
     - costmap_generator.subscriber.scenario
   - - costmap_generator.publisher.occupancy_grid
     - freespace_planner.subscriber.occupancy_grid
+  - - costmap_generator.publisher.occupancy_grid
+    - publisher.occupancy_grid
   - - subscriber.route
     - freespace_planner.subscriber.route
   - - subscriber.scenario

--- a/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/ScenarioPlanning.module.yaml
+++ b/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/ScenarioPlanning.module.yaml
@@ -25,6 +25,7 @@ subscribers:
   - name: route
   - name: odometry
   - name: acceleration
+  - name: steering_status
   - name: operation_mode_state
   - name: api_operation_mode_state
   - name: occupancy_grid_map
@@ -61,6 +62,8 @@ connections:
     - lane_driving.subscriber.odometry
   - - subscriber.acceleration
     - lane_driving.subscriber.accel
+  - - subscriber.steering_status
+    - lane_driving.subscriber.steering_status
   - - subscriber.pointcloud
     - lane_driving.subscriber.no_ground_pointcloud
   - - subscriber.operation_mode_state
@@ -109,6 +112,8 @@ connections:
     - velocity_smoother.subscriber.trajectory
   - - external_velocity_limit_selector.publisher.external_velocity_limit
     - velocity_smoother.subscriber.external_velocity_limit_mps
+  - - subscriber.odometry
+    - velocity_smoother.subscriber.current_odometry
   - - subscriber.acceleration
     - velocity_smoother.subscriber.acceleration
   - - subscriber.operation_mode_state

--- a/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/ScenarioPlanning.module.yaml
+++ b/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/ScenarioPlanning.module.yaml
@@ -116,7 +116,7 @@ connections:
   - - lane_driving.publisher.hazard_lights_cmd
     - hazard_lights_selector.subscriber.lane_driving_hazard_lights_cmd
   - - subscriber.system_hazard_lights_cmd
-    - hazard_lights_selector.subscriber.parking_hazard_lights_cmd
+    - hazard_lights_selector.subscriber.system_hazard_lights_cmd
   - - velocity_smoother.publisher.trajectory
     - publisher.trajectory
   - - lane_driving.publisher.path_with_lane_id

--- a/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/ScenarioPlanning.module.yaml
+++ b/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/ScenarioPlanning.module.yaml
@@ -75,6 +75,10 @@ connections:
     - lane_driving.subscriber.scenario
   - - external_velocity_limit_selector.publisher.external_velocity_limit
     - lane_driving.subscriber.external_velocity_limit_mps
+  - - lane_driving.publisher.velocity_limit
+    - external_velocity_limit_selector.subscriber.internal_limit
+  - - lane_driving.publisher.clear_velocity_limit
+    - external_velocity_limit_selector.subscriber.velocity_limit_clear_command
   - - subscriber.objects
     - parking.subscriber.objects
   - - subscriber.pointcloud

--- a/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/ScenarioPlanning.module.yaml
+++ b/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/ScenarioPlanning.module.yaml
@@ -37,6 +37,15 @@ subscribers:
 publishers:
   - name: trajectory
   - name: path_with_lane_id
+  - name: planning_factors/blind_spot
+  - name: planning_factors/crosswalk
+  - name: planning_factors/detection_area
+  - name: planning_factors/intersection
+  - name: planning_factors/no_stopping_area
+  - name: planning_factors/stop_line
+  - name: planning_factors/traffic_light
+  - name: planning_factors/virtual_traffic_light
+  - name: planning_factors/walkway
   - name: hazard_lights_cmd
   - name: turn_indicators_cmd
   - name: scenario
@@ -126,6 +135,24 @@ connections:
     - publisher.trajectory
   - - lane_driving.publisher.path_with_lane_id
     - publisher.path_with_lane_id
+  - - lane_driving.publisher.planning_factors/blind_spot
+    - publisher.planning_factors/blind_spot
+  - - lane_driving.publisher.planning_factors/crosswalk
+    - publisher.planning_factors/crosswalk
+  - - lane_driving.publisher.planning_factors/detection_area
+    - publisher.planning_factors/detection_area
+  - - lane_driving.publisher.planning_factors/intersection
+    - publisher.planning_factors/intersection
+  - - lane_driving.publisher.planning_factors/no_stopping_area
+    - publisher.planning_factors/no_stopping_area
+  - - lane_driving.publisher.planning_factors/stop_line
+    - publisher.planning_factors/stop_line
+  - - lane_driving.publisher.planning_factors/traffic_light
+    - publisher.planning_factors/traffic_light
+  - - lane_driving.publisher.planning_factors/virtual_traffic_light
+    - publisher.planning_factors/virtual_traffic_light
+  - - lane_driving.publisher.planning_factors/walkway
+    - publisher.planning_factors/walkway
   - - velocity_smoother.publisher.current_velocity_limit_mps
     - publisher.current_max_velocity
   - - scenario_selector.publisher.scenario

--- a/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/ScenarioPlanning.module.yaml
+++ b/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/ScenarioPlanning.module.yaml
@@ -28,10 +28,10 @@ subscribers:
   - name: operation_mode_state
   - name: api_operation_mode_state
   - name: occupancy_grid_map
-  - name: costmap
   - name: traffic_signals
   - name: control_cmd
   - name: predicted_trajectory
+  - name: system_hazard_lights_cmd
 
 publishers:
   - name: trajectory
@@ -53,7 +53,7 @@ connections:
     - lane_driving.subscriber.objects
   - - subscriber.occupancy_grid_map
     - lane_driving.subscriber.occupancy_grid_map
-  - - subscriber.costmap
+  - - parking.publisher.occupancy_grid
     - lane_driving.subscriber.costmap
   - - subscriber.traffic_signals
     - lane_driving.subscriber.traffic_signals
@@ -115,6 +115,8 @@ connections:
     - velocity_smoother.subscriber.operation_mode_state
   - - lane_driving.publisher.hazard_lights_cmd
     - hazard_lights_selector.subscriber.lane_driving_hazard_lights_cmd
+  - - subscriber.system_hazard_lights_cmd
+    - hazard_lights_selector.subscriber.parking_hazard_lights_cmd
   - - velocity_smoother.publisher.trajectory
     - publisher.trajectory
   - - lane_driving.publisher.path_with_lane_id

--- a/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/lane_driving/behavior_planning/BehaviorPlanning.module.yaml
+++ b/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/lane_driving/behavior_planning/BehaviorPlanning.module.yaml
@@ -26,6 +26,15 @@ subscribers:
 
 publishers:
   - name: path
+  - name: planning_factors/blind_spot
+  - name: planning_factors/crosswalk
+  - name: planning_factors/detection_area
+  - name: planning_factors/intersection
+  - name: planning_factors/no_stopping_area
+  - name: planning_factors/stop_line
+  - name: planning_factors/traffic_light
+  - name: planning_factors/virtual_traffic_light
+  - name: planning_factors/walkway
   - name: path_with_lane_id
   - name: turn_indicators_cmd
   - name: hazard_lights_cmd
@@ -73,6 +82,24 @@ connections:
     - behavior_velocity_planner.subscriber.path_with_lane_id
   - - behavior_velocity_planner.publisher.path
     - publisher.path
+  - - behavior_velocity_planner.publisher.planning_factors/blind_spot
+    - publisher.planning_factors/blind_spot
+  - - behavior_velocity_planner.publisher.planning_factors/crosswalk
+    - publisher.planning_factors/crosswalk
+  - - behavior_velocity_planner.publisher.planning_factors/detection_area
+    - publisher.planning_factors/detection_area
+  - - behavior_velocity_planner.publisher.planning_factors/intersection
+    - publisher.planning_factors/intersection
+  - - behavior_velocity_planner.publisher.planning_factors/no_stopping_area
+    - publisher.planning_factors/no_stopping_area
+  - - behavior_velocity_planner.publisher.planning_factors/stop_line
+    - publisher.planning_factors/stop_line
+  - - behavior_velocity_planner.publisher.planning_factors/traffic_light
+    - publisher.planning_factors/traffic_light
+  - - behavior_velocity_planner.publisher.planning_factors/virtual_traffic_light
+    - publisher.planning_factors/virtual_traffic_light
+  - - behavior_velocity_planner.publisher.planning_factors/walkway
+    - publisher.planning_factors/walkway
   - - behavior_path_planner.publisher.path_with_lane_id
     - publisher.path_with_lane_id
   - - behavior_path_planner.publisher.turn_indicators_cmd

--- a/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/lane_driving/motion_planning/MotionPlanning.module.yaml
+++ b/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/lane_driving/motion_planning/MotionPlanning.module.yaml
@@ -29,6 +29,7 @@ subscribers:
 publishers:
   - name: trajectory
   - name: velocity_limit
+  - name: clear_velocity_limit
 
 connections:
   - - subscriber.path
@@ -67,3 +68,5 @@ connections:
     - publisher.trajectory
   - - motion_velocity_planner.publisher.velocity_limit
     - publisher.velocity_limit
+  - - motion_velocity_planner.publisher.clear_velocity_limit
+    - publisher.clear_velocity_limit

--- a/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/lane_driving/motion_planning/MotionPlanning.module.yaml
+++ b/autoware_universe_launch/autoware_planning_launch/design/module/scenario_planning/lane_driving/motion_planning/MotionPlanning.module.yaml
@@ -17,6 +17,7 @@ subscribers:
   - name: vector_map
   - name: odometry
   - name: accel
+  - name: steering_status
   - name: objects
   - name: no_ground_pointcloud
   - name: traffic_signals
@@ -48,6 +49,8 @@ connections:
     - motion_velocity_planner.subscriber.vehicle_odometry
   - - subscriber.accel
     - motion_velocity_planner.subscriber.accel
+  - - subscriber.steering_status
+    - motion_velocity_planner.subscriber.steering_status
   - - subscriber.objects
     - motion_velocity_planner.subscriber.dynamic_objects
   - - subscriber.no_ground_pointcloud


### PR DESCRIPTION
## Description

Connects the module inputs the design graph left without a source, in `Planning.module` and `Control.module`. Each reproduces wiring the launch files already perform; the design had not encoded it, so the exported launcher dropped the remap and the node subscribed to an unresolved relative name.

**Planning**

- `remaining_distance_time_calculator.planning_velocity` ← `scenario_planning.current_max_velocity`
- `external_velocity_limit_selector` internal limit and clear command ← `motion_velocity_planner`, forwarded through `MotionPlanning` and `LaneDriving`. The selector previously had no input remaps at all, so the external velocity limit path was inert.
- `manual_lane_change_handler`: route availability, and the `set_preferred_primitive` client
- `lane_driving.costmap` ← `parking` (new `occupancy_grid` port); the `costmap` input on `ScenarioPlanning` is dropped, since the producer is inside the module
- `MissionPlanning.route_marker` ← `mission_planner`, restoring the topic `autoware.rviz` expects

**Control**

- `collision_detector.operation_mode_state` ← `api_operation_mode_state`
- operation mode transition manager: gate mode, selector mode, and the `select_external_command` client
- `stop_mode_operator`: steering and velocity

New component interfaces, where the counterpart is outside Planning/Control: `Control.client.control_mode_request` (vehicle interface), `Planning.server.set_preferred_lane` (AD API), `Planning.subscriber.system_hazard_lights_cmd` (MRM operator).

## Related links

- autowarefoundation/autoware_core#1416 — velocity limit message types. **Required**: without it the `current_max_velocity -> planning_velocity` connection fails the designer's type check.
- autowarefoundation/autoware_universe#13298 — the matching node design updates. **Required** by the `system_hazard_lights_cmd` connection. (Previously split out as #13304, which is now folded back into #13298.)

## How was this PR tested?

- `autoware_sample_designs` builds clean with both linked PRs in the workspace; designer warning set unchanged.
- Diffed the exported `Runtime/main_ecu` launcher: five previously dropped remaps now appear, with the legacy absolute names preserved. Three topics are renamed by design, including `route_marker` → `/planning/mission_planning/route_marker`, which fixes an RViz mismatch.
- `pre-commit` on every changed design file.

## Notes for reviewers

Design-only change; no launch file or source code is touched.

Conflicts with #1965, which splits `Control.module.yaml` into sub-modules — whichever lands first, the other rebases.

Left unconnected on purpose: `behavior_velocity_planner.external_velocity_limit_mps` (API topic with no in-design publisher; belongs node-side in `autoware_core`), `planning_evaluator.reference_trajectory` (a launch-time `<let>` switch, not fixed topology), and `stop_mode_operator`'s outputs (their consumer `control_command_gate` is not modeled as a design node).

## Interface changes

New ports: `Control.client.control_mode_request`, `Planning.server.set_preferred_lane`, `Planning.subscriber.system_hazard_lights_cmd`, `Parking.publisher.occupancy_grid`, `clear_velocity_limit` on `MotionPlanning` and `LaneDriving`. Removed: `ScenarioPlanning.subscriber.costmap`.

## Effects on system behavior

Restores the external velocity limit path, the operation mode transition manager's gate and selector inputs, the manual lane change handler's route availability and preferred-primitive service, and the behavior planner's costmap input — all of which resolved to unbound relative names in the exported launcher.

