### PR TITLE
feat(concatenate_and_time_sync_node): add output_point_type parameter

### DIFF
--- a/autoware_sample_designs/config/sensing/lidar/concatenate_and_time_sync_node.param.yaml
+++ b/autoware_sample_designs/config/sensing/lidar/concatenate_and_time_sync_node.param.yaml
@@ -11,6 +11,7 @@
     synchronized_pointcloud_postfix: pointcloud
     input_twist_topic_type: twist
     output_frame: base_link
+    output_point_type: XYZIRC
     matching_strategy:
       type: advanced
       lidar_timestamp_offsets: [0.0, 0.015, 0.016]

--- a/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/config/concatenate_and_time_sync_node.param.yaml
+++ b/sensor_kit/awsim_labs_sensor_kit_launch/awsim_labs_sensor_kit_launch/config/concatenate_and_time_sync_node.param.yaml
@@ -16,6 +16,7 @@
                     "/sensing/lidar/left/pointcloud_before_sync", # 0.05
                 ]
     output_frame: base_link
+    output_point_type: XYZIRC
     matching_strategy:
           type: advanced
           lidar_timestamp_offsets: [0.0, 0.0, 0.0]

--- a/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/config/concatenate_and_time_sync_node.param.yaml
+++ b/sensor_kit/sample_sensor_kit_launch/sample_sensor_kit_launch/config/concatenate_and_time_sync_node.param.yaml
@@ -16,6 +16,7 @@
                     "/sensing/lidar/left/pointcloud_before_sync",
                 ]
     output_frame: base_link
+    output_point_type: XYZIRC
     matching_strategy:
       type: advanced
       lidar_timestamp_offsets: [0.0, 0.015, 0.016]


### PR DESCRIPTION
## Description

Adds `output_point_type: XYZIRC` to the three `concatenate_and_time_sync_node` configs. autowarefoundation/autoware_universe#13324 makes this parameter required (no C++ default, by project policy); `XYZIRC` reproduces the current output.

**Must be merged before** autowarefoundation/autoware_universe#13324. Until then the node ignores the extra key.

## How was this PR tested?

N/A

## Notes for reviewers

None.

## Effects on system behavior

None.
