### PR TITLE
fix(carla): load the lidar preprocessing, and declare the autonomous availability unit

### DIFF
--- a/autoware_launch/config/system/diagnostics/autoware-carla.yaml
+++ b/autoware_launch/config/system/diagnostics/autoware-carla.yaml
@@ -46,6 +46,15 @@ units:
       - { type: link, link: /autoware/system }
       - { type: link, link: /adapi/mrm_request/delegate }
 
+  # The driving-mode availability flag autoware_diagnostic_graph_aggregator maps
+  # mode 1002 to (config/default.param.yaml), split out from the continuable flag
+  # in autowarefoundation/autoware_universe#13252. Without it the aggregator logs
+  # "Mode path not found: 1002" and autonomous is never reported available.
+  - path: /autoware/modes/autonomous/available
+    type: and
+    list:
+      - { type: link, link: /autoware/modes/autonomous }
+
   - path: /autoware/modes/pull_over
     type: and
     list:

--- a/sensor_kit/carla_sensor_kit_launch/carla_sensor_kit_launch/launch/lidar.launch.xml
+++ b/sensor_kit/carla_sensor_kit_launch/carla_sensor_kit_launch/launch/lidar.launch.xml
@@ -1,6 +1,10 @@
 <launch>
   <!-- CARLA publishes an undistorted pointcloud without ring information; only the crop boxes apply -->
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
+  <!-- The container lives at the root namespace, but these loads run inside
+       /sensing/lidar: a relative target resolves there and never appears, so the
+       load waits forever and the whole lidar preprocessing silently never runs. -->
+  <let name="target_container" value="/$(var pointcloud_container_name)"/>
   <arg name="crop_box_filter_self_param_path" default="$(find-pkg-share carla_sensor_kit_launch)/config/crop_box_filter_self.param.yaml"/>
   <arg name="crop_box_filter_mirror_param_path" default="$(find-pkg-share carla_sensor_kit_launch)/config/crop_box_filter_mirror.param.yaml"/>
 
@@ -8,7 +12,7 @@
     <push-ros-namespace namespace="lidar"/>
 
     <include file="$(find-pkg-share autoware_sensing_launch)/launch/pointcloud_crop_boxes.launch.xml">
-      <arg name="target_container" value="$(var pointcloud_container_name)"/>
+      <arg name="target_container" value="$(var target_container)"/>
       <arg name="use_intra_process" value="true"/>
       <arg name="input/pointcloud" value="/sensing/lidar/top/pointcloud_before_sync"/>
       <arg name="intermediate/pointcloud" value="self_cropped/pointcloud"/>
@@ -17,7 +21,7 @@
       <arg name="crop_box_filter_secondary_param_path" value="$(var crop_box_filter_mirror_param_path)"/>
     </include>
 
-    <load_composable_node target="$(var pointcloud_container_name)">
+    <load_composable_node target="$(var target_container)">
       <composable_node pkg="topic_tools" plugin="topic_tools::RelayNode" name="pointcloud_relay">
         <param name="input_topic" value="mirror_cropped/pointcloud"/>
         <param name="output_topic" value="/sensing/lidar/concatenated/pointcloud"/>


### PR DESCRIPTION
## Description

Two regressions that landed after the CARLA integration was last exercised leave the documented run unable to drive:

```bash
ros2 launch autoware_launch e2e_simulator.launch.xml \
    map_path:=$HOME/autoware_data/maps/Town01 \
    vehicle_model:=sample_vehicle \
    sensor_model:=carla_sensor_kit \
    simulator_type:=carla
```

### The lidar preprocessing never loads

`carla_sensor_kit_launch/launch/lidar.launch.xml` targets the pointcloud container by its relative name from inside the `/sensing/lidar` namespace, so the loads wait on `/sensing/lidar/pointcloud_container`, which never appears. The crop boxes and the relay are therefore never loaded and nothing publishes `/sensing/lidar/concatenated/pointcloud`: no NDT input, no `kinematic_state`, no trajectory. Nothing reports it until shutdown prints

```
[WARNING] [launch_ros.actions.load_composable_nodes]: Abandoning wait for the 'pointcloud_container/_container/load_node' service response, due to shutdown.
```

`sample_sensor_kit_launch` passes an absolute `target_container`; this makes the CARLA kit do the same. The relative name came in with #1938 (2026-08-17).

### The CARLA diagnostic graph has no autonomous availability unit

`autoware_diagnostic_graph_aggregator` maps driving mode 1002 to `/autoware/modes/autonomous/available` since autowarefoundation/autoware_universe#13252 split the available and continuable flags (2026-08-26). `autoware-carla.yaml` never defined that path, so the aggregator logs `Mode path not found: 1002` and autonomous is never reported available -- the vehicle cannot be engaged.

> [!NOTE]
> `autoware-main.yaml` does not define that unit either, so the same is likely true for the other configurations. This PR only touches the CARLA graph, which is the one I could verify.

## Tests performed

Ran Autoware against CARLA with `simulator_type:=carla`:

- `/sensing/lidar/concatenated/pointcloud` is published again (it was absent), NDT converges and `/localization/kinematic_state` flows.
- The aggregator no longer logs `Mode path not found`, and `/api/operation_mode/state` reports `is_autonomous_mode_available: true`, so the ego can be engaged and drives its route.

Verified on CARLA 0.10 with Town10HD_Opt rather than the 0.9.15/Town01 pair the README documents; both failures are in launch wiring rather than anything version specific.

## Notes for reviewers

Driving that setup to completion also needed threshold tuning that is specific to CARLA 0.10 running at a few Hz (localization covariance, control latency, topic rate monitors). That is deliberately **not** in this PR -- it is configuration for one simulator build, not a fix -- and can follow separately if it is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YcAUGi47RJ8rkK94AyqXuF
