### PR TITLE
feat(diffusion_planner): add ego_snap_to_prev_trajectory parameters

### DIFF
--- a/autoware_universe_launch/autoware_planning_config/config/neural_net_planner/diffusion_planner.param.yaml
+++ b/autoware_universe_launch/autoware_planning_config/config/neural_net_planner/diffusion_planner.param.yaml
@@ -52,6 +52,18 @@
     object_motion_resampling:
       enable: true                    # re-time neighbor histories onto a constant 0.1s grid anchored at the ego stamp
       max_extrapolation_time: 0.5     # [s]  max extrapolation horizon (both forward from newest and backward from oldest observation)
+    ego_snap_to_prev_trajectory:
+      enable: false                   # snap the ego pose onto the closest segment of the previous planning trajectory
+      max_position_error_m: 0.3       # [m]   skip the snap when the actual ego pose is farther than this from the snapped pose
+      max_yaw_error_deg: 5.0          # [deg] skip the snap when the heading differs by more than this from the snapped pose
+      max_search_segment_count: 5     # number of leading segments of the previous trajectory searched for the closest one
+      min_speed_mps: 0.0              # [m/s] skip the snap below this speed; measured worse than no gate, so disabled by default
+      limit_mode: "bound"             # "bound": keep the snapped pose within the error limits of the raw pose (continuous); "reject": skip the snap when a limit is exceeded
+      correction_gain: 0.1            # fraction of the raw-vs-snapped residual re-injected per frame (bound mode); 0 = stay exactly on the previous plan
+      yaw_source: "polyline_tangent"  # "polyline_tangent" (spline tangent of the previous trajectory, averaged over the fit window) or "predicted_heading" (model heading channel)
+      yaw_fit_half_window_m: 1.0      # [m] arc length on each side of the foot point used to fit the tangent
+      yaw_fit_min_length_m: 0.2       # [m] fall back to the localization heading when the fit window is shorter than this
+      history_prefix_count: 10        # earlier ego poses prepended to the previous trajectory so the tangent window can extend behind the ego
     planning_factor:
       enable_stop: true
       enable_slowdown: false

--- a/autoware_universe_launch/autoware_planning_config/config/neural_net_planner/diffusion_planner.param.yaml
+++ b/autoware_universe_launch/autoware_planning_config/config/neural_net_planner/diffusion_planner.param.yaml
@@ -59,7 +59,7 @@
       max_search_segment_count: 5     # number of leading segments of the previous trajectory searched for the closest one
       min_speed_mps: 0.0              # [m/s] skip the snap below this speed; measured worse than no gate, so disabled by default
       limit_mode: "bound"             # "bound": keep the snapped pose within the error limits of the raw pose (continuous); "reject": skip the snap when a limit is exceeded
-      correction_gain: 0.1            # fraction of the raw-vs-snapped residual re-injected per frame (bound mode); 0 = stay exactly on the previous plan
+      snap_strength: 0.9              # how far from the raw pose toward the snapped pose (bound mode); 0 = feature off, 1 = stay exactly on the previous plan
       yaw_source: "polyline_tangent"  # "polyline_tangent" (spline tangent of the previous trajectory, averaged over the fit window) or "predicted_heading" (model heading channel)
       yaw_fit_half_window_m: 1.0      # [m] arc length on each side of the foot point used to fit the tangent
       yaw_fit_min_length_m: 0.2       # [m] fall back to the localization heading when the fit window is shorter than this


### PR DESCRIPTION
## Description

The diffusion planner node declares an `ego_snap_to_prev_trajectory` parameter group that this configuration did not carry, so the node fell back to its compiled-in defaults and the parameters were neither visible nor tunable from the launch configuration. This adds the group, copied byte for byte from the package's own default config so the two files cannot drift.

The feature stays disabled (`enable: false`), so behaviour is unchanged.

Four of the keys (`enable`, `max_position_error_m`, `max_yaw_error_deg`, `max_search_segment_count`) correspond to autowarefoundation/autoware_universe#13234, which is already merged. The remaining keys (`limit_mode`, `snap_strength`, `yaw_source`, `yaw_fit_half_window_m`, `yaw_fit_min_length_m`, `history_prefix_count`) come with autowarefoundation/autoware_universe#13320, so this must merge after that one.

`snap_strength` is the parameter that #13320 renames from `correction_gain` and inverts. The old form was `gain * localized + (1 - gain) * snapped`, so gain 0 was the strongest snap and gain 1 disabled it, which reads backwards. `snap_strength = 1 - correction_gain`, hence 0.9 here for what was 0.1. The node raises at load time if the old name is still set, so this file cannot land before #13320 and cannot be left behind after it.

## How was this PR tested?

- [x] The file parses as YAML and the resulting parameter group matches the node's declared parameters exactly, by name and by value.
- [x] Launched in the planning simulator; the node reports every key at the configured value via `ros2 param get`.

## Notes for reviewers

Values are the package defaults, not tuned settings. The feature is off, so none of them take effect until it is enabled.

## Effects on system behavior

None. The feature remains disabled and every value matches what the node was already using as its compiled-in default.
